### PR TITLE
Set agreements base URL & header

### DIFF
--- a/src/config/agreements.js
+++ b/src/config/agreements.js
@@ -22,6 +22,12 @@ const agreements = convict({
     default: 'http://localhost:3555',
     env: 'AGREEMENTS_API_URL'
   },
+  baseUrl: {
+    doc: 'Agreements base URL',
+    format: String,
+    default: '/agreement',
+    env: 'AGREEMENTS_BASE_URL'
+  },
   jwtSecret: {
     doc: 'JWT Secret',
     format: String,

--- a/src/server/agreements/controller.js
+++ b/src/server/agreements/controller.js
@@ -49,7 +49,7 @@ function buildProxyHeaders(token, request) {
     const encryptedAuth = Jwt.token.generate({ sbi: sbi.toString(), source }, jwtSecret)
     return {
       Authorization: `Bearer ${token}`,
-      'defra-grants-proxy': 'true',
+      'x-base-url': config.get('agreements.baseUrl'),
       'content-type': request.headers['content-type'] || 'application/x-www-form-urlencoded',
       'x-encrypted-auth': encryptedAuth
     }

--- a/src/server/agreements/controller.test.js
+++ b/src/server/agreements/controller.test.js
@@ -77,6 +77,8 @@ describe('Agreements Controller', () => {
           return 'http://localhost:3003'
         case 'agreements.apiToken':
           return 'test-token'
+        case 'agreements.baseUrl':
+          return '/agreement'
         case 'agreements.jwtSecret':
           return 'test-jwt-secret'
         default:
@@ -235,7 +237,7 @@ describe('Agreements Controller', () => {
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
         'content-type': 'application/x-www-form-urlencoded',
-        'defra-grants-proxy': 'true',
+        'x-base-url': '/agreement',
         'x-encrypted-auth': 'mocked-jwt-token'
       })
       expect(Jwt.token.generate).toHaveBeenCalledWith({ sbi: 'test-sbi-value', source: 'defra' }, 'test-jwt-secret')
@@ -251,7 +253,7 @@ describe('Agreements Controller', () => {
 
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
-        'defra-grants-proxy': 'true',
+        'x-base-url': '/agreement',
         'content-type': 'application/x-www-form-urlencoded',
         'x-encrypted-auth': 'mocked-jwt-token'
       })
@@ -271,7 +273,7 @@ describe('Agreements Controller', () => {
 
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
-        'defra-grants-proxy': 'true',
+        'x-base-url': '/agreement',
         'content-type': 'application/json',
         'x-encrypted-auth': 'mocked-jwt-token'
       })
@@ -287,7 +289,7 @@ describe('Agreements Controller', () => {
 
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
-        'defra-grants-proxy': 'true',
+        'x-base-url': '/agreement',
         'content-type': 'application/x-www-form-urlencoded',
         'x-encrypted-auth': 'mocked-jwt-token'
       })
@@ -303,7 +305,7 @@ describe('Agreements Controller', () => {
 
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
-        'defra-grants-proxy': 'true',
+        'x-base-url': '/agreement',
         'content-type': 'application/x-www-form-urlencoded',
         'x-encrypted-auth': 'mocked-jwt-token'
       })
@@ -322,7 +324,7 @@ describe('Agreements Controller', () => {
 
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
-        'defra-grants-proxy': 'true',
+        'x-base-url': '/agreement',
         'content-type': 'application/json',
         'x-encrypted-auth': 'mocked-jwt-token'
       })
@@ -394,7 +396,7 @@ describe('Agreements Controller', () => {
       expect(mapUriResult.uri).toBe('http://localhost:3003/test/endpoint')
       expect(mapUriResult.headers).toEqual({
         Authorization: 'Bearer test-token',
-        'defra-grants-proxy': 'true',
+        'x-base-url': '/agreement',
         'content-type': 'application/x-www-form-urlencoded',
         'x-encrypted-auth': 'mocked-jwt-token'
       })

--- a/src/server/agreements/index.js
+++ b/src/server/agreements/index.js
@@ -1,4 +1,5 @@
 import { getAgreementController } from '~/src/server/agreements/controller.js'
+import { config } from '~/src/config/config.js'
 
 /**
  * Sets up the routes used in the /agreements page.
@@ -11,7 +12,7 @@ export const agreements = {
       server.route([
         {
           method: 'GET',
-          path: '/agreement/{path*}',
+          path: `${String(config.get('agreements.baseUrl'))}/{path*}`,
           options: {
             auth: false
           },
@@ -19,7 +20,7 @@ export const agreements = {
         },
         {
           method: 'POST',
-          path: '/agreement/{path*}',
+          path: `${String(config.get('agreements.baseUrl'))}/{path*}`,
           options: {
             auth: false,
             plugins: {


### PR DESCRIPTION
Sets the agreements service base URL by config and passes it down via the `x-base-url` header. Required for https://github.com/DEFRA/farming-grants-agreements-api/pull/90