### PR TITLE
Use custom layout for DXT form pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@defra/forms-engine-plugin": "^0.1.8",
+        "@defra/forms-engine-plugin": "0.1.12",
         "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/bell": "^13.1.0",
@@ -2026,13 +2026,13 @@
       "license": "MIT"
     },
     "node_modules/@defra/forms-engine-plugin": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-0.1.8.tgz",
-      "integrity": "sha512-+2RehYwOIDtZO2kSoJJogNjST6Vzpmv2OmobetIN8reZ+8NGVvcJVCYZls3qenc3ermvJci9VPNYrI9fqswTLA==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-0.1.12.tgz",
+      "integrity": "sha512-foEPoYUg/XdAUqHbMpADXA2B0mj+Tb58peyWNFhQsV54lX6W4/YOQgCAf8IoigPOXm/BskFToJPoy3PGQImVsQ==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.409",
+        "@defra/forms-model": "^3.0.441",
         "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/boom": "^10.0.1",
@@ -2074,7 +2074,8 @@
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
         "proxy-agent": "^6.5.0",
-        "resolve": "^1.22.10"
+        "resolve": "^1.22.10",
+        "yaml": "^2.7.1"
       },
       "engines": {
         "node": "^22.11.0",
@@ -2082,12 +2083,12 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.428",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.428.tgz",
-      "integrity": "sha512-SCDpjS/tOzoENcU273FLjXwAN45BDU921cp+VH4sNqrNHCYbPKaV84ON0pmKKgyl+kHvvmD1jSq51GzF9g6JKQ==",
+      "version": "3.0.444",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.444.tgz",
+      "integrity": "sha512-Bn6BHR2kiXIJKgXwt58pmjflnY888EUop1NMbgEaVgEv5HlAuLvzXNdUmM7fOZH+eudV8wF0Gil24JEdmfwViw==",
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "marked": "^15.0.7",
+        "marked": "^15.0.9",
         "nanoid": "^5.0.7",
         "slug": "^10.0.0",
         "uuid": "^11.1.0"
@@ -11806,9 +11807,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.7.tgz",
-      "integrity": "sha512-dgLIeKGLx5FwziAnsk4ONoGwHwGPJzselimvlVskE9XLN4Orv9u2VA3GWw/lYUqjfA0rUT/6fqKwfZJapP9BEg==",
+      "version": "15.0.11",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.11.tgz",
+      "integrity": "sha512-1BEXAU2euRCG3xwgLVT1y0xbJEld1XOrmRJpUwRCcy7rxhSCwMrmEu9LXoPhHSCJG41V7YcQ2mjKRr5BA3ITIA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -17776,6 +17777,18 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@defra/forms-engine-plugin": "0.1.12",
+        "@defra/forms-engine-plugin": "^0.1.14",
         "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/bell": "^13.1.0",
@@ -2026,9 +2026,9 @@
       "license": "MIT"
     },
     "node_modules/@defra/forms-engine-plugin": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-0.1.12.tgz",
-      "integrity": "sha512-foEPoYUg/XdAUqHbMpADXA2B0mj+Tb58peyWNFhQsV54lX6W4/YOQgCAf8IoigPOXm/BskFToJPoy3PGQImVsQ==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-0.1.14.tgz",
+      "integrity": "sha512-EsZ45dDQJVN0uJdxh7VGvUvsFdz3Bj6DUkQzSpeYbGd/HGReNxpzKYF0e6tVa5LQ1vq20qMWl1iyxA9WKQprKQ==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@defra/forms-engine-plugin": "^0.1.14",
+        "@defra/forms-engine-plugin": "^0.1.15",
         "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/bell": "^13.1.0",
@@ -95,7 +95,7 @@
         "tsx": "^4.19.2",
         "typescript": "^5.6.3",
         "webpack": "^5.96.1",
