### PR TITLE
Mock DAL data is not showing data

### DIFF
--- a/src/server/common/services/consolidated-view/consolidated-view.service.js
+++ b/src/server/common/services/consolidated-view/consolidated-view.service.js
@@ -71,9 +71,13 @@ async function fetchMockParcelDataForBusiness(sbi) {
  */
 export async function fetchParcelsForSbi(sbi) {
   const mockDALEnabled = config.get('consolidatedView.mockDALEnabled')
+  const formatResponse = (response) =>
+    response.data?.business?.land?.parcels || []
+
   try {
     if (mockDALEnabled) {
-      return await fetchMockParcelDataForBusiness(sbi)
+      const response = await fetchMockParcelDataForBusiness(sbi)
+      return formatResponse(response)
     }
 
     const now = new Date().toISOString()
@@ -116,7 +120,7 @@ export async function fetchParcelsForSbi(sbi) {
     }
 
     const responseJson = await response.json()
-    return responseJson.data?.business?.land?.parcels || []
+    return formatResponse(responseJson)
   } catch (error) {
     logger.error(
       { err: error },

--- a/src/server/common/services/consolidated-view/consolidated-view.service.test.js
+++ b/src/server/common/services/consolidated-view/consolidated-view.service.test.js
@@ -174,7 +174,7 @@ describe('fetchParcelsForSbi', () => {
 
       const result = await fetchParcelsForSbi(mockSbi)
 
-      expect(result).toEqual(mockFileData)
+      expect(result).toEqual(mockFileData.data.business.land.parcels)
       expect(fs.readFile).toHaveBeenCalledTimes(1)
       expect(fs.readFile).toHaveBeenCalledWith(getMockFilePath(mockSbi), 'utf8')
       expect(mockFetch).not.toHaveBeenCalled()


### PR DESCRIPTION
After adding the latest changes to fetch land data from a different endpoint and the SBI toolbar, mock DAL data has stopped showing data due to response format changes on the service we own on the frontend. This PR fixes that problem.