### PR TITLE
Remove unused parcel info on parcel actions page

### DIFF
--- a/src/server/land-grants/controllers/land-actions-page.controller.js
+++ b/src/server/land-grants/controllers/land-actions-page.controller.js
@@ -12,6 +12,7 @@ export default class LandActionsPageController extends QuestionPageController {
   viewName = 'choose-which-actions-to-do'
   quantityPrefix = 'qty-'
   availableActions = []
+  currentParcelSize = NOT_AVAILABLE
 
   /**
    * Extract action details from the form payload
@@ -66,23 +67,7 @@ export default class LandActionsPageController extends QuestionPageController {
             text: 'Total size'
           },
           value: {
-            text: NOT_AVAILABLE
-          }
-        },
-        {
-          key: {
-            text: 'Land Cover'
-          },
-          value: {
-            text: NOT_AVAILABLE
-          }
-        },
-        {
-          key: {
-            text: 'Intersections'
-          },
-          value: {
-            text: NOT_AVAILABLE
+            text: this.currentParcelSize
           }
         }
       ]
@@ -187,6 +172,9 @@ export default class LandActionsPageController extends QuestionPageController {
       // Load available actions for the land parcel
       try {
         const data = await fetchAvailableActionsForParcel({ parcelId, sheetId })
+        this.currentParcelSize = data.size
+          ? `${data.size.value} ${data.size.unit}`
+          : NOT_AVAILABLE
         this.availableActions = data.actions || []
         if (!this.availableActions.length) {
           request.logger.error({

--- a/src/server/land-grants/controllers/land-actions-page.controller.test.js
+++ b/src/server/land-grants/controllers/land-actions-page.controller.test.js
@@ -26,22 +26,6 @@ describe('LandActionsPageController', () => {
         value: {
           text: 'Not available'
         }
-      },
-      {
-        key: {
-          text: 'Land Cover'
-        },
-        value: {
-          text: 'Not available'
-        }
-      },
-      {
-        key: {
-          text: 'Intersections'
-        },
-        value: {
-          text: 'Not available'
-        }
       }
     ]
   }

--- a/src/server/land-grants/services/land-grants.service.js
+++ b/src/server/land-grants/services/land-grants.service.js
@@ -102,7 +102,7 @@ export async function fetchAvailableActionsForParcel({
   sheetId = ''
 }) {
   const parcelIds = [stringifyParcel({ sheetId, parcelId })]
-  const fields = ['actions', 'actions.availableArea']
+  const fields = ['actions', 'actions.availableArea', 'size']
   const data = await postToLandGrantsApi('/parcels', { parcelIds, fields })
 
   return data.parcels?.find(

--- a/src/server/land-grants/services/land-grants.service.test.js
+++ b/src/server/land-grants/services/land-grants.service.test.js
@@ -382,7 +382,7 @@ describe('land-grants service', () => {
         expect.objectContaining({
           body: JSON.stringify({
             parcelIds: ['SHEET123-PARCEL456'],
-            fields: ['actions', 'actions.availableArea']
+            fields: ['actions', 'actions.availableArea', 'size']
           })
         })
       )
@@ -410,7 +410,7 @@ describe('land-grants service', () => {
         expect.objectContaining({
           body: JSON.stringify({
             parcelIds: ['-'],
-            fields: ['actions', 'actions.availableArea']
+            fields: ['actions', 'actions.availableArea', 'size']
           })
         })
       )


### PR DESCRIPTION
This PR removes parcel information we don't need to display on parcel actions page, so we'll only display total size for the time being:

![image](https://github.com/user-attachments/assets/61ef4560-99f8-441f-94e1-33444c841387)
