### PR TITLE
Fix error handling on actions check page

### DIFF
--- a/src/server/land-grants/actions/land-actions-check-page.controller.js
+++ b/src/server/land-grants/actions/land-actions-check-page.controller.js
@@ -26,7 +26,7 @@ export default class LandActionsCheckPageController extends QuestionPageControll
           ...this.getViewModel(request, context),
           ...state,
           selectedActionRows: this.selectedActionRows,
-          errors: ['Please select an option']
+          errorMessage: 'Please select if you want to add more actions'
         })
       }
 

--- a/src/server/land-grants/actions/land-actions-check-page.controller.test.js
+++ b/src/server/land-grants/actions/land-actions-check-page.controller.test.js
@@ -111,7 +111,7 @@ describe('LandActionsCheckPageController', () => {
           }
         },
         selectedActionRows: [],
-        errors: ['Please select an option']
+        errorMessage: 'Please select if you want to add more actions'
       })
       expect(result).toBe('rendered view')
     })
@@ -133,7 +133,7 @@ describe('LandActionsCheckPageController', () => {
           }
         },
         selectedActionRows: [],
-        errors: ['Please select an option']
+        errorMessage: 'Please select if you want to add more actions'
       })
       expect(result).toBe('rendered view')
     })
@@ -155,7 +155,7 @@ describe('LandActionsCheckPageController', () => {
           }
         },
         selectedActionRows: [],
-        errors: ['Please select an option']
+        errorMessage: 'Please select if you want to add more actions'
       })
       expect(result).toBe('rendered view')
     })
@@ -219,7 +219,7 @@ describe('LandActionsCheckPageController', () => {
           }
         },
         selectedActionRows: [],
-        errors: ['Please select an option']
+        errorMessage: 'Please select if you want to add more actions'
       })
       expect(result).toBe('rendered view')
     })

--- a/src/server/land-grants/actions/land-actions-check.html
+++ b/src/server/land-grants/actions/land-actions-check.html
@@ -22,16 +22,15 @@
           text: info
         }) }}
       {% endif %}
-      {% if errors.length > 0 %}
-        {% set errorList = [] %}
-        {% for error in errors %}
-            {% set errorList = errorList.concat([{
-              text: error
-            }]) %}
-        {% endfor %}
+      {% if errorMessage %}
         {{ govukErrorSummary({
           titleText: "There is a problem",
-          errorList: errorList
+          errorList: [
+            {
+              text: errorMessage,
+              href: '#addMoreActions'
+            } 
+          ] 
         }) }}
       {% endif %}
 
@@ -59,26 +58,27 @@
     </div>
     <div class="govuk-grid-column-two-thirds">
       <form method="post" novalidate>
-        {{ govukRadios({
-					classes: "govuk-radios--inline",
-          name: "addMoreActions",
-          fieldset: {
-            legend: {
-              text: "Do you want to add more actions to your land?",
-              classes: "govuk-fieldset__legend--m"
-            }
-          },
-          items: [
-            {
-              value: "true",
-              text: "Yes"
-            },
-            {
-              value: "false",
-              text: "No"
-            }
-          ]
-        }) }}
+         {{ govukRadios({
+  classes: "govuk-radios--inline",
+  name: "addMoreActions",
+  fieldset: {
+    legend: {
+      text: "Do you want to add more actions to your land?",
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  items: [
+    {
+      value: "true",
+      text: "Yes"
+    },
+    {
+      value: "false",
+      text: "No"
+    }
+  ],
+  errorMessage: errorMessage and { text: errorMessage }
+}) }}
         <div class="govuk-button-group">
           <input type="hidden" name="crumb" value="{{ crumb }}">
           {% block form %}


### PR DESCRIPTION
This PR fixes the error handling behaviour on the actions check page. When user didn't submit any response to the form, we were triggering an error but the error wasn't linking to the form field and the form field wasn't being highlighted. This is what will happen now:

![image](https://github.com/user-attachments/assets/ddb0de6d-ad8a-4da3-989f-77e947d3ffe7)