-        "webpack-assets-manifest": "^5.2.1",
+        "webpack-assets-manifest": "^6.0.2",
         "webpack-cli": "^5.1.4"
       },
       "engines": {
@@ -2026,9 +2026,9 @@
       "license": "MIT"
     },
     "node_modules/@defra/forms-engine-plugin": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-0.1.14.tgz",
-      "integrity": "sha512-EsZ45dDQJVN0uJdxh7VGvUvsFdz3Bj6DUkQzSpeYbGd/HGReNxpzKYF0e6tVa5LQ1vq20qMWl1iyxA9WKQprKQ==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-0.1.15.tgz",
+      "integrity": "sha512-jl+P2Bf+gqcsHWgSEFJpnbL3ysfSBu4F39B5qJ4S6pjppkm6AAGbbVwu4txEOl6K/WEq2FUQm7E5kmlrRalUfg==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
@@ -5151,16 +5151,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -11709,21 +11699,6 @@
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "license": "MIT"
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -17380,44 +17355,22 @@
       }
     },
     "node_modules/webpack-assets-manifest": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-5.2.1.tgz",
-      "integrity": "sha512-MsEcXVio1GY6R+b4dVfTHIDMB0RB90KajQG8neRbH92vE2S1ClGw9mNa9NPlratYBvZOhExmN0qqMNFTaCTuIg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-6.0.2.tgz",
+      "integrity": "sha512-L27ie/OYb+AHqHQzBJ3wGSm5IHRPPO0lsCNoYwDa8qL5rNkTfmNSRnyWQK6TLvL3wLhsrAcVbnM/S17A6gv0DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.1.2",
         "deepmerge": "^4.3.1",
         "lockfile": "^1.0.4",
-        "lodash.get": "^4.4.2",
-        "lodash.has": "^4.5.2",
-        "schema-utils": "^3.3.0",
+        "schema-utils": "^4.3.0",
         "tapable": "^2.2.1"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=20.10.0"
       },
       "peerDependencies": {
-        "webpack": "^5.2.0"
-      }
-    },
-    "node_modules/webpack-assets-manifest/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
+        "webpack": "^5.61.0"
       }
     },
     "node_modules/webpack-cli": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@defra/forms-engine-plugin": "^0.1.14",
+    "@defra/forms-engine-plugin": "^0.1.15",
     "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/bell": "^13.1.0",
@@ -123,7 +123,7 @@
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
     "webpack": "^5.96.1",
-    "webpack-assets-manifest": "^5.2.1",
+    "webpack-assets-manifest": "^6.0.2",
     "webpack-cli": "^5.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@defra/forms-engine-plugin": "^0.1.8",
+    "@defra/forms-engine-plugin": "0.1.12",
     "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/bell": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@defra/forms-engine-plugin": "0.1.12",
+    "@defra/forms-engine-plugin": "^0.1.14",
     "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/bell": "^13.1.0",

--- a/src/client/stylesheets/application.scss
+++ b/src/client/stylesheets/application.scss
@@ -1,4 +1,5 @@
-@use 'govuk-frontend';
+@use 'pkg:@defra/forms-engine-plugin';
+@use 'pkg:govuk-frontend';
 
 @use 'variables';
 @use 'helpers';

--- a/src/config/nunjucks/nunjucks.js
+++ b/src/config/nunjucks/nunjucks.js
@@ -9,12 +9,12 @@ import * as filters from './filters/filters.js'
 import * as globals from './globals.js'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
