### PR TITLE
Remove the agreement name page

### DIFF
--- a/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
+++ b/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
@@ -42,21 +42,6 @@ pages:
         options: {}
         schema: {}
 
-  - title: Enter your agreement name
-    path: /agreement-name
-    next:
-      - path: /select-land-parcel
-    components:
-      - type: TextField
-        name: agreementName
-        title: Agreement name
-        hint: This will appear on your agreement documents, it is for your own use. For example 'Joe's Farm Funding 2025'.
-        options:
-          required: true
-          classes: govuk-input--width-30
-          customValidationMessages:
-            string.empty: Enter your agreement name
-
   - title: Select Land Parcel
     controller: LandParcelPageController
     path: /select-land-parcel

--- a/src/server/land-grants/mappers/state-to-gas-answers-mapper.js
+++ b/src/server/land-grants/mappers/state-to-gas-answers-mapper.js
@@ -92,7 +92,7 @@ export function stateToLandGrantsGasAnswers(state) {
   const { landParcels } = state
   const result = {
     hasCheckedLandIsUpToDate: state.hasCheckedLandIsUpToDate,
-    agreementName: state.agreementName,
+    agreementName: 'NO_LONGER_REQUIRED',
     scheme: 'SFI',
     year: 2025,
     actionApplications: []

--- a/src/server/land-grants/mappers/state-to-gas-answers-mapper.test.js
+++ b/src/server/land-grants/mappers/state-to-gas-answers-mapper.test.js
@@ -12,8 +12,8 @@ describe('stateToLandGrantsGasAnswers', () => {
     const input = {
       hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
-      agreementName: "Joe's farm funding 2025",
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       landParcels: {
         'SX0679-9238': {
           actionsObj: {
@@ -30,7 +30,7 @@ describe('stateToLandGrantsGasAnswers', () => {
       scheme: 'SFI',
       year: 2025,
       hasCheckedLandIsUpToDate: true,
-      agreementName: "Joe's farm funding 2025",
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -72,6 +72,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -118,6 +119,7 @@ describe('stateToLandGrantsGasAnswers', () => {
       hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: []
     }
 
@@ -138,6 +140,7 @@ describe('stateToLandGrantsGasAnswers', () => {
       scheme: 'SFI',
       year: 2025,
       hasCheckedLandIsUpToDate: true,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: []
     }
 
@@ -161,6 +164,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -194,6 +198,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -226,6 +231,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -258,6 +264,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -287,6 +294,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -313,6 +321,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -334,6 +343,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: []
     }
 
@@ -345,6 +355,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: []
     }
 
@@ -368,6 +379,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           sheetId: 'SX06799238', // The entire value becomes sheetId
@@ -400,6 +412,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -433,6 +446,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           sheetId: 'SX0679',
@@ -463,6 +477,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -495,6 +510,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -543,6 +559,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -576,6 +593,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -606,6 +624,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     const expected = {
       scheme: 'SFI',
       year: 2025,
+      agreementName: 'NO_LONGER_REQUIRED',
       actionApplications: [
         {
           parcelId: '9238',
@@ -632,7 +651,7 @@ describe('schema validation', () => {
         frn: 'frn-1234',
         crn: 'crn-1234',
         defraId: 'defra-id-1234',
-        agreementName: "Joe's farm funding 2025",
+        agreementName: 'NO_LONGER_REQUIRED',
         scheme: 'SFI',
         year: 2025,
         hasCheckedLandIsUpToDate: true,
@@ -649,7 +668,7 @@ describe('schema validation', () => {
       },
       // Minimal object with actions
       {
-        agreementName: "Joe's farm funding 2025",
+        agreementName: 'NO_LONGER_REQUIRED',
         hasCheckedLandIsUpToDate: true,
         landParcels: {
           'SX0679-9238': {


### PR DESCRIPTION
This pr remove the agreement name page, https://eaflood.atlassian.net/browse/SFIR-263

- Also defaults the agreement name to NO_LONGER_REQUIRED
- Removing the page, has also correctly removed the page from the summary
- Updated the tests