### PR TITLE
Update DXT custom form layout to use form name

### DIFF
--- a/src/server/common/templates/layouts/dxt-form.njk
+++ b/src/server/common/templates/layouts/dxt-form.njk
@@ -3,7 +3,33 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block pageTitle %}
-  {{ "Error: " if errors | length }}{{ pageTitle | evaluate }} {{ serviceName }}
+  {{ "Error: " if errors | length }}{{ pageTitle | evaluate }} | {{ name | default(serviceName) }}
+{% endblock %}
+
+{% block header %}
+  {{ govukHeader({
+    homepageUrl: "https://www.gov.uk/",
+    classes: "govuk-header--full-width-border",
+    containerClasses: "govuk-width-container",
+    useTudorCrown: true
+  }) }}
+
+  {{ govukServiceNavigation({ serviceName: name | default(serviceName) , serviceUrl: serviceUrl }) }}
+
+  {{ defraAccountBar({
+    businessName: "",
+    sbi: "1234567890",
+    userName: ""
+  }) }}
+
+  <div class="govuk-width-container">
+    {{ govukPhaseBanner({
+      tag: {
+        text: "Beta"
+      },
+      text: 'This is a new service - your feedback will help us to improve it.'
+    }) }}
+  </div>
 {% endblock %}
 
 {% block beforeContent %}


### PR DESCRIPTION
## Issue

DXT form pages were not surfacing the form name but instead displaying the `serviceName`. This fixes the initial issue #66  introduced but we still need to flesh out a bit more on what `grants-ui` servicename will be

## Before
![image](https://github.com/user-attachments/assets/2d6fc6c9-250b-4031-a7bc-274a11194d15)


## After

![image](https://github.com/user-attachments/assets/3f1ce973-15da-4187-824b-251b1ff801bc)