+export const grantsUiPaths = [
+  path.resolve(dirname, '../../server/common/templates'),
+  path.resolve(dirname, '../../server/common/components')
+]
 const nunjucksEnvironment = nunjucks.configure(
-  [
-    'node_modules/govuk-frontend/dist/',
-    path.resolve(dirname, '../../server/common/templates'),
-    path.resolve(dirname, '../../server/common/components')
-  ],
+  ['node_modules/govuk-frontend/dist/', ...grantsUiPaths],
   {
     autoescape: true,
     throwOnUndefined: false,

--- a/src/server/common/forms/definitions/adding-value.json
+++ b/src/server/common/forms/definitions/adding-value.json
@@ -457,7 +457,7 @@
         {
           "type": "YesNoField",
           "name": "remainingCostsYesNoField",
-          "title": " ",
+          "title": "Can you pay the remaining costs?",
           "options": {
             "customValidationMessages": {
               "any.required": "Select yes if you can pay the remaining costs"

--- a/src/server/common/helpers/serve-static-files.js
+++ b/src/server/common/helpers/serve-static-files.js
@@ -19,14 +19,6 @@ export const serveStaticFiles = {
       server.route([
         {
           method: 'GET',
-          path: '/stylesheets/application.min.css',
-          handler: {
-            file: './stylesheets/dxt-application.min.css'
-          },
-          options
-        },
-        {
-          method: 'GET',
           path: '/javascripts/application.min.js',
           handler: {
             file: './javascripts/dxt-application.min.js'

--- a/src/server/common/templates/layouts/dxt-form.njk
+++ b/src/server/common/templates/layouts/dxt-form.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block pageTitle %}
-  {{ "Error: " if errors | length }}{{ pageTitle | evaluate }} {{ serviceName }}
+  {{ "Error: " if errors | length }}{{ pageTitle | evaluate }} | {{ serviceName }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/src/server/common/templates/layouts/form.njk
+++ b/src/server/common/templates/layouts/form.njk
@@ -1,0 +1,14 @@
+{% extends "layouts/page.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% block pageTitle %}
+  {{ "Error: " if errors | length }}{{ pageTitle | evaluate }} {{ serviceName }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ super() }}
+  {% if backLink %}
+    {{ govukBackLink(backLink) }}
+  {% endif %}
+{% endblock %}

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -43,7 +43,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  {{ pageTitle }} | {{ serviceName }}
+  {{ "Error: " if errors | length }}{{ pageTitle }} | {{ serviceName }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -109,7 +109,7 @@ const registerFormsPlugin = async (server) => {
         formatCurrency
       },
       nunjucks: {
-        baseLayoutPath: 'layouts/form.njk',
+        baseLayoutPath: 'layouts/dxt-form.njk',
         paths: grantsUiPaths
       },
       viewContext: context,

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -9,7 +9,11 @@ import Scooter from '@hapi/scooter'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { config } from '~/src/config/config.js'
-import { nunjucksConfig } from '~/src/config/nunjucks/nunjucks.js'
+import {
+  nunjucksConfig,
+  grantsUiPaths
+} from '~/src/config/nunjucks/nunjucks.js'
+import { context } from '~/src/config/nunjucks/context/context.js'
 // import auth from '~/src/plugins/auth.js'
 import csp from '~/src/plugins/content-security-policy.js'
 import sso from '~/src/plugins/sso.js'
@@ -104,6 +108,11 @@ const registerFormsPlugin = async (server) => {
       filters: {
         formatCurrency
       },
+      nunjucks: {
+        baseLayoutPath: 'layouts/form.njk',
+        paths: grantsUiPaths
+      },
+      viewContext: context,
       viewPaths: getViewPaths(),
       controllers: {
         ConfirmationPageController,

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -47,7 +47,7 @@ const getViewPaths = () => {
     `${basePath}/land-grants/parcel`,
     `${basePath}/land-grants/submission`,
     `${basePath}/views`,
-    `${basePath}/common/templates`
+    ...grantsUiPaths
   ]
 }
 
@@ -110,10 +110,9 @@ const registerFormsPlugin = async (server) => {
       },
       nunjucks: {
         baseLayoutPath: 'layouts/dxt-form.njk',
-        paths: grantsUiPaths
+        paths: getViewPaths()
       },
       viewContext: context,
-      viewPaths: getViewPaths(),
       controllers: {
         ConfirmationPageController,
         DeclarationPageController,

--- a/src/server/land-grants/actions/land-actions.html
+++ b/src/server/land-grants/actions/land-actions.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends baseLayoutPath %}
 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
@@ -42,11 +42,11 @@
               checked: actions and actions.includes(action.code)
             }]) %}
           {% endfor %}
-          
+
           {% if actionList.length > 0 %}
           <div class="govuk-form-group">
             <fieldset class="govuk-fieldset" aria-describedby="action-hint">
-              
+
               <table class="govuk-table">
                 <caption class="govuk-table__caption govuk-table__caption--l">Available actions for selected parcel</caption>
                 <thead class="govuk-table__head">
@@ -84,7 +84,7 @@
 
             </fieldset>
           </div>
-            
+
           <div class="govuk-button-group">
             <input type="hidden" name="crumb" value="{{ crumb }}">
             {% block form %}

--- a/src/server/land-grants/parcel/land-parcel.html
+++ b/src/server/land-grants/parcel/land-parcel.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends baseLayoutPath %}
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
@@ -31,7 +31,7 @@
               text: parcel.sheetId + "-" + parcel.parcelId + " (Total size: " + parcel.area + " ha.)"
             }]) %}
           {% endfor %}
-          
+
           {% if radioItems.length > 0 %}
             {{ govukRadios({
                 name: "landParcel",
@@ -44,9 +44,9 @@
                 },
                 items: radioItems,
                 value: parcelId
-              }) 
+              })
             }}
