### PR TITLE
Make land grants CRN configurable

### DIFF
--- a/src/config/land-grants.js
+++ b/src/config/land-grants.js
@@ -26,6 +26,12 @@ const landGrants = convict({
     format: String,
     default: '',
     env: 'LAND_GRANTS_API_URL'
+  },
+  customerReferenceNumber: {
+    doc: 'Customer Reference Number for the land grants forms',
+    format: Number,
+    default: 1100014934,
+    env: 'LAND_GRANTS_CUSTOMER_REFERENCE_NUMBER'
   }
 })
 

--- a/src/server/land-grants/controllers/confirm-farm-details.controller.js
+++ b/src/server/land-grants/controllers/confirm-farm-details.controller.js
@@ -3,6 +3,7 @@ import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { formatPhone } from '~/src/server/land-grants/utils/format-phone.js'
 import { sbiStore } from '~/src/server/sbi/state.js'
 import { fetchBusinessAndCustomerInformation } from '../../common/services/consolidated-view/consolidated-view.service.js'
+import { config } from '~/src/config/config.js'
 
 const logger = createLogger()
 
@@ -10,7 +11,7 @@ export default class ConfirmFarmDetailsController extends QuestionPageController
   viewName = 'confirm-farm-details'
 
   // Constants
-  static CUSTOMER_ID = 1100014934
+  static CUSTOMER_ID = config.get('landGrants.customerReferenceNumber')
   static ERROR_MESSAGE = 'Unable to find farm information, please try again later.'
 
   /**


### PR DESCRIPTION
Having a single hard-coded customer reference number is forcing us to try ensure DAL data is sync between their Mocked data and their live data in test env.