### PR TITLE
Update select parcels page to match prototype

### DIFF
--- a/src/server/land-grants/views/select-land-parcel.html
+++ b/src/server/land-grants/views/select-land-parcel.html
@@ -48,7 +48,7 @@
                     isPageHeading: false
                   }
                 },
-                items: radioItems.slice(0, 3),
+                items: radioItems,
                 value: parcelId,
                 errorMessage: errorMessage and { text: errorMessage }
               })

--- a/src/server/land-grants/views/select-land-parcel.html
+++ b/src/server/land-grants/views/select-land-parcel.html
@@ -36,17 +36,17 @@
           {% endfor %}
 
           {% if radioItems.length > 0 %}
-            <h1 class="govuk-heading-l">
-              Select land parcel for actions
-            </h1>
-
             {{ govukRadios({
                 name: "selectedLandParcel",
                 fieldset: {
                   legend: {
-                    text: "Use your map to check these reference numbers against your land parcels.",
-                    isPageHeading: false
+                    text: "Select land parcel for actions",
+                    isPageHeading: true,
+                    classes: "govuk-fieldset__legend--l"
                   }
+                },
+                hint: {
+                  text: "Use your map to check these reference numbers against your land parcels."
                 },
                 items: radioItems,
                 value: parcelId,

--- a/src/server/land-grants/views/select-land-parcel.html
+++ b/src/server/land-grants/views/select-land-parcel.html
@@ -6,6 +6,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "support-details/macro.njk" import defraSupportDetails %}
 
 {% block content %}
 <div class="govuk-body">
@@ -35,20 +36,27 @@
           {% endfor %}
 
           {% if radioItems.length > 0 %}
+            <h1 class="govuk-heading-l">
+              Select land parcel for actions
+            </h1>
+
             {{ govukRadios({
                 name: "selectedLandParcel",
                 fieldset: {
                   legend: {
-                    text: "Select land parcel for actions",
-                    isPageHeading: true,
-                    classes: "govuk-fieldset__legend--l"
+                    text: "Use your map to check these reference numbers against your land parcels.",
+                    isPageHeading: false
                   }
                 },
-                items: radioItems,
+                items: radioItems.slice(0, 3),
                 value: parcelId,
                 errorMessage: errorMessage and { text: errorMessage }
               })
             }}
+
+            <p class="govuk-body">
+              You will be able to add actions to the other land parcels before submitting your application.
+            </p>
 
             <div id="landParcels" class="govuk-button-group">
               <input type="hidden" name="crumb" value="{{ crumb }}">
@@ -67,6 +75,8 @@
           {% endif %}
         </form>
       {% endif %}
+
+      {{ defraSupportDetails() }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
Update the select parcels page to match prototype:

https://eaflood.atlassian.net/browse/SFIR-203

@aliuk2012 - Here is the ui, the gap between the header and the first line of text, is slightly different to the prototype, but I think the prototype is wrong.

In order to add this new line of text, I have added a header, and changed the fieldlist text to the new text, i guess there are many ways to do this, let me know if you prefer another way.

<img width="1212" height="813" alt="Screenshot 2025-08-08 at 13 20 39" src="https://github.com/user-attachments/assets/bb5081ca-de29-485d-99f8-911d61d34d26" />