-            
+
             <div class="govuk-button-group">
               <input type="hidden" name="crumb" value="{{ crumb }}">
               {% block form %}

--- a/src/server/land-grants/submission/submission.html
+++ b/src/server/land-grants/submission/submission.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends baseLayoutPath %}
 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}

--- a/src/server/views/confirmation-page.html
+++ b/src/server/views/confirmation-page.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends baseLayoutPath %}
 {% set backLink = false %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 

--- a/src/server/views/declaration-page.html
+++ b/src/server/views/declaration-page.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends baseLayoutPath %}
 
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/server/views/score-results.html
+++ b/src/server/views/score-results.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends baseLayoutPath %}
 
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import path from 'path'
 import TerserPlugin from 'terser-webpack-plugin'
-import WebpackAssetsManifest from 'webpack-assets-manifest'
+import { WebpackAssetsManifest } from 'webpack-assets-manifest'
 
 const { NODE_ENV = 'development' } = process.env
 
@@ -115,7 +115,8 @@ export default {
                 loadPaths: [
                   path.join(dirname, 'src/client/stylesheets'),
                   path.join(dirname, 'src/server/common/components'),
-                  path.join(dirname, 'src/server/common/templates/partials')
+                  path.join(dirname, 'src/server/common/templates/partials'),
+                  path.join(dirname, 'node_modules')
                 ],
                 quietDeps: true,
                 sourceMapIncludeSources: true,
@@ -185,12 +186,6 @@ export default {
         {
           from: path.join(govukFrontendPath, 'dist/govuk/assets'),
           to: 'assets'
-        },
-        {
-          from: require.resolve(
-            '@defra/forms-engine-plugin/application.min.css'
-          ),
-          to: 'stylesheets/dxt-application.min.css'
         },
         {
           from: require.resolve(


### PR DESCRIPTION
Creates a new `layouts/form.njk`, based off our base `layouts/page.njk` template. This `form.njk` template adds any required alterations for a form to be presented.

This PR is not quite ready to be merged, I'm having one issue with the initialisation of a YesNo component on a form - just trying to work that out. It's completely unrelated to this change, not quite sure what's going on!

There's a dependency on the next version of the plugin, which hasn't been published yet. See: https://github.com/DEFRA/forms-engine-plugin/pull/60

Old:
![image](https://github.com/user-attachments/assets/a0866f9b-00d6-46b0-b04c-b997ceb95285)

New:
![image](https://github.com/user-attachments/assets/83bf4c9b-6805-4d83-b3c5-55e283502228)