### PR TITLE
Add new Defra Accounts Bar component and update page headings

### DIFF
--- a/src/client/stylesheets/components/_index.scss
+++ b/src/client/stylesheets/components/_index.scss
@@ -1,2 +1,3 @@
 // import custom component styles
+@use "account-bar/account-bar";
 @use "heading/heading";

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -59,7 +59,7 @@ export const config = convict({
   serviceName: {
     doc: 'Applications Service Name',
     format: String,
-    default: 'grants-ui'
+    default: 'Manage land-based actions'
   },
   root: {
     doc: 'Project root',

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -56,6 +56,11 @@ export const config = convict({
     default: oneWeekMs,
     env: 'STATIC_CACHE_TIMEOUT'
   },
+  gitRepositoryName: {
+    doc: 'The name of the git repository which is used for logging events',
+    format: String,
+    default: 'grants-ui'
+  },
   serviceName: {
     doc: 'Applications Service Name',
     format: String,

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -47,7 +47,7 @@ describe('#context', () => {
             url: '/about'
           }
         ],
-        serviceName: 'grants-ui',
+        serviceName: 'Manage land-based actions',
         serviceUrl: '/',
         auth: {
           isAuthenticated: false,
@@ -142,7 +142,7 @@ describe('#context cache', () => {
             url: '/about'
           }
         ],
-        serviceName: 'grants-ui',
+        serviceName: 'Manage land-based actions',
         serviceUrl: '/',
         auth: {
           isAuthenticated: false,

--- a/src/server/common/components/account-bar/_account-bar.scss
+++ b/src/server/common/components/account-bar/_account-bar.scss
@@ -1,0 +1,17 @@
+@use "govuk-frontend" as *;
+
+.defra-account-bar {
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
+.defra-account-bar__headings {
+  @extend %govuk-heading-s;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.defra-account-bar__headings--right-aligned {
+  @include govuk-media-query($from: desktop) {
+    text-align: right;
+  }
+}

--- a/src/server/common/components/account-bar/macro.njk
+++ b/src/server/common/components/account-bar/macro.njk
@@ -1,0 +1,3 @@
+{% macro defraAccountBar(params) %}
+    {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/server/common/components/account-bar/template.njk
+++ b/src/server/common/components/account-bar/template.njk
@@ -1,0 +1,19 @@
+{% if params is defined and params.userName != null and params.userName | length > 0 and params.businessName != null and params.businessName | length > 0 %}
+  <div class="govuk-width-container">
+    <div class="defra-account-bar">
+      <div class="govuk-grid-row govuk-!-padding-top-3">
+        <div class="govuk-grid-column-two-thirds-from-desktop defra-account-bar__headings govuk-!-margin-bottom-2">
+            <span class="govuk-visually-hidden">Acting on behalf of </span>
+            {{ params.businessName }}
+            <div class="govuk-!-font-size-16 govuk-!-font-weight-regular govuk-!-margin-top-1">Single business identifier (SBI): {{ params.sbi }} </div>
+        </div>
+
+        <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-2 defra-account-bar__headings defra-account-bar__headings--right-aligned">
+          <span class="govuk-visually-hidden">Signed in as </span>
+          {{ params.userName }}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}
+

--- a/src/server/common/helpers/errors.test.js
+++ b/src/server/common/helpers/errors.test.js
@@ -34,7 +34,7 @@ describe('#errors', () => {
     })
 
     expect(result).toEqual(
-      expect.stringContaining('Page not found | grants-ui')
+      expect.stringContaining('Page not found | Manage land-based actions')
     )
     expect(statusCode).toBe(statusCodes.notFound)
   })

--- a/src/server/common/helpers/logging/logger-options.js
+++ b/src/server/common/helpers/logging/logger-options.js
@@ -4,7 +4,7 @@ import { config } from '~/src/config/config.js'
 import { getTraceId } from '@defra/hapi-tracing'
 
 const logConfig = config.get('log')
-const serviceName = config.get('serviceName')
+const serviceName = config.get('gitRepositoryName')
 const serviceVersion = config.get('serviceVersion')
 
 /**

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -5,6 +5,7 @@
 
 {# Import custom components globally #}
 {% from "heading/macro.njk" import appHeading %}
+{% from "account-bar/macro.njk" import defraAccountBar %}
 
 {% set mainClasses = "app-main-wrapper" %}
 
@@ -21,6 +22,13 @@
     serviceUrl: serviceUrl,
     useTudorCrown: true
   }) }}
+
+  {{ defraAccountBar({
+    businessName: "Agile Farms Ltd",
+    sbi: "1234567890",
+    userName: "Alfred Waldron"
+  }) }}
+
   {% include "partials/navigation/navigation.njk" %}
 {% endblock %}
 

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -2,6 +2,7 @@
 
 {# Import GOVUK components globally #}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 
 {# Import custom components globally #}
@@ -29,6 +30,16 @@
     sbi: "1234567890",
     userName: "Alfred Waldron"
   }) }}
+
+  <div class="govuk-width-container">
+
+    {{ govukPhaseBanner({
+      tag: {
+        text: "Beta"
+      },
+      text: 'This is a new service - your feedback will help us to improve it.'
+    }) }}
+  </div>
 {% endblock %}
 
 {% block pageTitle %}

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -2,6 +2,7 @@
 
 {# Import GOVUK components globally #}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 
 {# Import custom components globally #}
 {% from "heading/macro.njk" import appHeading %}
@@ -16,20 +17,18 @@
 {% block header %}
   {{ govukHeader({
     homepageUrl: "https://www.gov.uk/",
-    classes: "app-header",
+    classes: "govuk-header--full-width-border",
     containerClasses: "govuk-width-container",
-    serviceName: serviceName,
-    serviceUrl: serviceUrl,
     useTudorCrown: true
   }) }}
+
+  {{ govukServiceNavigation({ serviceName: serviceName, serviceUrl: serviceUrl }) }}
 
   {{ defraAccountBar({
     businessName: "Agile Farms Ltd",
     sbi: "1234567890",
     userName: "Alfred Waldron"
   }) }}
-
-  {% include "partials/navigation/navigation.njk" %}
 {% endblock %}
 
 {% block pageTitle %}

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -9,7 +9,7 @@
 {% from "heading/macro.njk" import appHeading %}
 {% from "account-bar/macro.njk" import defraAccountBar %}
 
-{% set mainClasses = "app-main-wrapper" %}
+{% set mainClasses = "" %}
 
 {% block head %}
   <link href="{{ getAssetPath('stylesheets/application.scss') }}" rel="stylesheet">

--- a/src/server/home/index.njk
+++ b/src/server/home/index.njk
@@ -3,27 +3,23 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
-  <div class="govuk-width-container">
-    <main class="govuk-main-wrapper">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">Sign into your Defra account</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Sign into your Defra account</h1>
 
-          <p class="govuk-body">Use this service to sign in with your Defra account.</p>
-          <p class="govuk-body">If you have multiple businesses that are registered to your rural payments account, you'll be asked which one you're applying for.</p>
-          <p class="govuk-body">Signing in takes around 5 minutes.</p>
+      <p class="govuk-body">Use this service to sign in with your Defra account.</p>
+      <p class="govuk-body">If you have multiple businesses that are registered to your rural payments account, you'll be asked which one you're applying for.</p>
+      <p class="govuk-body">Signing in takes around 5 minutes.</p>
 
-          {{ govukButton({
-            classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-8",
-            href: "/auth/sign-in",
-            isStartButton: true,
-            text: "Sign in"
-          }) }}
+      {{ govukButton({
+        classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-8",
+        href: "/auth/sign-in",
+        isStartButton: true,
+        text: "Sign in"
+      }) }}
 
-          <h2 class="govuk-heading-m">Before you start</h2>
-          <p class="govuk-body">You’ll need your Rural Payments service customer reference number (CRN) and password to sign in.</p>
-        </div>
-      </div>
-    </main>
+      <h2 class="govuk-heading-m">Before you start</h2>
+      <p class="govuk-body">You’ll need your Rural Payments service customer reference number (CRN) and password to sign in.</p>
+    </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Background

To bring the UI closer inline with what is shown in the prototype

## What has changed?
I created a new component called `Defra Account Bar` which displays the current users name, business name and SBI. Its a similar pattern used on Single Front Door but with improved markup (I.e not using `h3` for the larger/bolder text). The component will only display is username and business name are passed to it. 

- Display new Defra Account Bar in the service using fake username/business name which can later be updated from Defra ID
- Updated the serviceName from `grants-ui` to `Manage land-based actions` 
- Added the service navigation component which is the new pattern that GOV.UK will be moving to instead of displaying the name in the Header
- Add simple phase banner for the moment



## Before - Desktop
![image](https://github.com/user-attachments/assets/352814b5-c911-4c22-b04f-810c6902bd02)

## Before - Mobile
![image](https://github.com/user-attachments/assets/ddb8e1b0-4b48-48ff-8d9d-6a1d83860e9b)


## After - Desktop
![image](https://github.com/user-attachments/assets/cebdf29c-e3fa-46cb-8833-b120c6f8b507)

## After - Mobile
![image](https://github.com/user-attachments/assets/932dc87c-d4d5-467c-9c9c-fd4f09231364)
