### PR TITLE
add potential grant funding pages

### DIFF
--- a/src/config/nunjucks/filters/format-currency.js
+++ b/src/config/nunjucks/filters/format-currency.js
@@ -3,11 +3,21 @@
  * @param {Intl.LocalesArgument} locale
  * @param {string} currency
  */
-export function formatCurrency(value, locale = 'en-GB', currency = 'GBP') {
-  const formatter = new Intl.NumberFormat(locale, {
-    style: 'currency',
-    currency
-  })
+export function formatCurrency(
+  value,
+  locale = 'en-GB',
+  currency = 'GBP',
+  maximumFractionDigits = 2,
+  style = 'currency'
+) {
+  const options = {
+    style,
+    maximumFractionDigits
+  }
 
-  return formatter.format(value)
+  if (style === 'currency') {
+    options.currency = currency
+  }
+
+  return new Intl.NumberFormat(locale, options).format(value)
 }

--- a/src/config/nunjucks/filters/format-currency.test.js
+++ b/src/config/nunjucks/filters/format-currency.test.js
@@ -12,4 +12,18 @@ describe('#formatCurrency', () => {
       expect(formatCurrency('5500000', 'en-US', 'USD')).toBe('$5,500,000.00')
     })
   })
+
+  describe('With no currency symbol', () => {
+    test('Should format with commas but no currency sign', () => {
+      expect(formatCurrency('1234567', 'en-GB', 'GBP', 0, 'decimal')).toBe(
+        '1,234,567'
+      )
+    })
+  })
+
+  describe('With 0 fraction digits', () => {
+    test('Should format with no decimals', () => {
+      expect(formatCurrency('8900000', 'en-GB', 'GBP', 0)).toBe('£8,900,000')
+    })
+  })
 })

--- a/src/server/common/forms/definitions/adding-value.json
+++ b/src/server/common/forms/definitions/adding-value.json
@@ -390,7 +390,7 @@
           "name": "projectCostInfo",
           "type": "Html",
           "title": "Html",
-          "content": "<p class=\"govuk-hint\">Do not include VAT<br><br>Enter cost of items, for example 695000</p>"
+          "content": "<p class=\"govuk-hint\">Do not include VAT<br><br>Enter cost of items, for example {{ 695000 | formatCurrency: 'en-GB', 'GBP', 0, 'decimal' }}</p>"
         },
         {
           "name": "projectCostNumberField",
@@ -429,7 +429,29 @@
       "condition": "projectCostCondition"
     },
     {
-      "title": "{%- assign estimatedCost = 'projectCostNumberField' | answer -%} {%- assign applicantPayMultiplier = 0.6 -%} {%- assign applicantPayAmount = estimatedCost | times: applicantPayMultiplier -%} Can you pay the remaining costs of {{ applicantPayAmount | money }}?",
+      "title": "Potential grant funding",
+      "path": "/potential-funding",
+      "components": [
+        {
+          "name": "potentialFundingInfo",
+          "title": "Html",
+          "type": "Html",
+          "content": "<p class=\"govuk-body\"> {% assign estimatedCost = 'projectCostNumberField' | answer %} {% assign eligibilityMultiplier = 0.4 %} {% assign eligibilityAmount = estimatedCost | times: eligibilityMultiplier %} {% if eligibilityAmount <= 300000 and eligibilityAmount >= 25000 %} You may be able to apply for grant funding of up to {{ eligibilityAmount | formatCurrency: 'en-GB', 'GBP', 0 }} (40% of {{ estimatedCost | formatCurrency: 'en-GB', 'GBP', 0 }}).{% elsif eligibilityAmount > 300000 %} You may be able to apply for grant funding of up to £300,000, based on the estimated cost of {{ estimatedCost | formatCurrency: 'en-GB', 'GBP', 0 }}.\n\n\n<div class=\"govuk-inset-text\">The maximum grant you can apply for is £300,000</div> {% endif %}</p>\n",
+          "options": {},
+          "schema": {}
+        },
+        {
+          "type": "Html",
+          "name": "potentialFundingWarning",
+          "title": "Html",
+          "content": "<div class=\"govuk-warning-text\"> <span class=\"govuk-warning-text__icon\" aria-hidden=\"true\">!</span> <strong class=\"govuk-warning-text__text\"> <span class=\"govuk-visually-hidden\">Warning</span>There's no guarantee the project will receive a grant.</strong></div>",
+          "options": {},
+          "schema": {}
+        }
+      ]
+    },
+    {
+      "title": "{%- assign estimatedCost = 'projectCostNumberField' | answer -%} {%- assign applicantPayMultiplier = 0.6 -%} {%- assign applicantPayAmount = estimatedCost | times: applicantPayMultiplier -%} Can you pay the remaining costs of {{ applicantPayAmount | formatCurrency: 'en-GB', 'GBP', 0 }}?",
       "path": "/remaining-costs",
       "components": [
         {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -28,6 +28,7 @@ import DeclarationPageController from '~/src/server/controllers/declaration/cont
 import LandActionsController from '~/src/server/land-grants/actions/actions.controller.js'
 import LandParcelController from '~/src/server/land-grants/parcels/parcel.controller.js'
 import { router } from './router.js'
+import { formatCurrency } from '../config/nunjucks/filters/format-currency.js'
 
 const SESSION_CACHE_NAME = 'session.cache.name'
 
@@ -96,6 +97,9 @@ const registerFormsPlugin = async (server) => {
       services: {
         formsService,
         formSubmissionService
+      },
+      filters: {
+        formatCurrency
       },
       viewPaths: getViewPaths(),
       controllers: {


### PR DESCRIPTION
@ScenarioFactory This solution satisfies the logic in the ticket, and fixes the issue of the 695000 in project-cost not having a comma separator.

However, an important point is that because we are conditionally rendering content rather than having different pages, both of these have the same URL. Is this acceptable?