### PR TITLE
RPS-696 - Land Grants actions page: display land parcel information card

### DIFF
--- a/src/server/land-grants/controllers/land-actions-page.controller.js
+++ b/src/server/land-grants/controllers/land-actions-page.controller.js
@@ -68,6 +68,40 @@ export default class LandActionsPageController extends QuestionPageController {
     }
   }
 
+  getSelectedLandParcelData(context) {
+    const { state } = context
+
+    return {
+      name: state.landParcel,
+      rows: [
+        {
+          key: {
+            text: 'Total size'
+          },
+          value: {
+            text: 'Not available'
+          }
+        },
+        {
+          key: {
+            text: 'Land Cover'
+          },
+          value: {
+            text: 'Not available'
+          }
+        },
+        {
+          key: {
+            text: 'Intersections'
+          },
+          value: {
+            text: 'Not available'
+          }
+        }
+      ]
+    }
+  }
+
   /**
    * This method is called when there is a POST request to the select land actions page.
    * It gets the land parcel id and redirects to the next step in the journey.
@@ -91,6 +125,7 @@ export default class LandActionsPageController extends QuestionPageController {
       const newState = {
         ...state,
         actions: this.transformActionsForView(actionsObj),
+        selectedLandParcel: this.getSelectedLandParcelData(context),
         actionsObj
       }
 
@@ -177,6 +212,7 @@ export default class LandActionsPageController extends QuestionPageController {
       const viewModel = {
         ...this.getViewModel(request, context),
         ...state,
+        selectedLandParcel: this.getSelectedLandParcelData(context),
         errors: collection.getErrors(collection.getErrors())
       }
 

--- a/src/server/land-grants/controllers/land-actions-page.controller.js
+++ b/src/server/land-grants/controllers/land-actions-page.controller.js
@@ -6,6 +6,8 @@ import {
   validateLandActions
 } from '~/src/server/land-grants/services/land-grants.service.js'
 
+const NOT_AVAILABLE = 'Not available'
+
 export default class LandActionsPageController extends QuestionPageController {
   viewName = 'choose-which-actions-to-do'
   quantityPrefix = 'qty-'
@@ -79,7 +81,7 @@ export default class LandActionsPageController extends QuestionPageController {
             text: 'Total size'
           },
           value: {
-            text: 'Not available'
+            text: NOT_AVAILABLE
           }
         },
         {
@@ -87,7 +89,7 @@ export default class LandActionsPageController extends QuestionPageController {
             text: 'Land Cover'
           },
           value: {
-            text: 'Not available'
+            text: NOT_AVAILABLE
           }
         },
         {
@@ -95,7 +97,7 @@ export default class LandActionsPageController extends QuestionPageController {
             text: 'Intersections'
           },
           value: {
-            text: 'Not available'
+            text: NOT_AVAILABLE
           }
         }
       ]

--- a/src/server/land-grants/controllers/land-actions-page.controller.test.js
+++ b/src/server/land-grants/controllers/land-actions-page.controller.test.js
@@ -16,6 +16,36 @@ describe('LandActionsPageController', () => {
   let mockContext
   let mockH
 
+  const selectedLandParcel = {
+    name: 'sheet1-parcel1',
+    rows: [
+      {
+        key: {
+          text: 'Total size'
+        },
+        value: {
+          text: 'Not available'
+        }
+      },
+      {
+        key: {
+          text: 'Land Cover'
+        },
+        value: {
+          text: 'Not available'
+        }
+      },
+      {
+        key: {
+          text: 'Intersections'
+        },
+        value: {
+          text: 'Not available'
+        }
+      }
+    ]
+  }
+
   const availableActions = [
     {
       code: 'CMOR1',
@@ -335,6 +365,7 @@ describe('LandActionsPageController', () => {
         expect.objectContaining({
           landParcel: 'sheet1-parcel1',
           availableActions,
+          selectedLandParcel,
           actions: ['CMOR1', 'UPL1']
         })
       )
@@ -460,6 +491,7 @@ describe('LandActionsPageController', () => {
           landParcel: 'sheet1-parcel1',
           actions: 'CMOR1: 10 ha.',
           actionsObj,
+          selectedLandParcel,
           applicationValue: '£1,250.75'
         })
       )

--- a/src/server/land-grants/views/choose-which-actions-to-do.html
+++ b/src/server/land-grants/views/choose-which-actions-to-do.html
@@ -7,6 +7,7 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% block content %}
 <div class="govuk-body">
@@ -26,10 +27,26 @@
         }) }}
       {% endif %}
 
-      <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">Land parcel: {{landParcel}}</span>
-        Choose which actions to do
-      </h1>
+      <h1 class="govuk-heading-l">Choose which actions to do</h1>
+
+      {{ govukSummaryList({
+          card: {
+            title: {
+              text: "Chosen parcel: " + selectedLandParcel.name
+            },
+            actions: {
+              items: [
+                {
+                  href: "/find-funding-for-land-or-farms/select-land-parcel",
+                  text: "Change",
+                  visuallyHiddenText: "land parcel to do actions on"
+                }
+              ]
+            }
+          },
+          rows: selectedLandParcel.rows
+        }) 
+      }}
       <div class="govuk-hint">
 
       </div>


### PR DESCRIPTION
Display land parcel information on actions page:

![image](https://github.com/user-attachments/assets/c3a2fa42-87be-46ea-a246-c95ed0a56888)

Information data is still not available, as it requires an API change.