### PR TITLE
Future RPS - Send multiple parcels to GAS and remove unneeded DXT variables from form definition

### DIFF
--- a/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
+++ b/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
@@ -56,33 +56,10 @@ pages:
   - title: Select Land Parcel
     controller: LandParcelPageController
     path: /select-land-parcel
-    next:
-      - path: /choose-which-actions-to-do
-    components:
-      - type: TextField
-        name: landParcel
-        title: Parcel
-        options:
-          required: true
-        schema: {}
 
   - title: Choose which actions to do
     controller: LandActionsPageController
     path: /choose-which-actions-to-do
-    next:
-      - path: /check-selected-land-actions
-    components:
-      - type: TextField
-        name: actions
-        title: Actions
-        options:
-          required: true
-        schema: {}
-      - type: TextField
-        name: applicationValue
-        title: Total application value
-        options: {}
-        schema: {}
 
   - title: Check selected land actions
     path: /check-selected-land-actions

--- a/src/server/land-grants/controllers/land-actions-page.controller.test.js
+++ b/src/server/land-grants/controllers/land-actions-page.controller.test.js
@@ -16,7 +16,7 @@ describe('LandActionsPageController', () => {
   let mockContext
   let mockH
 
-  const selectedLandParcel = {
+  const selectedLandParcelObj = {
     name: 'sheet1-parcel1',
     rows: [
       {
@@ -90,7 +90,7 @@ describe('LandActionsPageController', () => {
     mockRequest = {
       payload: {
         'qty-CMOR1': 10,
-        actions: ['CMOR1', 'UPL1']
+        selectedActions: ['CMOR1', 'UPL1']
       },
       logger: {
         error: jest.fn()
@@ -99,7 +99,7 @@ describe('LandActionsPageController', () => {
 
     mockContext = {
       state: {
-        landParcel: 'sheet1-parcel1'
+        selectedLandParcel: 'sheet1-parcel1'
       }
     }
 
@@ -130,7 +130,7 @@ describe('LandActionsPageController', () => {
   describe('extractActionsObjectFromPayload', () => {
     test('should extract action data correctly from payload', () => {
       const payload = {
-        actions: ['CMOR1', 'UPL1'],
+        selectedActions: ['CMOR1', 'UPL1'],
         'qty-CMOR1': 10,
         'qty-UPL1': 5,
         'other-field': 'value'
@@ -154,7 +154,7 @@ describe('LandActionsPageController', () => {
 
     test('should ignore action codes not present in availableActions', () => {
       const payload = {
-        actions: ['unknownAction'],
+        selectedActions: ['unknownAction'],
         'qty-unknownAction': 15
       }
 
@@ -171,7 +171,7 @@ describe('LandActionsPageController', () => {
 
     test('should skip actions not included in actions array', () => {
       const payload = {
-        actions: ['CMOR1'],
+        selectedActions: ['CMOR1'],
         'qty-CMOR1': 10,
         'qty-UPL1': 5
       }
@@ -189,7 +189,7 @@ describe('LandActionsPageController', () => {
 
     test('should skip actions with empty quantity values', () => {
       const payload = {
-        actions: ['CMOR1', 'UPL1'],
+        selectedActions: ['CMOR1', 'UPL1'],
         'qty-CMOR1': 10,
         'qty-UPL1': ''
       }
@@ -215,7 +215,7 @@ describe('LandActionsPageController', () => {
       ]
 
       const payload = {
-        actions: ['CMOR1'],
+        selectedActions: ['CMOR1'],
         'qty-CMOR1': 10
       }
 
@@ -228,80 +228,6 @@ describe('LandActionsPageController', () => {
           unit: undefined
         }
       })
-    })
-  })
-
-  describe('transformActionsForView', () => {
-    test('should transform single action object to formatted string', () => {
-      const actionsObj = {
-        CMOR1: {
-          description: 'CMOR1: Assess moorland and produce a written record',
-          value: 10,
-          unit: 'ha'
-        }
-      }
-
-      const result = controller.transformActionsForView(actionsObj)
-
-      expect(result).toBe('CMOR1: 10 ha')
-    })
-
-    test('should transform multiple actions to formatted string', () => {
-      const actionsObj = {
-        CMOR1: {
-          description: 'CMOR1: Assess moorland and produce a written record',
-          value: 10,
-          unit: 'ha'
-        },
-        UPL1: {
-          description: 'UPL1: Moderate livestock grazing on moorland',
-          value: 5,
-          unit: 'ha'
-        }
-      }
-
-      const result = controller.transformActionsForView(actionsObj)
-
-      expect(result).toBe('CMOR1: 10 ha - UPL1: 5 ha')
-    })
-
-    test('should handle empty actions object', () => {
-      const result = controller.transformActionsForView({})
-
-      expect(result).toBe('')
-    })
-
-    test('should handle actions with different units', () => {
-      const actionsObj = {
-        CMOR1: {
-          description: 'CMOR1: Assess moorland and produce a written record',
-          value: 10,
-          unit: 'ha'
-        },
-        UPL1: {
-          description: 'UPL1: Moderate livestock grazing on moorland',
-          value: 3,
-          unit: 'km'
-        }
-      }
-
-      const result = controller.transformActionsForView(actionsObj)
-
-      expect(result).toBe('CMOR1: 10 ha - UPL1: 3 km')
-    })
-
-    test('should handle actions with zero values', () => {
-      const actionsObj = {
-        CMOR1: {
-          description: 'CMOR1: Assess moorland and produce a written record',
-          value: 0,
-          unit: 'ha'
-        }
-      }
-
-      const result = controller.transformActionsForView(actionsObj)
-
-      expect(result).toBe('CMOR1: 0 ha')
     })
   })
 
@@ -351,7 +277,7 @@ describe('LandActionsPageController', () => {
         actions: availableActions
       })
 
-      mockContext.state.actions = ['CMOR1', 'UPL1']
+      mockContext.state.selectedActions = ['CMOR1', 'UPL1']
 
       const handler = controller.makeGetRouteHandler()
       const result = await handler(mockRequest, mockContext, mockH)
@@ -363,10 +289,9 @@ describe('LandActionsPageController', () => {
       expect(mockH.view).toHaveBeenCalledWith(
         'choose-which-actions-to-do',
         expect.objectContaining({
-          landParcel: 'sheet1-parcel1',
+          selectedLandParcel: 'sheet1-parcel1',
           availableActions,
-          selectedLandParcel,
-          actions: ['CMOR1', 'UPL1']
+          selectedLandParcelObj
         })
       )
       expect(result).toBe('rendered view')
@@ -441,7 +366,7 @@ describe('LandActionsPageController', () => {
         'choose-which-actions-to-do',
         expect.objectContaining({
           availableActions: [],
-          landParcel: 'sheet1-parcel1'
+          selectedLandParcel: 'sheet1-parcel1'
         })
       )
       expect(result).toBe('rendered view')
@@ -488,13 +413,11 @@ describe('LandActionsPageController', () => {
       expect(controller.setState).toHaveBeenCalledWith(
         mockRequest,
         expect.objectContaining({
-          landParcel: 'sheet1-parcel1',
-          actions: 'CMOR1: 10 ha',
+          selectedLandParcel: 'sheet1-parcel1',
           applicationValue: '£1,250.75',
-          selectedLandParcel,
+          selectedLandParcelObj,
           landParcels: {
             'sheet1-parcel1': {
-              actions: 'CMOR1: 10 ha',
               actionsObj: {
                 CMOR1: {
                   description:
@@ -526,11 +449,9 @@ describe('LandActionsPageController', () => {
       expect(controller.setState).toHaveBeenCalledWith(
         mockRequest,
         expect.objectContaining({
-          landParcel: 'sheet1-parcel1',
-          actions: '',
+          selectedLandParcel: 'sheet1-parcel1',
           landParcels: {
             'sheet1-parcel1': {
-              actions: '',
               actionsObj: {}
             }
           }
@@ -540,7 +461,7 @@ describe('LandActionsPageController', () => {
 
     test('should handle missing actions gracefully', async () => {
       mockRequest.payload = {
-        actions: [],
+        selectedActions: [],
         action: 'validate'
       }
 
@@ -560,7 +481,7 @@ describe('LandActionsPageController', () => {
     test('should validate actions when validate action is requested', async () => {
       mockRequest.payload = {
         'qty-CMOR1': 10,
-        actions: ['CMOR1'],
+        selectedActions: ['CMOR1'],
         action: 'validate'
       }
 
@@ -591,7 +512,7 @@ describe('LandActionsPageController', () => {
     test('should render view with validation errors when validation fails', async () => {
       mockRequest.payload = {
         'qty-CMOR1': 10,
-        actions: ['CMOR1'],
+        selectedActions: ['CMOR1'],
         action: 'validate'
       }
 
@@ -625,11 +546,9 @@ describe('LandActionsPageController', () => {
       expect(controller.setState).toHaveBeenCalledWith(
         mockRequest,
         expect.objectContaining({
-          landParcel: 'sheet1-parcel1',
-          actions: 'CMOR1: 10 ha',
+          selectedLandParcel: 'sheet1-parcel1',
           landParcels: {
             'sheet1-parcel1': {
-              actions: 'CMOR1: 10 ha',
               actionsObj: {
                 CMOR1: {
                   description:

--- a/src/server/land-grants/controllers/land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/land-parcel-page.controller.js
@@ -29,9 +29,9 @@ export default class LandParcelPageController extends QuestionPageController {
     const fn = async (request, context, h) => {
       const { state } = context
       const payload = request.payload ?? {}
-      const { landParcel, action } = payload
+      const { selectedLandParcel, action } = payload
 
-      if (action === 'validate' && !landParcel) {
+      if (action === 'validate' && !selectedLandParcel) {
         return h.view(this.viewName, {
           ...super.getViewModel(request, context),
           ...state,
@@ -42,7 +42,7 @@ export default class LandParcelPageController extends QuestionPageController {
 
       await this.setState(request, {
         ...state,
-        landParcel
+        selectedLandParcel
       })
       return this.proceed(request, h, this.getNextPath(context))
     }
@@ -63,7 +63,7 @@ export default class LandParcelPageController extends QuestionPageController {
      * @param {Pick} h
      */
     const fn = async (request, context, h) => {
-      const { landParcel = '' } = context.state || {}
+      const { selectedLandParcel = '' } = context.state || {}
       const sbi = sbiStore.get('sbi')
 
       const { viewName } = this
@@ -76,7 +76,7 @@ export default class LandParcelPageController extends QuestionPageController {
         const viewModel = {
           ...baseViewModel,
           parcels: this.parcels,
-          landParcel
+          selectedLandParcel
         }
 
         return h.view(viewName, viewModel)

--- a/src/server/land-grants/controllers/land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/land-parcel-page.controller.test.js
@@ -140,7 +140,7 @@ describe('LandParcelPageController', () => {
     })
 
     it('populates full viewModel correctly', async () => {
-      mockContext.state.landParcel = state.selectedLandParcel
+      mockContext.state = state
 
       const result = await controller.makeGetRouteHandler()(
         mockRequest,
@@ -162,7 +162,7 @@ describe('LandParcelPageController', () => {
 
   describe('POST route handler', () => {
     it('saves landParcel and proceeds', async () => {
-      mockRequest.payload = state.selectedLandParcel
+      mockRequest.payload = { selectedLandParcel: state.selectedLandParcel }
       mockContext = setupContext({ existing: 'value' })
 
       const result = await controller.makePostRouteHandler()(

--- a/src/server/land-grants/controllers/land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/land-parcel-page.controller.test.js
@@ -41,7 +41,7 @@ describe('LandParcelPageController', () => {
   let mockH
 
   const renderedViewMock = 'mock-rendered-view'
-  const landParcel = { landParcel: 'sheet123' }
+  const state = { selectedLandParcel: 'sheet123' }
 
   const setupRequest = () => ({
     query: {},
@@ -95,7 +95,7 @@ describe('LandParcelPageController', () => {
         expect.objectContaining({
           pageTitle: 'Select Land Parcel',
           parcels: controllerParcelsResponse,
-          landParcel: ''
+          selectedLandParcel: ''
         })
       )
       expect(result).toBe(renderedViewMock)
@@ -132,7 +132,7 @@ describe('LandParcelPageController', () => {
       expect(mockH.view).toHaveBeenCalledWith(
         'select-land-parcel',
         expect.objectContaining({
-          landParcel: '',
+          selectedLandParcel: '',
           parcels: controllerParcelsResponse
         })
       )
@@ -140,7 +140,7 @@ describe('LandParcelPageController', () => {
     })
 
     it('populates full viewModel correctly', async () => {
-      mockContext.state.landParcel = landParcel.landParcel
+      mockContext.state.landParcel = state.selectedLandParcel
 
       const result = await controller.makeGetRouteHandler()(
         mockRequest,
@@ -151,7 +151,7 @@ describe('LandParcelPageController', () => {
       expect(mockH.view).toHaveBeenCalledWith(
         'select-land-parcel',
         expect.objectContaining({
-          landParcel: 'sheet123',
+          selectedLandParcel: 'sheet123',
           parcels: controllerParcelsResponse,
           pageTitle: 'Select Land Parcel'
         })
@@ -162,7 +162,7 @@ describe('LandParcelPageController', () => {
 
   describe('POST route handler', () => {
     it('saves landParcel and proceeds', async () => {
-      mockRequest.payload = landParcel
+      mockRequest.payload = state.selectedLandParcel
       mockContext = setupContext({ existing: 'value' })
 
       const result = await controller.makePostRouteHandler()(
@@ -173,7 +173,7 @@ describe('LandParcelPageController', () => {
 
       expect(controller.setState).toHaveBeenCalledWith(mockRequest, {
         existing: 'value',
-        landParcel: landParcel.landParcel
+        selectedLandParcel: state.selectedLandParcel
       })
       expect(controller.proceed).toHaveBeenCalledWith(
         mockRequest,
@@ -217,7 +217,7 @@ describe('LandParcelPageController', () => {
 
       expect(controller.setState).toHaveBeenCalledWith(mockRequest, {
         foo: 'bar',
-        landParcel: undefined
+        selectedLandParcel: undefined
       })
       expect(controller.proceed).toHaveBeenCalled()
       expect(result).toBe('next')
@@ -234,7 +234,7 @@ describe('LandParcelPageController', () => {
       )
 
       expect(controller.setState).toHaveBeenCalledWith(mockRequest, {
-        landParcel: undefined
+        selectedLandParcel: undefined
       })
       expect(controller.proceed).toHaveBeenCalled()
       expect(result).toBe('next')

--- a/src/server/land-grants/mappers/state-to-gas-answers-mapper.js
+++ b/src/server/land-grants/mappers/state-to-gas-answers-mapper.js
@@ -21,6 +21,69 @@
  */
 
 /**
+ * Creates an appliedFor object from action data
+ * @param {object} actionData - The action data object
+ * @returns {object} The appliedFor object
+ */
+function createAppliedForObject(actionData) {
+  const appliedFor = {}
+
+  if (actionData.unit != null) {
+    appliedFor.unit = actionData.unit.trim()
+  }
+
+  if (actionData.value != null) {
+    const quantity = parseFloat(actionData.value)
+    appliedFor.quantity = !isNaN(quantity) ? quantity : undefined
+  }
+
+  return appliedFor
+}
+
+/**
+ * Processes a single action and creates an action application
+ * @param {string} actionCode - The action code
+ * @param {object} actionData - The action data
+ * @param {string} sheetId - The sheet ID
+ * @param {string} parcelId - The parcel ID
+ * @returns {object} The action application object
+ */
+function createActionApplication(actionCode, actionData, sheetId, parcelId) {
+  const actionApplication = {
+    code: actionCode,
+    sheetId,
+    parcelId
+  }
+
+  if (actionData && typeof actionData === 'object') {
+    const appliedFor = createAppliedForObject(actionData)
+
+    if (Object.keys(appliedFor).length > 0) {
+      actionApplication.appliedFor = appliedFor
+    }
+  }
+
+  return actionApplication
+}
+
+/**
+ * Processes actions for a single parcel
+ * @param {object} actionsObj - The actions object
+ * @param {string} sheetId - The sheet ID
+ * @param {string} parcelId - The parcel ID
+ * @returns {object[]} Array of action applications
+ */
+function processParcelActions(actionsObj, sheetId, parcelId) {
+  if (!actionsObj || Object.keys(actionsObj).length === 0) {
+    return []
+  }
+
+  return Object.entries(actionsObj).map(([actionCode, actionData]) =>
+    createActionApplication(actionCode, actionData, sheetId, parcelId)
+  )
+}
+
+/**
  * Transforms FormContext object into a GAS Application answers object for Land Grants.
  * @param {object} state
  * @returns {GASAnswers}
@@ -35,41 +98,21 @@ export function stateToLandGrantsGasAnswers(state) {
     actionApplications: []
   }
 
-  if (landParcels && Object.keys(landParcels).length > 0) {
-    for (const [parcelKey, data] of Object.entries(landParcels)) {
-      const { actionsObj } = data
-      const [sheetId, parcelId] = parcelKey.split('-') ?? []
-
-      if (!actionsObj || Object.keys(actionsObj).length === 0) {
-        continue
-      }
-
-      Object.entries(actionsObj).forEach(([actionCode, actionData]) => {
-        const actionApplication = {
-          code: actionCode,
-          sheetId,
-          parcelId
-        }
-
-        if (actionData && typeof actionData === 'object') {
-          const appliedFor = {}
-
-          if (actionData.unit != null) {
-            appliedFor.unit = actionData.unit.trim()
-          }
-
-          if (actionData.value != null) {
-            const quantity = parseFloat(actionData.value)
-            appliedFor.quantity = !isNaN(quantity) ? quantity : undefined
-          }
-          if (Object.keys(appliedFor).length > 0) {
-            actionApplication.appliedFor = appliedFor
-          }
-        }
-
-        result.actionApplications.push(actionApplication)
-      })
-    }
+  if (!landParcels || Object.keys(landParcels).length === 0) {
+    return result
   }
+
+  for (const [parcelKey, data] of Object.entries(landParcels)) {
+    const { actionsObj } = data
+    const [sheetId, parcelId] = parcelKey.split('-') ?? []
+
+    const actionApplications = processParcelActions(
+      actionsObj,
+      sheetId,
+      parcelId
+    )
+    result.actionApplications.push(...actionApplications)
+  }
+
   return result
 }

--- a/src/server/land-grants/mappers/state-to-gas-answers-mapper.js
+++ b/src/server/land-grants/mappers/state-to-gas-answers-mapper.js
@@ -40,33 +40,35 @@ export function stateToLandGrantsGasAnswers(state) {
       const { actionsObj } = data
       const [sheetId, parcelId] = parcelKey.split('-') ?? []
 
-      if (actionsObj && Object.keys(actionsObj).length > 0) {
-        Object.entries(actionsObj).forEach(([actionCode, actionData]) => {
-          const actionApplication = {
-            code: actionCode,
-            sheetId,
-            parcelId
-          }
-
-          if (actionData && typeof actionData === 'object') {
-            const appliedFor = {}
-
-            if (actionData.unit != null) {
-              appliedFor.unit = actionData.unit.trim()
-            }
-
-            if (actionData.value != null) {
-              const quantity = parseFloat(actionData.value)
-              appliedFor.quantity = !isNaN(quantity) ? quantity : undefined
-            }
-            if (Object.keys(appliedFor).length > 0) {
-              actionApplication.appliedFor = appliedFor
-            }
-          }
-
-          result.actionApplications.push(actionApplication)
-        })
+      if (!actionsObj || Object.keys(actionsObj).length === 0) {
+        continue
       }
+
+      Object.entries(actionsObj).forEach(([actionCode, actionData]) => {
+        const actionApplication = {
+          code: actionCode,
+          sheetId,
+          parcelId
+        }
+
+        if (actionData && typeof actionData === 'object') {
+          const appliedFor = {}
+
+          if (actionData.unit != null) {
+            appliedFor.unit = actionData.unit.trim()
+          }
+
+          if (actionData.value != null) {
+            const quantity = parseFloat(actionData.value)
+            appliedFor.quantity = !isNaN(quantity) ? quantity : undefined
+          }
+          if (Object.keys(appliedFor).length > 0) {
+            actionApplication.appliedFor = appliedFor
+          }
+        }
+
+        result.actionApplications.push(actionApplication)
+      })
     }
   }
   return result

--- a/src/server/land-grants/mappers/state-to-gas-answers-mapper.test.js
+++ b/src/server/land-grants/mappers/state-to-gas-answers-mapper.test.js
@@ -11,14 +11,17 @@ describe('stateToLandGrantsGasAnswers', () => {
   it('should transform a complete object correctly', () => {
     const input = {
       hasCheckedLandIsUpToDate: true,
-      landParcel: 'SX0679-9238',
       scheme: 'SFI',
       agreementName: "Joe's farm funding 2025",
       year: 2025,
-      actionsObj: {
-        CSAM1: {
-          value: '44',
-          unit: 'ha'
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: {
+              value: '44',
+              unit: 'ha'
+            }
+          }
         }
       }
     }
@@ -46,19 +49,22 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should handle multiple actions with different units', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: {
-          value: '44',
-          unit: 'ha'
-        },
-        CSAM2: {
-          value: '100',
-          unit: 'm2'
-        },
-        CSAM3: {
-          value: '5',
-          unit: 'count'
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: {
+              value: '44',
+              unit: 'ha'
+            },
+            CSAM2: {
+              value: '100',
+              unit: 'm2'
+            },
+            CSAM3: {
+              value: '5',
+              unit: 'count'
+            }
+          }
         }
       }
     }
@@ -100,23 +106,19 @@ describe('stateToLandGrantsGasAnswers', () => {
     expect(stateToLandGrantsGasAnswers(input)).toEqual(expected)
   })
 
-  it('should not include actionApplications when landParcel is missing', () => {
+  it('should include actionApplications when landParcels object is missing', () => {
     const input = {
       hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
-      actionsObj: {
-        CSAM1: {
-          value: '44',
-          unit: 'ha'
-        }
-      }
+      landParcels: {}
     }
 
     const expected = {
       hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
-      year: 2025
+      year: 2025,
+      actionApplications: []
     }
 
     expect(stateToLandGrantsGasAnswers(input)).toEqual(expected)
@@ -127,13 +129,16 @@ describe('stateToLandGrantsGasAnswers', () => {
       scheme: 'SFI',
       year: 2025,
       hasCheckedLandIsUpToDate: true,
-      landParcel: 'SX0679-9238'
+      landParcels: {
+        'SX0679-9238': {}
+      }
     }
 
     const expected = {
       scheme: 'SFI',
       year: 2025,
-      hasCheckedLandIsUpToDate: true
+      hasCheckedLandIsUpToDate: true,
+      actionApplications: []
     }
 
     expect(stateToLandGrantsGasAnswers(input)).toEqual(expected)
@@ -141,11 +146,14 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should handle decimal values correctly', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: {
-          value: '44.75',
-          unit: 'ha'
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: {
+              value: '44.75',
+              unit: 'ha'
+            }
+          }
         }
       }
     }
@@ -171,11 +179,14 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should omit unit in appliedFor when unit is missing', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: {
-          value: '44'
-          // unit is missing
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: {
+              value: '44'
+              // unit is missing
+            }
+          }
         }
       }
     }
@@ -200,11 +211,14 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should omit quantity in appliedFor when value is missing', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: {
-          unit: 'ha'
-          // value is missing
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: {
+              unit: 'ha'
+              // value is missing
+            }
+          }
         }
       }
     }
@@ -229,11 +243,14 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should omit quantity when value is not a valid number', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: {
-          value: 'not-a-number',
-          unit: 'ha'
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: {
+              value: 'not-a-number',
+              unit: 'ha'
+            }
+          }
         }
       }
     }
@@ -258,9 +275,12 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should omit appliedFor when action data is empty', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: {} // Empty object
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: {}
+          }
+        }
       }
     }
 
@@ -281,9 +301,12 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should omit appliedFor when action data is not an object', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: 'string-value' // Not an object
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: 'string-value' // Not an object
+          }
+        }
       }
     }
 
@@ -310,7 +333,8 @@ describe('stateToLandGrantsGasAnswers', () => {
 
     const expected = {
       scheme: 'SFI',
-      year: 2025
+      year: 2025,
+      actionApplications: []
     }
 
     expect(stateToLandGrantsGasAnswers(input)).toEqual(expected)
@@ -320,19 +344,23 @@ describe('stateToLandGrantsGasAnswers', () => {
     const input = {}
     const expected = {
       scheme: 'SFI',
-      year: 2025
+      year: 2025,
+      actionApplications: []
     }
 
     expect(stateToLandGrantsGasAnswers(input)).toEqual(expected)
   })
 
-  it('should handle landParcel without dash', () => {
+  it('should handle land parcels without dash', () => {
     const input = {
-      landParcel: 'SX06799238', // No dash
-      actionsObj: {
-        CSAM1: {
-          value: '44',
-          unit: 'ha'
+      landParcels: {
+        SX06799238: {
+          actionsObj: {
+            CSAM1: {
+              value: '44',
+              unit: 'ha'
+            }
+          }
         }
       }
     }
@@ -357,11 +385,14 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should include zero as a valid quantity', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: {
-          value: '0',
-          unit: 'ha'
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: {
+              value: '0',
+              unit: 'ha'
+            }
+          }
         }
       }
     }
@@ -385,13 +416,16 @@ describe('stateToLandGrantsGasAnswers', () => {
     expect(stateToLandGrantsGasAnswers(input)).toEqual(expected)
   })
 
-  it('should handle landParcel with multiple dashes correctly', () => {
+  it('should handle landParcels with multiple dashes correctly', () => {
     const input = {
-      landParcel: 'SX0679-9238-EXTRA',
-      actionsObj: {
-        CSAM1: {
-          value: '44',
-          unit: 'ha'
+      landParcels: {
+        'SX0679-9238-EXTRA': {
+          actionsObj: {
+            CSAM1: {
+              value: '44',
+              unit: 'ha'
+            }
+          }
         }
       }
     }
@@ -417,9 +451,12 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should handle null values in actionsObj', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: null
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: null // Null value for action
+          }
+        }
       }
     }
 
@@ -440,15 +477,18 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should handle mixed action data types', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: {
-          value: '44',
-          unit: 'ha'
-        },
-        CSAM2: null,
-        CSAM3: 'string-value',
-        CSAM4: {}
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: {
+              value: '44',
+              unit: 'ha'
+            },
+            CSAM2: null, // Null action
+            CSAM3: 'string-value', // String action
+            CSAM4: {} // Empty object action
+          }
+        }
       }
     }
 
@@ -488,11 +528,14 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should handle string values with spaces', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: {
-          value: '  44  ',
-          unit: '  ha  '
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: {
+              value: '  44  ', // String with leading and trailing spaces
+              unit: '  ha  ' // Unit with spaces
+            }
+          }
         }
       }
     }
@@ -518,11 +561,14 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should handle numeric strings with leading zeros', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: {
-          value: '0044.50',
-          unit: 'ha'
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: {
+              value: '0044.50', // Numeric string with leading zeros
+              unit: 'ha'
+            }
+          }
         }
       }
     }
@@ -548,9 +594,12 @@ describe('stateToLandGrantsGasAnswers', () => {
 
   it('should handle undefined values in actionsObj', () => {
     const input = {
-      landParcel: 'SX0679-9238',
-      actionsObj: {
-        CSAM1: undefined
+      landParcels: {
+        'SX0679-9238': {
+          actionsObj: {
+            CSAM1: undefined // Undefined action
+          }
+        }
       }
     }
 
@@ -587,11 +636,14 @@ describe('schema validation', () => {
         scheme: 'SFI',
         year: 2025,
         hasCheckedLandIsUpToDate: true,
-        landParcel: 'SX0679-9238',
-        actionsObj: {
-          CSAM1: {
-            value: '44',
-            unit: 'ha'
+        landParcels: {
+          'SX0679-9238': {
+            actionsObj: {
+              CSAM1: {
+                value: '44',
+                unit: 'ha'
+              }
+            }
           }
         }
       },
@@ -599,11 +651,14 @@ describe('schema validation', () => {
       {
         agreementName: "Joe's farm funding 2025",
         hasCheckedLandIsUpToDate: true,
-        landParcel: 'SX0679-9238',
-        actionsObj: {
-          CSAM1: {
-            value: '44',
-            unit: 'ha'
+        landParcels: {
+          'SX0679-9238': {
+            actionsObj: {
+              CSAM1: {
+                value: '44',
+                unit: 'ha'
+              }
+            }
           }
         }
       }

--- a/src/server/land-grants/views/choose-which-actions-to-do.html
+++ b/src/server/land-grants/views/choose-which-actions-to-do.html
@@ -32,7 +32,7 @@
       {{ govukSummaryList({
           card: {
             title: {
-              text: "Chosen parcel: " + selectedLandParcel.name
+              text: "Chosen parcel: " + selectedLandParcelObj.name
             },
             actions: {
               items: [
@@ -44,7 +44,7 @@
               ]
             }
           },
-          rows: selectedLandParcel.rows
+          rows: selectedLandParcelObj.rows
         }) 
       }}
       <div class="govuk-hint">
@@ -84,8 +84,8 @@
                   <tr class="govuk-table__row">
                     <td class="govuk-table__cell">
                       <div class="govuk-checkboxes__item series-selector-items">
-                        <input class="govuk-checkboxes__input" id="{{action.value}}" name="actions" type="checkbox" value="{{action.value}}" {% if action.checked %}checked{% endif %}>
-                        <label class="govuk-label govuk-checkboxes__label" for="actions">
+                        <input class="govuk-checkboxes__input" id="{{action.value}}" name="selectedActions" type="checkbox" value="{{action.value}}" {% if action.checked %}checked{% endif %}>
+                        <label class="govuk-label govuk-checkboxes__label" for="selectedActions">
                         <span class="govuk-visually-hidden">{{action.value}}</span></label>
                       </div>
                     </td>

--- a/src/server/land-grants/views/select-land-parcel.html
+++ b/src/server/land-grants/views/select-land-parcel.html
@@ -36,7 +36,7 @@
 
           {% if radioItems.length > 0 %}
             {{ govukRadios({
-                name: "landParcel",
+                name: "selectedLandParcel",
                 fieldset: {
                   legend: {
                     text: "Select land parcel for actions",


### PR DESCRIPTION
This PR enables sending multiple parcel data to GAS on land grants form submission.

There are some variables in our form definition that we don't need anymore, as we're replacing them with more complex objects to better support multiple parcels and actions being submitted. This PR gets rid of the old variables from the form definition and code.