### PR TITLE
Change "Funding Details" and "Total Application Value" to sentence case 

### DIFF
--- a/src/server/common/forms/definitions/find-funding-for-land-or-farms.json
+++ b/src/server/common/forms/definitions/find-funding-for-land-or-farms.json
@@ -119,7 +119,7 @@
         {
           "type": "TextField",
           "name": "applicationValue",
-          "title": "Total Application Value",
+          "title": "Total application value",
           "options": {},
           "schema": {}
         }

--- a/src/server/common/forms/definitions/find-funding-for-land-or-farms.json
+++ b/src/server/common/forms/definitions/find-funding-for-land-or-farms.json
@@ -126,7 +126,7 @@
       ]
     },
     {
-      "title": "Funding Details",
+      "title": "Funding details",
       "path": "/summary",
       "controller": "SubmissionPageController"
     },


### PR DESCRIPTION
Updated the page heading to use sentence case for consistency with style guidelines.

## Before

![image](https://github.com/user-attachments/assets/cdef8b5b-0d04-43a3-9993-7358fe227dcf)


## After

![image](https://github.com/user-attachments/assets/9e54b9ef-9985-4a5d-b0f4-7157be38e243)
