### PR TITLE
State persister for save and return

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2058,14 +2058,14 @@
       "license": "MIT"
     },
     "node_modules/@defra/forms-engine-plugin": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-2.0.2.tgz",
-      "integrity": "sha512-VT4jbYzhazDhkk8bbflLzWuKzK4WHC5pwW9EdfTxvyXUEURZvtRhqe/jcHz9VUX03TNeALi7ZRnrIKMzAeworg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-2.0.3.tgz",
+      "integrity": "sha512-7eQwUlFyj2EFKmAY1xSQnvNc0/TXH4NjrwM/cxM4RogNJhYsD07QyEDlQC+pQp7Qq4B6djgBXy03QsOzmRFklA==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@defra/forms-model": "^3.0.506",
-        "@defra/hapi-tracing": "^1.0.0",
+        "@defra/hapi-tracing": "^1.26.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/boom": "^10.0.1",
         "@hapi/catbox": "^12.1.1",

--- a/src/server/common/helpers/state/get-cache-key-helper.js
+++ b/src/server/common/helpers/state/get-cache-key-helper.js
@@ -19,26 +19,26 @@ export const getCacheKey = (request) => {
 
   if (!credentials) {
     outputLog(request, 'Missing auth credentials')
-    throw new Error('1Missing auth credentials')
+    throw new Error('Missing auth credentials')
   }
   const { crn: userId, relationships } = credentials
 
   if (!userId) {
     outputLog(request, 'Missing user ID in credentials')
-    throw new Error('2Missing user ID in credentials')
+    throw new Error('Missing user ID in credentials')
   }
 
   // Support single-business users for now
   const businessId = (Array.isArray(relationships) && relationships[0]?.split(':')[1]) || null
   if (!businessId) {
     outputLog(request, 'Missing or malformed business relationship in credentials')
-    throw new Error(`3Missing or malformed business relationship in credentials: ${JSON.stringify(relationships)}`)
+    throw new Error(`Missing or malformed business relationship in credentials: ${JSON.stringify(relationships)}`)
   }
 
   const grantId = request.params?.slug
   if (!grantId) {
     outputLog(request, 'Missing grantId')
-    throw new Error('4Missing grantId')
+    throw new Error('Missing grantId')
   }
   return { userId, businessId, grantId }
 }

--- a/src/server/common/helpers/state/persist-state-helper.js
+++ b/src/server/common/helpers/state/persist-state-helper.js
@@ -12,10 +12,7 @@ export async function persistStateToApi(state, request) {
   const { userId, businessId, grantId } = getCacheKey(request)
   const url = new URL('/state/', GRANTS_UI_BACKEND_ENDPOINT)
 
-  request.logger.info(
-    ['session-persister'],
-    `Persisting state to backend for identity: ${userId}:${businessId}:${grantId}`
-  )
+  request.logger.info(`Persisting state to backend for identity: ${userId}:${businessId}:${grantId}`)
 
   try {
     const response = await fetch(url.href, {
@@ -27,6 +24,7 @@ export async function persistStateToApi(state, request) {
         userId,
         businessId,
         grantId,
+        grantVersion: 'v1', // TODO: Update when support for same grant versioning is implemented
         state
       })
     })
@@ -35,7 +33,12 @@ export async function persistStateToApi(state, request) {
       throw new Error(`Failed to persist state: ${response.status}`)
     }
   } catch (err) {
-    request.logger.error(['session-persister'], 'Failed to persist state to API', err)
-    throw err
+    request.logger.error({
+      message: `Failed to persist state to API`,
+      err
+    })
+
+    // TODO: See TGC-781
+    // throw err
   }
 }

