### PR TITLE
Land Grants: Switch action qty from input to hidden input

### DIFF
--- a/src/server/land-grants/views/choose-which-actions-to-do.html
+++ b/src/server/land-grants/views/choose-which-actions-to-do.html
@@ -47,28 +47,12 @@
           {% set action = actionId or actions[0].id %}
 
           {% for action in availableActions %}
+            <input type="hidden" name="{{quantityPrefix + action.code }}" value="{{ action.availableArea.value}}">
+
             {% set actionsCheckboxes = actionsCheckboxes.concat([{
               value: action.code,
               text: action.description,
-              checked: actions and actions.includes(action.code),
-              conditional: {
-                html: govukInput({
-                  name: quantityPrefix + action.code,
-                  spellcheck: false,
-                  classes: "govuk-input--width-10",
-                  label: {
-                    text: "Quantity"
-                  },
-                  hint: {
-                    text: action.availableArea.value + " " + action.availableArea.unit + " available"
-                  },
-                  value: selectedActionsQuantities[ quantityPrefix + action.code ] or "",
-                  errorMessage: errors[action.code],
-                  suffix: {
-                    text: action.availableArea.unit
-                  }
-                })
-              }
+              checked: actions and actions.includes(action.code)
             }]) %}
           {% endfor %}
 


### PR DESCRIPTION
We want to eventually remove the qty input fields and retrieve it directly from the server. This is the first step but does not force the user to input the available area and instead sets it using a hidden input field


### Before

<img width="500" height="818" alt="image" src="https://github.com/user-attachments/assets/1b90cd17-8c41-4393-92e5-49e7f6bd0c68" />

### After
<img width="664" height="611" alt="image" src="https://github.com/user-attachments/assets/c305734e-fa5b-40ae-8b66-c87c76c951a3" />
