### PR TITLE
Remove unused availableArea field

### DIFF
--- a/src/server/land-grants/services/land-grants.service.js
+++ b/src/server/land-grants/services/land-grants.service.js
@@ -57,9 +57,9 @@ export const landActionsToApiPayload = ({ sheetId, parcelId, actionsObj }) => {
     sbi,
     actions: actionsObj
       ? Object.entries(actionsObj).map(([code, area]) => ({
-          code,
-          quantity: Number(area.value)
-        }))
+        code,
+        quantity: Number(area.value)
+      }))
       : []
   }
 }
@@ -104,7 +104,7 @@ export async function calculateGrantPayment({ landParcels }) {
  */
 export async function fetchAvailableActionsForParcel({ parcelId = '', sheetId = '' }) {
   const parcelIds = [stringifyParcel({ sheetId, parcelId })]
-  const fields = ['actions', 'actions.availableArea', 'size']
+  const fields = ['actions', 'size']
   const data = await postToLandGrantsApi('/parcels', { parcelIds, fields })
 
   return data.parcels?.find((p) => p.parcelId === parcelId && p.sheetId === sheetId)

--- a/src/server/land-grants/services/land-grants.service.test.js
+++ b/src/server/land-grants/services/land-grants.service.test.js
@@ -369,7 +369,7 @@ describe('land-grants service', () => {
         expect.objectContaining({
           body: JSON.stringify({
             parcelIds: ['SHEET123-PARCEL456'],
-            fields: ['actions', 'actions.availableArea', 'size']
+            fields: ['actions', 'size']
           })
         })
       )
@@ -397,7 +397,7 @@ describe('land-grants service', () => {
         expect.objectContaining({
           body: JSON.stringify({
             parcelIds: ['-'],
-            fields: ['actions', 'actions.availableArea', 'size']
+            fields: ['actions', 'size']
           })
         })
       )


### PR DESCRIPTION
This PR removes an unused field that used to exist on the parcels controller: 'actions.availableArea'.