--- a/src/server/common/helpers/state/persist-state-helper.js
+++ b/src/server/common/helpers/state/persist-state-helper.js
@@ -1,0 +1,41 @@
+import 'dotenv/config'
+import { config } from '~/src/config/config.js'
+import { getCacheKey } from './get-cache-key-helper.js'
+
+const GRANTS_UI_BACKEND_ENDPOINT = config.get('session.cache.apiEndpoint')
+
+export async function persistStateToApi(state, request) {
+  if (!GRANTS_UI_BACKEND_ENDPOINT?.length) {
+    return
+  }
+
+  const { userId, businessId, grantId } = getCacheKey(request)
+  const url = new URL('/state/', GRANTS_UI_BACKEND_ENDPOINT)
+
+  request.logger.info(
+    ['session-persister'],
+    `Persisting state to backend for identity: ${userId}:${businessId}:${grantId}`
+  )
+
+  try {
+    const response = await fetch(url.href, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        userId,
+        businessId,
+        grantId,
+        state
+      })
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to persist state: ${response.status}`)
+    }
+  } catch (err) {
+    request.logger.error(['session-persister'], 'Failed to persist state to API', err)
+    throw err
+  }
+}

--- a/src/server/common/helpers/state/persist-state-helper.test.js
+++ b/src/server/common/helpers/state/persist-state-helper.test.js
@@ -23,7 +23,8 @@ describe('persistStateToApi', () => {
   describe('With backend configured correctly', () => {
     beforeEach(async () => {
       process.env.GRANTS_UI_BACKEND_URL = 'http://localhost:3002'
-      ;({ persistStateToApi } = await import('~/src/server/common/helpers/state/persist-state-helper.js'))
+      const helper = await import('~/src/server/common/helpers/state/persist-state-helper.js')
+      persistStateToApi = helper.persistStateToApi
       jest.clearAllMocks()
     })
 
@@ -108,7 +109,7 @@ describe('persistStateToApi', () => {
   describe('Without backend configured', () => {
     it('returns early when endpoint is not defined', async () => {
       process.env.GRANTS_UI_BACKEND_URL = ''
-      ;({ persistStateToApi } = await import('~/src/server/common/helpers/state/persist-state-helper.js'))
+      const { persistStateToApi } = await import('~/src/server/common/helpers/state/persist-state-helper.js')
 
       const request = mockRequestWithIdentity({ params: { slug: 'test-slug' } })
       const testState = { foo: 'bar' }
@@ -122,7 +123,7 @@ describe('persistStateToApi', () => {
 
     it('throws error when endpoint is whitespace only', async () => {
       process.env.GRANTS_UI_BACKEND_URL = '   '
-      ;({ persistStateToApi } = await import('~/src/server/common/helpers/state/persist-state-helper.js'))
+      const { persistStateToApi } = await import('~/src/server/common/helpers/state/persist-state-helper.js')
 
       const request = mockRequestWithIdentity({ params: { slug: 'test-slug' } })
       const testState = { foo: 'bar' }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -44,6 +44,7 @@ import { SummaryPageController } from '@defra/forms-engine-plugin/controllers/Su
 import { getCacheKey } from './common/helpers/state/get-cache-key-helper.js'
 import { fetchSavedStateFromApi } from './common/helpers/state/fetch-saved-state-helper.js'
 import { formsAuthCallback } from '~/src/server/auth/forms-engine-plugin-auth-helpers.js'
+import { persistStateToApi } from './common/helpers/state/persist-state-helper.js'
 
 const SESSION_CACHE_NAME = 'session.cache.name'
 
@@ -123,6 +124,9 @@ const registerFormsPlugin = async (server, prefix = '') => {
         },
         sessionHydrator: async (request) => {
           return fetchSavedStateFromApi(request)
+        },
+        sessionPersister: async (request, state) => {
+          return persistStateToApi(state, request)
         }
       },
       onRequest: formsAuthCallback,

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -125,7 +125,7 @@ const registerFormsPlugin = async (server, prefix = '') => {
         sessionHydrator: async (request) => {
           return fetchSavedStateFromApi(request)
         },
-        sessionPersister: async (request, state) => {
+        sessionPersister: async (state, request) => {
           return persistStateToApi(state, request)
         }
       },


### PR DESCRIPTION
## Summary

Adds session persistence to DXT to complement session rehydration. This ensures session state is saved not just to cache but also asynchronously to a backend store, enabling Save & Return functionality across devices and sessions.

### Key Changes
- persistStateToApi that is called within DXT's handleSaveAndReturn to persists session state to backend
- Replaces reliance on cacheService.setState for Save & Return
- Improves session durability and supports multi-device use

### Out of scope
This is the first iteration for security scan (note there will be still some work to be added for resilient persister similar to what was done for session purging and for error handling/messaging to the UX when session persisting fails).