### PR TITLE
Mocking DAL based on env variable

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -102,7 +102,7 @@ export const config = convict({
     }
   },
   consolidatedView: {
-    mockEnabled: {
+    mockDALEnabled: {
       doc: 'Consolidated View API mock enabled',
       format: Boolean,
       default: false,

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -102,6 +102,12 @@ export const config = convict({
     }
   },
   consolidatedView: {
+    mockEnabled: {
+      doc: 'Consolidated View API mock enabled',
+      format: Boolean,
+      default: false,
+      env: 'CV_API_MOCK_ENABLED'
+    },
     apiEndpoint: {
       doc: 'Consolidated View API endpoint',
       format: String,

--- a/src/server/__mocks__/consolidated-view/106238988.json
+++ b/src/server/__mocks__/consolidated-view/106238988.json
@@ -1,0 +1,162 @@
+{
+  "data": {
+    "business": {
+      "sbi": "106238988",
+      "organisationId": "5559799",
+      "land": {
+        "parcels": [
+          {
+            "parcelId": "0155",
+            "sheetId": "SD7946",
+            "area": 4.0383
+          },
+          {
+            "parcelId": "4509",
+            "sheetId": "SD7846",
+            "area": 0.0633
+          },
+          {
+            "parcelId": "7245",
+            "sheetId": "SD7846",
+            "area": 6.7412
+          },
+          {
+            "parcelId": "0926",
+            "sheetId": "SD7846",
+            "area": 1.7908
+          },
+          {
+            "parcelId": "9135",
+            "sheetId": "SD7846",
+            "area": 2.9989
+          },
+          {
+            "parcelId": "0638",
+            "sheetId": "SD7946",
+            "area": 0.9335
+          },
+          {
+            "parcelId": "1215",
+            "sheetId": "SD7846",
+            "area": 0.0972
+          },
+          {
+            "parcelId": "0617",
+            "sheetId": "SD7846",
+            "area": 0.7099
+          },
+          {
+            "parcelId": "7013",
+            "sheetId": "SD7846",
+            "area": 8.9902
+          },
+          {
+            "parcelId": "0155",
+            "sheetId": "SD7642",
+            "area": 1.2324
+          },
+          {
+            "parcelId": "0412",
+            "sheetId": "SD7846",
+            "area": 0.4666
+          },
+          {
+            "parcelId": "4503",
+            "sheetId": "SD7846",
+            "area": 0.7252
+          },
+          {
+            "parcelId": "5103",
+            "sheetId": "SD7846",
+            "area": 0.0585
+          },
+          {
+            "parcelId": "5197",
+            "sheetId": "SD7845",
+            "area": 0.9849
+          },
+          {
+            "parcelId": "9420",
+            "sheetId": "SD7746",
+            "area": 0.1854
+          },
+          {
+            "parcelId": "2147",
+            "sheetId": "SD7946",
+            "area": 2.5796
+          },
+          {
+            "parcelId": "1533",
+            "sheetId": "SD7946",
+            "area": 3.2249
+          },
+          {
+            "parcelId": "9538",
+            "sheetId": "SD7542",
+            "area": 1.2224
+          },
+          {
+            "parcelId": "2024",
+            "sheetId": "SD7846",
+            "area": 0.8704
+          },
+          {
+            "parcelId": "8954",
+            "sheetId": "SD7846",
+            "area": 2.5109
+          },
+          {
+            "parcelId": "5637",
+            "sheetId": "SD7846",
+            "area": 3.5502
+          },
+          {
+            "parcelId": "8408",
+            "sheetId": "SD7746",
+            "area": 7.2496
+          },
+          {
+            "parcelId": "1162",
+            "sheetId": "SD7946",
+            "area": 2.2103
+          },
+          {
+            "parcelId": "0345",
+            "sheetId": "SD7642",
+            "area": 2.3867
+          },
+          {
+            "parcelId": "4510",
+            "sheetId": "SD7846",
+            "area": 0.0368
+          },
+          {
+            "parcelId": "5112",
+            "sheetId": "SD7846",
+            "area": 0.4277
+          },
+          {
+            "parcelId": "4624",
+            "sheetId": "SD7846",
+            "area": 3.4107
+          },
+          {
+            "parcelId": "4156",
+            "sheetId": "SD7946",
+            "area": 5.1567
+          },
+          {
+            "parcelId": "5465",
+            "sheetId": "SD7946",
+            "area": 1.2932
+          },
+          {
+            "parcelId": "2533",
+            "sheetId": "SD7946",
+            "area": 0.1052
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/server/__mocks__/consolidated-view/106284736.json
+++ b/src/server/__mocks__/consolidated-view/106284736.json
@@ -1,0 +1,252 @@
+{
+  "data": {
+    "business": {
+      "sbi": "106284736",
+      "organisationId": "5560725",
+      "land": {
+        "parcels": [
+          {
+            "parcelId": "7039",
+            "sheetId": "SD6843",
+            "area": 1.3308
+          },
+          {
+            "parcelId": "6292",
+            "sheetId": "SD6743",
+            "area": 7.5713
+          },
+          {
+            "parcelId": "1785",
+            "sheetId": "SD6842",
+            "area": 4.6925
+          },
+          {
+            "parcelId": "8083",
+            "sheetId": "SD6743",
+            "area": 4.5341
+          },
+          {
+            "parcelId": "8120",
+            "sheetId": "SD6743",
+            "area": 2.9859
+          },
+          {
+            "parcelId": "2122",
+            "sheetId": "SD6843",
+            "area": 6.7943
+          },
+          {
+            "parcelId": "4925",
+            "sheetId": "SD6843",
+            "area": 0.1638
+          },
+          {
+            "parcelId": "8333",
+            "sheetId": "SD6743",
+            "area": 3.3189
+          },
+          {
+            "parcelId": "0307",
+            "sheetId": "SD6944",
+            "area": 4.9762
+          },
+          {
+            "parcelId": "9664",
+            "sheetId": "SD6843",
+            "area": 2.964
+          },
+          {
+            "parcelId": "5533",
+            "sheetId": "SD6843",
+            "area": 3.0535
+          },
+          {
+            "parcelId": "1162",
+            "sheetId": "SD6842",
+            "area": 2.7838
+          },
+          {
+            "parcelId": "7067",
+            "sheetId": "SD6844",
+            "area": 3.1023
+          },
+          {
+            "parcelId": "2399",
+            "sheetId": "SD6943",
+            "area": 3.0124
+          },
+          {
+            "parcelId": "8473",
+            "sheetId": "SD6743",
+            "area": 0.5824
+          },
+          {
+            "parcelId": "5426",
+            "sheetId": "SD6843",
+            "area": 0.0152
+          },
+          {
+            "parcelId": "3088",
+            "sheetId": "SD6842",
+            "area": 0.0289
+          },
+          {
+            "parcelId": "8055",
+            "sheetId": "SD6743",
+            "area": 4.6998
+          },
+          {
+            "parcelId": "3979",
+            "sheetId": "SD6943",
+            "area": 7.1039
+          },
+          {
+            "parcelId": "5422",
+            "sheetId": "SD6743",
+            "area": 5.1299
+          },
+          {
+            "parcelId": "3514",
+            "sheetId": "SD6843",
+            "area": 3.2396
+          },
+          {
+            "parcelId": "5580",
+            "sheetId": "SD6842",
+            "area": 2.5813
+          },
+          {
+            "parcelId": "4921",
+            "sheetId": "SD6843",
+            "area": 0.1087
+          },
+          {
+            "parcelId": "3841",
+            "sheetId": "SD6843",
+            "area": 3.385
+          },
+          {
+            "parcelId": "6455",
+            "sheetId": "SD6843",
+            "area": 5.7015
+          },
+          {
+            "parcelId": "0447",
+            "sheetId": "SD6943",
+            "area": 8.7602
+          },
+          {
+            "parcelId": "1385",
+            "sheetId": "SD6943",
+            "area": 2.3609
+          },
+          {
+            "parcelId": "8467",
+            "sheetId": "SD6843",
+            "area": 3.0254
+          },
+          {
+            "parcelId": "7272",
+            "sheetId": "SD6843",
+            "area": 1.6722
+          },
+          {
+            "parcelId": "5461",
+            "sheetId": "SD6743",
+            "area": 9.0771
+          },
+          {
+            "parcelId": "7435",
+            "sheetId": "SD6843",
+            "area": 1.4056
+          },
+          {
+            "parcelId": "7268",
+            "sheetId": "SD6743",
+            "area": 0.6564
+          },
+          {
+            "parcelId": "5419",
+            "sheetId": "SD6843",
+            "area": 0.3933
+          },
+          {
+            "parcelId": "2447",
+            "sheetId": "SD6843",
+            "area": 3.5109
+          },
+          {
+            "parcelId": "8889",
+            "sheetId": "SD6843",
+            "area": 5.132
+          },
+          {
+            "parcelId": "4301",
+            "sheetId": "SD6843",
+            "area": 6.3008
+          },
+          {
+            "parcelId": "4282",
+            "sheetId": "SD6842",
+            "area": 3.08
+          },
+          {
+            "parcelId": "0784",
+            "sheetId": "SD6842",
+            "area": 4.2022
+          },
+          {
+            "parcelId": "9977",
+            "sheetId": "SD6843",
+            "area": 1.2006
+          },
+          {
+            "parcelId": "6006",
+            "sheetId": "SD6743",
+            "area": 3.4
+          },
+          {
+            "parcelId": "8077",
+            "sheetId": "SD6843",
+            "area": 0.0691
+          },
+          {
+            "parcelId": "0882",
+            "sheetId": "SD6943",
+            "area": 0.0185
+          },
+          {
+            "parcelId": "0977",
+            "sheetId": "SD6943",
+            "area": 0.0315
+          },
+          {
+            "parcelId": "3625",
+            "sheetId": "SD6743",
+            "area": 4.0902
+          },
+          {
+            "parcelId": "5424",
+            "sheetId": "SD6843",
+            "area": 0.1642
+          },
+          {
+            "parcelId": "9381",
+            "sheetId": "SD6843",
+            "area": 0.3822
+          },
+          {
+            "parcelId": "0085",
+            "sheetId": "SD6943",
+            "area": 0.5984
+          },
+          {
+            "parcelId": "9485",
+            "sheetId": "SD6843",
+            "area": 0.1447
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/server/__mocks__/consolidated-view/121428499.json
+++ b/src/server/__mocks__/consolidated-view/121428499.json
@@ -1,0 +1,522 @@
+{
+  "data": {
+    "business": {
+      "sbi": "121428499",
+      "organisationId": "5447505",
+      "land": {
+        "parcels": [
+          {
+            "id": "4528473",
+            "parcelId": "8781",
+            "sheetId": "SD6351",
+            "area": 68.0498
+          },
+          {
+            "id": "1957166",
+            "parcelId": "8774",
+            "sheetId": "SD6352",
+            "area": 11.1006
+          },
+          {
+            "id": "6452787",
+            "parcelId": "7537",
+            "sheetId": "SD6252",
+            "area": 0.3361
+          },
+          {
+            "id": "4976152",
+            "parcelId": "3140",
+            "sheetId": "SD6950",
+            "area": 4.5699
+          },
+          {
+            "id": "6487326",
+            "parcelId": "3232",
+            "sheetId": "SD5851",
+            "area": 42.2833
+          },
+          {
+            "id": "2026447",
+            "parcelId": "7174",
+            "sheetId": "SD6251",
+            "area": 8.9349
+          },
+          {
+            "id": "2021709",
+            "parcelId": "4310",
+            "sheetId": "SD6352",
+            "area": 6.5942
+          },
+          {
+            "id": "1902050",
+            "parcelId": "8442",
+            "sheetId": "SD6252",
+            "area": 3.6248
+          },
+          {
+            "id": "1959466",
+            "parcelId": "4413",
+            "sheetId": "SD6351",
+            "area": 3.0395
+          },
+          {
+            "id": "6611820",
+            "parcelId": "5509",
+            "sheetId": "SD6252",
+            "area": 1.8477
+          },
+          {
+            "id": "2022012",
+            "parcelId": "0161",
+            "sheetId": "SD6351",
+            "area": 2.436
+          },
+          {
+            "id": "1928160",
+            "parcelId": "7889",
+            "sheetId": "SD6251",
+            "area": 0.3572
+          },
+          {
+            "id": "1961457",
+            "parcelId": "4624",
+            "sheetId": "SD7155",
+            "area": 3.3462
+          },
+          {
+            "id": "1951009",
+            "parcelId": "9861",
+            "sheetId": "SD6352",
+            "area": 1.7721
+          },
+          {
+            "id": "1984017",
+            "parcelId": "3772",
+            "sheetId": "SD6352",
+            "area": 0.4845
+          },
+          {
+            "id": "7347864",
+            "parcelId": "1441",
+            "sheetId": "SD6351",
+            "area": 0.9175
+          },
+          {
+            "id": "1993681",
+            "parcelId": "2185",
+            "sheetId": "SD6351",
+            "area": 4.419
+          },
+          {
+            "id": "1941243",
+            "parcelId": "2602",
+            "sheetId": "SD6353",
+            "area": 0.4599
+          },
+          {
+            "id": "6611821",
+            "parcelId": "2415",
+            "sheetId": "SD6252",
+            "area": 64.1389
+          },
+          {
+            "id": "6452788",
+            "parcelId": "8023",
+            "sheetId": "SD6252",
+            "area": 0.4578
+          },
+          {
+            "id": "6611822",
+            "parcelId": "4796",
+            "sheetId": "SD6251",
+            "area": 1.8591
+          },
+          {
+            "id": "1902514",
+            "parcelId": "3622",
+            "sheetId": "SD6252",
+            "area": 0.5482
+          },
+          {
+            "id": "4528495",
+            "parcelId": "8609",
+            "sheetId": "SD7155",
+            "area": 7.5229
+          },
+          {
+            "id": "2032945",
+            "parcelId": "6308",
+            "sheetId": "SD7155",
+            "area": 1.705
+          },
+          {
+            "id": "6457103",
+            "parcelId": "2654",
+            "sheetId": "SD6351",
+            "area": 5.9945
+          },
+          {
+            "id": "6611828",
+            "parcelId": "0998",
+            "sheetId": "SD6250",
+            "area": 1.7798
+          },
+          {
+            "id": "7290752",
+            "parcelId": "7554",
+            "sheetId": "SD7155",
+            "area": 7.0501
+          },
+          {
+            "id": "2035937",
+            "parcelId": "5164",
+            "sheetId": "SD6352",
+            "area": 6.3924
+          },
+          {
+            "id": "2043962",
+            "parcelId": "4593",
+            "sheetId": "SD6352",
+            "area": 6.9321
+          },
+          {
+            "id": "6611826",
+            "parcelId": "3851",
+            "sheetId": "SD6050",
+            "area": 2.0376
+          },
+          {
+            "id": "6611831",
+            "parcelId": "8778",
+            "sheetId": "SD6150",
+            "area": 0.2202
+          },
+          {
+            "id": "6611833",
+            "parcelId": "4796",
+            "sheetId": "SD6150",
+            "area": 0.3067
+          },
+          {
+            "id": "4636328",
+            "parcelId": "4373",
+            "sheetId": "SD7255",
+            "area": 14.0581
+          },
+          {
+            "id": "1943822",
+            "parcelId": "0872",
+            "sheetId": "SD7244",
+            "area": 3.0774
+          },
+          {
+            "id": "6611825",
+            "parcelId": "9265",
+            "sheetId": "SD6050",
+            "area": 7.8436
+          },
+          {
+            "id": "6611832",
+            "parcelId": "8088",
+            "sheetId": "SD6150",
+            "area": 0.4432
+          },
+          {
+            "id": "4528470",
+            "parcelId": "6030",
+            "sheetId": "SD6252",
+            "area": 10.6865
+          },
+          {
+            "id": "6457105",
+            "parcelId": "1332",
+            "sheetId": "SD6351",
+            "area": 0.1012
+          },
+          {
+            "id": "2005866",
+            "parcelId": "6685",
+            "sheetId": "SD6252",
+            "area": 18.1473
+          },
+          {
+            "id": "2053766",
+            "parcelId": "2465",
+            "sheetId": "SD7244",
+            "area": 4.5855
+          },
+          {
+            "id": "2037180",
+            "parcelId": "8952",
+            "sheetId": "SD6251",
+            "area": 0.7196
+          },
+          {
+            "id": "2061561",
+            "parcelId": "2253",
+            "sheetId": "SD6352",
+            "area": 6.458
+          },
+          {
+            "id": "2036519",
+            "parcelId": "8868",
+            "sheetId": "SD6251",
+            "area": 0.1889
+          },
+          {
+            "id": "2039491",
+            "parcelId": "2085",
+            "sheetId": "SD7244",
+            "area": 4.9215
+          },
+          {
+            "id": "2041277",
+            "parcelId": "5174",
+            "sheetId": "SD6252",
+            "area": 12.2583
+          },
+          {
+            "id": "6611827",
+            "parcelId": "1717",
+            "sheetId": "SD6151",
+            "area": 233.4926
+          },
+          {
+            "id": "6954670",
+            "parcelId": "6001",
+            "sheetId": "SD6351",
+            "area": 1.795
+          },
+          {
+            "id": "1982723",
+            "parcelId": "1073",
+            "sheetId": "SD6352",
+            "area": 13.7223
+          },
+          {
+            "id": "1927304",
+            "parcelId": "8731",
+            "sheetId": "SD6352",
+            "area": 14.1486
+          },
+          {
+            "id": "6457104",
+            "parcelId": "1766",
+            "sheetId": "SD6351",
+            "area": 2.1324
+          },
+          {
+            "id": "6102886",
+            "parcelId": "4091",
+            "sheetId": "SD6351",
+            "area": 0.4614
+          },
+          {
+            "id": "6611824",
+            "parcelId": "1739",
+            "sheetId": "SD6352",
+            "area": 2.7069
+          },
+          {
+            "id": "4636317",
+            "parcelId": "2638",
+            "sheetId": "SD6251",
+            "area": 0.8531
+          },
+          {
+            "id": "1866216",
+            "parcelId": "8047",
+            "sheetId": "SD6251",
+            "area": 1.5728
+          },
+          {
+            "id": "1990267",
+            "parcelId": "9638",
+            "sheetId": "SD6252",
+            "area": 1.3588
+          },
+          {
+            "id": "6102880",
+            "parcelId": "7605",
+            "sheetId": "SD6251",
+            "area": 0.7098
+          },
+          {
+            "id": "4636318",
+            "parcelId": "4625",
+            "sheetId": "SD6251",
+            "area": 1.014
+          },
+          {
+            "id": "2003234",
+            "parcelId": "3560",
+            "sheetId": "SD6352",
+            "area": 1.1954
+          },
+          {
+            "id": "2016423",
+            "parcelId": "8789",
+            "sheetId": "SD6251",
+            "area": 5.2698
+          },
+          {
+            "id": "6456148",
+            "parcelId": "7656",
+            "sheetId": "SD6352",
+            "area": 1.569
+          },
+          {
+            "id": "6456149",
+            "parcelId": "5781",
+            "sheetId": "SD6352",
+            "area": 1.1351
+          },
+          {
+            "id": "6456150",
+            "parcelId": "3193",
+            "sheetId": "SD6352",
+            "area": 1.0654
+          },
+          {
+            "id": "6456147",
+            "parcelId": "3108",
+            "sheetId": "SD6353",
+            "area": 0.2791
+          },
+          {
+            "id": "1916529",
+            "parcelId": "1921",
+            "sheetId": "SD6352",
+            "area": 29.6734
+          },
+          {
+            "id": "6742706",
+            "parcelId": "9840",
+            "sheetId": "SD6050",
+            "area": 0.8242
+          },
+          {
+            "id": "6611823",
+            "parcelId": "8726",
+            "sheetId": "SD6251",
+            "area": 8.308
+          },
+          {
+            "id": "6457108",
+            "parcelId": "1426",
+            "sheetId": "SD6351",
+            "area": 0.43
+          },
+          {
+            "id": "6611830",
+            "parcelId": "5078",
+            "sheetId": "SD6150",
+            "area": 2.892
+          },
+          {
+            "id": "4551399",
+            "parcelId": "1028",
+            "sheetId": "SD6351",
+            "area": 0.8992
+          },
+          {
+            "id": "6742704",
+            "parcelId": "8972",
+            "sheetId": "SD6150",
+            "area": 0.6489
+          },
+          {
+            "id": "4551398",
+            "parcelId": "0615",
+            "sheetId": "SD6351",
+            "area": 2.5984
+          },
+          {
+            "id": "4551395",
+            "parcelId": "9215",
+            "sheetId": "SD6251",
+            "area": 0.2104
+          },
+          {
+            "id": "6102881",
+            "parcelId": "9232",
+            "sheetId": "SD6251",
+            "area": 1.1608
+          },
+          {
+            "id": "7298154",
+            "parcelId": "5684",
+            "sheetId": "SD6049",
+            "area": 4.683
+          },
+          {
+            "id": "6101802",
+            "parcelId": "6060",
+            "sheetId": "SD5949",
+            "area": 681.6199
+          },
+          {
+            "id": "4976153",
+            "parcelId": "2440",
+            "sheetId": "SD6950",
+            "area": 0.1227
+          },
+          {
+            "id": "6102884",
+            "parcelId": "6608",
+            "sheetId": "SD6353",
+            "area": 59.5602
+          },
+          {
+            "id": "6457106",
+            "parcelId": "5181",
+            "sheetId": "SD6351",
+            "area": 10.6684
+          },
+          {
+            "id": "6719017",
+            "parcelId": "4693",
+            "sheetId": "SD6351",
+            "area": 3.6555
+          },
+          {
+            "id": "7347866",
+            "parcelId": "0050",
+            "sheetId": "SD6351",
+            "area": 0.1118
+          },
+          {
+            "id": "7347868",
+            "parcelId": "9456",
+            "sheetId": "SD6251",
+            "area": 0.146
+          },
+          {
+            "id": "7347869",
+            "parcelId": "9751",
+            "sheetId": "SD6251",
+            "area": 0.0359
+          },
+          {
+            "id": "7347870",
+            "parcelId": "9949",
+            "sheetId": "SD6251",
+            "area": 0.0261
+          },
+          {
+            "id": "7347867",
+            "parcelId": "0839",
+            "sheetId": "SD6351",
+            "area": 0.2343
+          },
+          {
+            "id": "7347865",
+            "parcelId": "0351",
+            "sheetId": "SD6351",
+            "area": 0.0813
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
+++ b/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
@@ -13,10 +13,6 @@ pages:
 
   - title: Do your digital maps show the correct land details?
     path: /land-details
-    next:
-      - path: /you-must-correct-your-details
-        condition: uFOrmB
-      - path: /agreement-name
     components:
       - name: hasCheckedLandIsUpToDate
         title: Do your digital maps show the correct land details?
@@ -27,7 +23,8 @@ pages:
 
   - title: You must correct your land details
     path: /you-must-correct-your-details
-    next: []
+    controller: TerminalPageController
+    condition: landIsUpToDateCondition
     components:
       - name: FGyiLS
         title: You must correct your land details
@@ -97,7 +94,7 @@ pages:
 lists: []
 sections: []
 conditions:
-  - name: uFOrmB
+  - name: landIsUpToDateCondition
     displayName: notCorrect
     value:
       name: notCorrect

--- a/src/server/common/services/consolidated-view.service.js
+++ b/src/server/common/services/consolidated-view.service.js
@@ -66,9 +66,9 @@ async function fetchMockParcelDataForBusiness(sbi) {
  * @throws {Error} - For other unexpected errors
  */
 export async function fetchParcelDataForBusiness(sbi) {
-  const mockEnabled = config.get('consolidatedView.mockEnabled')
+  const mockDALEnabled = config.get('consolidatedView.mockDALEnabled')
   try {
-    if (mockEnabled) {
+    if (mockDALEnabled) {
       return await fetchMockParcelDataForBusiness(sbi)
     }
 

--- a/src/server/common/services/consolidated-view.service.test.js
+++ b/src/server/common/services/consolidated-view.service.test.js
@@ -55,7 +55,7 @@ describe('fetchParcelDataForBusiness', () => {
     config.set('consolidatedView', {
       apiEndpoint: 'https://api.example.com/graphql',
       authEmail: 'test@example.com',
-      mockEnabled: false
+      mockDALEnabled: false
     })
   })
 
@@ -156,7 +156,7 @@ describe('fetchParcelDataForBusiness', () => {
       config.set('consolidatedView', {
         apiEndpoint: 'https://api.example.com/graphql',
         authEmail: 'test@example.com',
-        mockEnabled: true
+        mockDALEnabled: true
       })
     })
 


### PR DESCRIPTION
At the moment, our application queries a DAL url on a real environment which is defined on the CV_API_ENDPOINT environment variable.

This is to add the ability to bypass calling the consolidated DAL API endpoint and serve static data instead.

CV_API_MOCK_ENABLED=true
