### PR TITLE
RPS-676 - Flow changes: ability to add more actions to land

### DIFF
--- a/src/server/land-grants/actions/land-actions-check-page.controller.js
+++ b/src/server/land-grants/actions/land-actions-check-page.controller.js
@@ -16,7 +16,23 @@ export default class LandActionsCheckPageController extends QuestionPageControll
      * @returns {Promise<import('@hapi/boom').Boom<any> | import('@hapi/hapi').ResponseObject>}
      */
     const fn = (request, context, h) => {
-      return this.proceed(request, h, this.getNextPath(context))
+      const { state } = context
+      const payload = request.payload ?? {}
+      const { addMoreActions } = payload
+
+      if (!addMoreActions) {
+        return h.view(this.viewName, {
+          ...this.getViewModel(request, context),
+          ...state,
+          errors: ['Please select an option']
+        })
+      }
+
+      const nextPath =
+        addMoreActions === 'true'
+          ? '/select-land-parcel'
+          : this.getNextPath(context)
+      return this.proceed(request, h, nextPath)
     }
 
     return fn

--- a/src/server/land-grants/actions/land-actions-check-page.controller.test.js
+++ b/src/server/land-grants/actions/land-actions-check-page.controller.test.js
@@ -41,7 +41,8 @@ describe('LandActionsCheckPageController', () => {
     }
 
     mockH = {
-      view: jest.fn().mockReturnValue('rendered view')
+      view: jest.fn().mockReturnValue('rendered view'),
+      redirect: jest.fn().mockReturnValue('redirected')
     }
   })
 
@@ -63,7 +64,65 @@ describe('LandActionsCheckPageController', () => {
   })
 
   describe('POST route handler', () => {
-    test('should proceed to next page', async () => {
+    test('should show error when addMoreActions is not provided', async () => {
+      mockRequest.payload = {}
+
+      const handler = controller.makePostRouteHandler()
+      const result = await handler(mockRequest, mockContext, mockH)
+
+      expect(mockH.view).toHaveBeenCalledWith('land-actions-check', {
+        pageTitle: 'Check selected land actions',
+        landParcel: 'sheet1-parcel1',
+        errors: ['Please select an option']
+      })
+      expect(result).toBe('rendered view')
+    })
+
+    test('should show error when addMoreActions is null', async () => {
+      mockRequest.payload = { addMoreActions: null }
+
+      const handler = controller.makePostRouteHandler()
+      const result = await handler(mockRequest, mockContext, mockH)
+
+      expect(mockH.view).toHaveBeenCalledWith('land-actions-check', {
+        pageTitle: 'Check selected land actions',
+        landParcel: 'sheet1-parcel1',
+        errors: ['Please select an option']
+      })
+      expect(result).toBe('rendered view')
+    })
+
+    test('should show error when addMoreActions is undefined', async () => {
+      mockRequest.payload = { addMoreActions: undefined }
+
+      const handler = controller.makePostRouteHandler()
+      const result = await handler(mockRequest, mockContext, mockH)
+
+      expect(mockH.view).toHaveBeenCalledWith('land-actions-check', {
+        pageTitle: 'Check selected land actions',
+        landParcel: 'sheet1-parcel1',
+        errors: ['Please select an option']
+      })
+      expect(result).toBe('rendered view')
+    })
+
+    test('should redirect to select-land-parcel when addMoreActions is "true"', async () => {
+      mockRequest.payload = { addMoreActions: 'true' }
+
+      const handler = controller.makePostRouteHandler()
+      const result = await handler(mockRequest, mockContext, mockH)
+
+      expect(controller.proceed).toHaveBeenCalledWith(
+        mockRequest,
+        mockH,
+        '/select-land-parcel'
+      )
+      expect(result).toBe('redirected')
+    })
+
+    test('should proceed to next path when addMoreActions is "false"', async () => {
+      mockRequest.payload = { addMoreActions: 'false' }
+
       const handler = controller.makePostRouteHandler()
       const result = await handler(mockRequest, mockContext, mockH)
 
@@ -72,8 +131,35 @@ describe('LandActionsCheckPageController', () => {
         mockH,
         '/next-path'
       )
-
       expect(result).toBe('redirected')
+    })
+
+    test('should proceed to next path when addMoreActions is "no"', async () => {
+      mockRequest.payload = { addMoreActions: 'no' }
+
+      const handler = controller.makePostRouteHandler()
+      const result = await handler(mockRequest, mockContext, mockH)
+
+      expect(controller.proceed).toHaveBeenCalledWith(
+        mockRequest,
+        mockH,
+        '/next-path'
+      )
+      expect(result).toBe('redirected')
+    })
+
+    test('should handle empty payload gracefully', async () => {
+      mockRequest.payload = null
+
+      const handler = controller.makePostRouteHandler()
+      const result = await handler(mockRequest, mockContext, mockH)
+
+      expect(mockH.view).toHaveBeenCalledWith('land-actions-check', {
+        pageTitle: 'Check selected land actions',
+        landParcel: 'sheet1-parcel1',
+        errors: ['Please select an option']
+      })
+      expect(result).toBe('rendered view')
     })
   })
 })

--- a/src/server/land-grants/actions/land-actions-check.html
+++ b/src/server/land-grants/actions/land-actions-check.html
@@ -60,6 +60,7 @@
     <div class="govuk-grid-column-two-thirds">
       <form method="post" novalidate>
         {{ govukRadios({
+					classes: "govuk-radios--inline",
           name: "addMoreActions",
           fieldset: {
             legend: {

--- a/src/server/land-grants/actions/land-actions-check.html
+++ b/src/server/land-grants/actions/land-actions-check.html
@@ -5,6 +5,7 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block content %}
 <div class="govuk-body">
@@ -37,6 +38,25 @@
       <form method="post" novalidate>
         <h1 class="govuk-heading-l">Check selected land actions for your farm</h1>
 
+        {{ govukRadios({
+          name: "addMoreActions",
+          fieldset: {
+            legend: {
+              text: "Do you want to add more actions to your land?",
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "true",
+              text: "Yes"
+            },
+            {
+              value: "false",
+              text: "No"
+            }
+          ]
+        }) }}
 
         <div class="govuk-button-group">
           <input type="hidden" name="crumb" value="{{ crumb }}">

--- a/src/server/land-grants/actions/land-actions-check.html
+++ b/src/server/land-grants/actions/land-actions-check.html
@@ -64,7 +64,7 @@
           fieldset: {
             legend: {
               text: "Do you want to add more actions to your land?",
-              classes: "govuk-fieldset__legend--l"
+              classes: "govuk-fieldset__legend--m"
             }
           },
           items: [


### PR DESCRIPTION
This PR presents a YES/NO question on the actions check page to offer the ability to add more land actions to a different land parcel:

![image](https://github.com/user-attachments/assets/0a03826c-8486-4894-9485-94e691d71af9)

