### PR TITLE
FRPSSFI-239 Add 'x-encrypted-auth' to agreements request headers

### DIFF
--- a/src/config/agreements.js
+++ b/src/config/agreements.js
@@ -7,7 +7,7 @@ import 'dotenv/config'
  * @typedef {object} AgreementsConfig
  * @property {string} apiToken
  * @property {string} apiUrl
- * @property {string} jwtToken
+ * @property {string} jwtSecret
  */
 
 const agreements = convict({
@@ -22,11 +22,11 @@ const agreements = convict({
     default: 'http://localhost:3555',
     env: 'AGREEMENTS_API_URL'
   },
-  jwtToken: {
-    doc: 'JWT token',
+  jwtSecret: {
+    doc: 'JWT Secret',
     format: String,
-    default: 'default-agreements-jwt-token',
-    env: 'AGREEMENTS_JWT_TOKEN'
+    default: 'default-agreements-jwt-secret',
+    env: 'AGREEMENTS_JWT_SECRET'
   }
 })
 

--- a/src/config/agreements.js
+++ b/src/config/agreements.js
@@ -5,18 +5,19 @@ import 'dotenv/config'
 
 /**
  * @typedef {object} AgreementsConfig
- * @property {string} agreementsApiToken
- * @property {string} agreementsApiUrl
+ * @property {string} apiToken
+ * @property {string} apiUrl
+ * @property {string} jwtToken
  */
 
 const agreements = convict({
-  agreementsApiToken: {
+  apiToken: {
     doc: 'Agreements API token',
     format: String,
     default: 'default-agreements-api-token',
     env: 'AGREEMENTS_API_TOKEN'
   },
-  agreementsApiUrl: {
+  apiUrl: {
     format: String,
     default: 'http://localhost:3555',
     env: 'AGREEMENTS_API_URL'

--- a/src/config/agreements.js
+++ b/src/config/agreements.js
@@ -18,8 +18,14 @@ const agreements = convict({
   },
   agreementsApiUrl: {
     format: String,
-    default: 'http://localhost:3003',
+    default: 'http://localhost:3555',
     env: 'AGREEMENTS_API_URL'
+  },
+  jwtToken: {
+    doc: 'JWT token',
+    format: String,
+    default: 'default-agreements-jwt-token',
+    env: 'AGREEMENTS_JWT_TOKEN'
   }
 })
 

--- a/src/server/agreements/controller.js
+++ b/src/server/agreements/controller.js
@@ -10,8 +10,8 @@ import { LogCodes } from '~/.server/server/common/helpers/logging/log-codes.js'
  * @throws {Error} If required config is missing
  */
 function validateConfig() {
-  const baseUrl = config.get('agreements.agreementsApiUrl')
-  const token = config.get('agreements.agreementsApiToken')
+  const baseUrl = config.get('agreements.apiUrl')
+  const token = config.get('agreements.apiToken')
 
   if (!baseUrl || !token) {
     throw new Error('Missing required configuration: agreements API settings')

--- a/src/server/agreements/controller.js
+++ b/src/server/agreements/controller.js
@@ -44,9 +44,9 @@ function buildTargetUri(baseUrl, path) {
 function buildProxyHeaders(token, request) {
   const sbi = sbiStore.get('sbi')
   const source = 'defra'
-  const jwtSecret = config.get('agreements.jwtToken')
+  const jwtSecret = config.get('agreements.jwtSecret')
   try {
-    const encryptedAuth = Jwt.token.generate({ sbi, source }, jwtSecret)
+    const encryptedAuth = Jwt.token.generate({ sbi: sbi.toString(), source }, jwtSecret)
     return {
       Authorization: `Bearer ${token}`,
       'defra-grants-proxy': 'true',

--- a/src/server/agreements/controller.test.js
+++ b/src/server/agreements/controller.test.js
@@ -1,5 +1,8 @@
 import { getAgreementController } from './controller.js'
 import { config } from '~/src/config/config.js'
+import Jwt from '@hapi/jwt'
+import { log } from '~/.server/server/common/helpers/logging/log.js'
+import { LogCodes } from '~/.server/server/common/helpers/logging/log-codes.js'
 
 jest.mock('~/src/config/config.js', () => ({
   config: {
@@ -14,6 +17,30 @@ jest.mock('~/src/server/common/helpers/logging/logger.js', () => ({
   }))
 }))
 
+jest.mock('~/src/server/sbi/state.js', () => ({
+  sbiStore: {
+    get: jest.fn(() => 'test-sbi-value')
+  }
+}))
+
+jest.mock('@hapi/jwt', () => ({
+  token: {
+    generate: jest.fn(() => 'mocked-jwt-token')
+  }
+}))
+
+jest.mock('~/.server/server/common/helpers/logging/log.js', () => ({
+  log: jest.fn()
+}))
+
+jest.mock('~/.server/server/common/helpers/logging/log-codes.js', () => ({
+  LogCodes: {
+    AGREEMENTS: {
+      AGREEMENT_ERROR: 'AGREEMENTS_AGREEMENT_ERROR'
+    }
+  }
+}))
+
 describe('Agreements Controller', () => {
   let mockRequest
   let mockH
@@ -21,6 +48,9 @@ describe('Agreements Controller', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+
+    // Reset JWT mock to default behavior
+    Jwt.token.generate.mockReturnValue('mocked-jwt-token')
 
     mockProxy = jest.fn()
     mockH = {
@@ -47,6 +77,8 @@ describe('Agreements Controller', () => {
           return 'http://localhost:3003'
         case 'agreements.agreementsApiToken':
           return 'test-token'
+        case 'agreements.jwtToken':
+          return 'test-jwt-secret'
         default:
           return undefined
       }
@@ -59,6 +91,7 @@ describe('Agreements Controller', () => {
 
       expect(config.get).toHaveBeenCalledWith('agreements.agreementsApiUrl')
       expect(config.get).toHaveBeenCalledWith('agreements.agreementsApiToken')
+      expect(config.get).toHaveBeenCalledWith('agreements.jwtToken')
       expect(mockH.proxy).toHaveBeenCalledWith({
         mapUri: expect.any(Function),
         passThrough: true,
@@ -73,6 +106,8 @@ describe('Agreements Controller', () => {
             return undefined
           case 'agreements.agreementsApiToken':
             return 'test-token'
+          case 'agreements.jwtToken':
+            return 'test-jwt-secret'
           default:
             return undefined
         }
@@ -115,6 +150,8 @@ describe('Agreements Controller', () => {
             return 'http://localhost:3003///'
           case 'agreements.agreementsApiToken':
             return 'test-token'
+          case 'agreements.jwtToken':
+            return 'test-jwt-secret'
           default:
             return undefined
         }
@@ -171,6 +208,8 @@ describe('Agreements Controller', () => {
             return 'http://localhost:3003/'
           case 'agreements.agreementsApiToken':
             return 'test-token'
+          case 'agreements.jwtToken':
+            return 'test-jwt-secret'
           default:
             return undefined
         }
@@ -196,8 +235,10 @@ describe('Agreements Controller', () => {
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
         'content-type': 'application/x-www-form-urlencoded',
-        'defra-grants-proxy': 'true'
+        'defra-grants-proxy': 'true',
+        'x-encrypted-auth': 'mocked-jwt-token'
       })
+      expect(Jwt.token.generate).toHaveBeenCalledWith({ sbi: 'test-sbi-value', source: 'defra' }, 'test-jwt-secret')
     })
 
     test('should build proxy headers for POST request with default content-type', async () => {
@@ -211,7 +252,8 @@ describe('Agreements Controller', () => {
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
         'defra-grants-proxy': 'true',
-        'content-type': 'application/x-www-form-urlencoded'
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-encrypted-auth': 'mocked-jwt-token'
       })
     })
 
@@ -230,7 +272,8 @@ describe('Agreements Controller', () => {
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
         'defra-grants-proxy': 'true',
-        'content-type': 'application/json'
+        'content-type': 'application/json',
+        'x-encrypted-auth': 'mocked-jwt-token'
       })
     })
 
@@ -245,7 +288,8 @@ describe('Agreements Controller', () => {
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
         'defra-grants-proxy': 'true',
-        'content-type': 'application/x-www-form-urlencoded'
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-encrypted-auth': 'mocked-jwt-token'
       })
     })
 
@@ -260,7 +304,8 @@ describe('Agreements Controller', () => {
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
         'defra-grants-proxy': 'true',
-        'content-type': 'application/x-www-form-urlencoded'
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-encrypted-auth': 'mocked-jwt-token'
       })
     })
 
@@ -278,7 +323,31 @@ describe('Agreements Controller', () => {
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
         'defra-grants-proxy': 'true',
-        'content-type': 'application/json'
+        'content-type': 'application/json',
+        'x-encrypted-auth': 'mocked-jwt-token'
+      })
+    })
+
+    test('should handle JWT generation error and log failure', async () => {
+      const jwtError = new Error('JWT secret invalid')
+      jwtError.stack = 'Error: JWT secret invalid\n    at Object.generate'
+      Jwt.token.generate.mockImplementationOnce(() => {
+        throw jwtError
+      })
+
+      mockRequest.userId = 'test-user-123'
+
+      await getAgreementController.handler(mockRequest, mockH)
+
+      expect(log).toHaveBeenCalledWith(LogCodes.AGREEMENTS.AGREEMENT_ERROR, {
+        userId: 'test-user-123',
+        error: 'JWT generate failed: JWT secret invalid'
+      })
+
+      expect(mockH.response).toHaveBeenCalledWith({
+        error: 'External Service Unavailable',
+        message: 'Unable to process request',
+        details: 'Failed to generate JWT token: JWT secret invalid'
       })
     })
   })
@@ -326,7 +395,8 @@ describe('Agreements Controller', () => {
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
         'defra-grants-proxy': 'true',
-        'content-type': 'application/x-www-form-urlencoded'
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-encrypted-auth': 'mocked-jwt-token'
       })
     })
 

--- a/src/server/agreements/controller.test.js
+++ b/src/server/agreements/controller.test.js
@@ -77,7 +77,7 @@ describe('Agreements Controller', () => {
           return 'http://localhost:3003'
         case 'agreements.apiToken':
           return 'test-token'
-        case 'agreements.jwtToken':
+        case 'agreements.jwtSecret':
           return 'test-jwt-secret'
         default:
           return undefined
@@ -91,7 +91,7 @@ describe('Agreements Controller', () => {
 
       expect(config.get).toHaveBeenCalledWith('agreements.apiUrl')
       expect(config.get).toHaveBeenCalledWith('agreements.apiToken')
-      expect(config.get).toHaveBeenCalledWith('agreements.jwtToken')
+      expect(config.get).toHaveBeenCalledWith('agreements.jwtSecret')
       expect(mockH.proxy).toHaveBeenCalledWith({
         mapUri: expect.any(Function),
         passThrough: true,
@@ -106,7 +106,7 @@ describe('Agreements Controller', () => {
             return undefined
           case 'agreements.apiToken':
             return 'test-token'
-          case 'agreements.jwtToken':
+          case 'agreements.jwtSecret':
             return 'test-jwt-secret'
           default:
             return undefined
@@ -150,7 +150,7 @@ describe('Agreements Controller', () => {
             return 'http://localhost:3003///'
           case 'agreements.apiToken':
             return 'test-token'
-          case 'agreements.jwtToken':
+          case 'agreements.jwtSecret':
             return 'test-jwt-secret'
           default:
             return undefined
@@ -208,7 +208,7 @@ describe('Agreements Controller', () => {
             return 'http://localhost:3003/'
           case 'agreements.apiToken':
             return 'test-token'
-          case 'agreements.jwtToken':
+          case 'agreements.jwtSecret':
             return 'test-jwt-secret'
           default:
             return undefined

--- a/src/server/agreements/controller.test.js
+++ b/src/server/agreements/controller.test.js
@@ -73,9 +73,9 @@ describe('Agreements Controller', () => {
     // Default config setup
     config.get.mockImplementation((key) => {
       switch (key) {
-        case 'agreements.agreementsApiUrl':
+        case 'agreements.apiUrl':
           return 'http://localhost:3003'
-        case 'agreements.agreementsApiToken':
+        case 'agreements.apiToken':
           return 'test-token'
         case 'agreements.jwtToken':
           return 'test-jwt-secret'
@@ -89,8 +89,8 @@ describe('Agreements Controller', () => {
     test('should validate configuration successfully with valid values', async () => {
       await getAgreementController.handler(mockRequest, mockH)
 
-      expect(config.get).toHaveBeenCalledWith('agreements.agreementsApiUrl')
-      expect(config.get).toHaveBeenCalledWith('agreements.agreementsApiToken')
+      expect(config.get).toHaveBeenCalledWith('agreements.apiUrl')
+      expect(config.get).toHaveBeenCalledWith('agreements.apiToken')
       expect(config.get).toHaveBeenCalledWith('agreements.jwtToken')
       expect(mockH.proxy).toHaveBeenCalledWith({
         mapUri: expect.any(Function),
@@ -102,9 +102,9 @@ describe('Agreements Controller', () => {
     test('should return 503 when agreements API URL is missing', async () => {
       config.get.mockImplementation((key) => {
         switch (key) {
-          case 'agreements.agreementsApiUrl':
+          case 'agreements.apiUrl':
             return undefined
-          case 'agreements.agreementsApiToken':
+          case 'agreements.apiToken':
             return 'test-token'
           case 'agreements.jwtToken':
             return 'test-jwt-secret'
@@ -125,9 +125,9 @@ describe('Agreements Controller', () => {
     test('should return 503 when agreements API token is missing', async () => {
       config.get.mockImplementation((key) => {
         switch (key) {
-          case 'agreements.agreementsApiUrl':
+          case 'agreements.apiUrl':
             return 'http://localhost:3003'
-          case 'agreements.agreementsApiToken':
+          case 'agreements.apiToken':
             return undefined
           default:
             return undefined
@@ -146,9 +146,9 @@ describe('Agreements Controller', () => {
     test('should handle baseUrl with trailing slashes', async () => {
       config.get.mockImplementation((key) => {
         switch (key) {
-          case 'agreements.agreementsApiUrl':
+          case 'agreements.apiUrl':
             return 'http://localhost:3003///'
-          case 'agreements.agreementsApiToken':
+          case 'agreements.apiToken':
             return 'test-token'
           case 'agreements.jwtToken':
             return 'test-jwt-secret'
@@ -204,9 +204,9 @@ describe('Agreements Controller', () => {
     test('should build target URI correctly with base URL having trailing slash', async () => {
       config.get.mockImplementation((key) => {
         switch (key) {
-          case 'agreements.agreementsApiUrl':
+          case 'agreements.apiUrl':
             return 'http://localhost:3003/'
-          case 'agreements.agreementsApiToken':
+          case 'agreements.apiToken':
             return 'test-token'
           case 'agreements.jwtToken':
             return 'test-jwt-secret'


### PR DESCRIPTION
* The `x-encrypted-auth` header should include:
     * **sbi** - in the future will be provided by `defra-id`
     * **source** - which will always be 'defra' from `grants-ui`
* Renamed `AgreementsConfig` environment variables - Removed the redundant agreements prefix

**Resolves:** FRPSSFI-239 FRPSSFI-185