### PR TITLE
Add new support details component to land grants forms

### DIFF
--- a/src/config/nunjucks/nunjucks.js
+++ b/src/config/nunjucks/nunjucks.js
@@ -11,7 +11,8 @@ import * as globals from './globals.js'
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 export const grantsUiPaths = [
   path.resolve(dirname, '../../server/common/templates'),
-  path.resolve(dirname, '../../server/common/components')
+  path.resolve(dirname, '../../server/common/components'),
+  path.resolve(dirname, '../../server/land-grants/components')
 ]
 const nunjucksEnvironment = nunjucks.configure(['node_modules/govuk-frontend/dist/', ...grantsUiPaths], {
   autoescape: true,

--- a/src/server/land-grants/components/support-details/macro.njk
+++ b/src/server/land-grants/components/support-details/macro.njk
@@ -1,0 +1,3 @@
+{% macro defraSupportDetails(params) %}
+    {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/server/land-grants/components/support-details/template.njk
+++ b/src/server/land-grants/components/support-details/template.njk
@@ -1,0 +1,11 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{{ govukDetails({
+  summaryText: "If you have a question",
+  html: '<p class="gov-body">Contact the Rural Payments Agency if you have a query.</p>
+         <p class="gov-body">
+            Telephone: 03000 200 301<br>
+            Monday to Friday, 8:30am to 5pm (except bank holidays)</p>
+         <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/call-charges" target="_blank">Find out about call charges (opens in new tab)</a></p>
+         <p class="govuk-body">Email: <a class="govuk-link" href="mailto:ruralpayments@defra.gov.uk">ruralpayments@defra.gov.uk</a></p>'
+}) }}

--- a/src/server/land-grants/views/confirm-farm-details.html
+++ b/src/server/land-grants/views/confirm-farm-details.html
@@ -3,6 +3,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "support-details/macro.njk" import defraSupportDetails %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -26,9 +27,12 @@
         {{ govukButton({
             text: "Continue",
             preventDoubleClick: true
-          }) 
+          })
         }}
       </form>
+
+<!--      Add support details component -->
+      {{ defraSupportDetails() }}
     </div>
   </div>
 


### PR DESCRIPTION
New component created to be reused across multiple pages of the land grants forms


<img width="635" height="249" alt="image" src="https://github.com/user-attachments/assets/f6dd5640-3ec2-4133-abcd-042dd41d8a94" />


- Added to the "Confirm your details" page

<img width="665" height="829" alt="image" src="https://github.com/user-attachments/assets/0eba8c2a-c4ef-4368-baf7-46ac2123bdbf" />
