### PR TITLE
Fix SBI Select list logic

### DIFF
--- a/src/server/common/templates/layouts/dxt-form.njk
+++ b/src/server/common/templates/layouts/dxt-form.njk
@@ -32,7 +32,7 @@
     }) }}
 
     {% set checkTitle = pageTitle | string | lower %}
-    {% set isStartPage = pageTitle and ('check if you can apply' in checkTitle or 'find funding' in checkTitle) %}
+    {% set isStartPage = pageTitle and ('check if you can apply' in checkTitle or 'start page' in checkTitle) %}
     {% if enableSbiSelector and (serviceUrl == '/find-funding-for-land-or-farms' or serviceUrl == '/adding-value') and isStartPage %}
 
       {{ sbiSelector({


### PR DESCRIPTION
The SBI select list was not appearing on the "Find funding for land or farms" forms. This was because this forms start pages page title does not include "find funding" but is called "start page".

I'm still working with DXT forms to get global nunjucks functions supported so we can move this logic out of the views and can be properly unit tested