### PR TITLE
Removed user/business name from account bar

### DIFF
--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -26,9 +26,9 @@
   {{ govukServiceNavigation({ serviceName: serviceName, serviceUrl: serviceUrl }) }}
 
   {{ defraAccountBar({
-    businessName: "Agile Farms Ltd",
+    businessName: "",
     sbi: "1234567890",
-    userName: "Alfred Waldron"
+    userName: ""
   }) }}
 
   <div class="govuk-width-container">


### PR DESCRIPTION
This will hide the account bar until we have defra id setup


### Before

![image](https://github.com/user-attachments/assets/450c1a89-4ce4-421e-bf45-7a937322e6ff)


### After

![image](https://github.com/user-attachments/assets/fac7cd9e-511f-4742-9f3e-1b67ff4c9b7b)
