### PR TITLE
Sfir 163 confirm land details

### DIFF
--- a/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
+++ b/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
@@ -20,22 +20,6 @@ pages:
     path: /confirm-you-will-be-eligible
     view: confirm-you-will-be-eligible.html
 
-  - title: You must correct your land details
-    path: /you-must-correct-your-details
-    controller: TerminalPageController
-    condition: landIsUpToDateCondition
-    components:
-      - name: FGyiLS
-        title: You must correct your land details
-        type: Html
-        hint: ''
-        content: |+
-          <p class="govuk-body">
-            You must correct your land details.
-          </p>
-        options: {}
-        schema: {}
-
   - title: Select Land Parcel
     controller: LandParcelPageController
     path: /select-land-parcel
@@ -62,3 +46,4 @@ pages:
 
 lists: []
 sections: []
+conditions: []

--- a/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
+++ b/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
@@ -20,16 +20,6 @@ pages:
     path: /confirm-you-will-be-eligible
     view: confirm-you-will-be-eligible.html
 
-  - title: Do your digital maps show the correct land details?
-    path: /land-details
-    components:
-      - name: hasCheckedLandIsUpToDate
-        title: Do your digital maps show the correct land details?
-        type: YesNoField
-        hint: ''
-        options: {}
-        schema: {}
-
   - title: You must correct your land details
     path: /you-must-correct-your-details
     controller: TerminalPageController

--- a/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
+++ b/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
@@ -62,18 +62,3 @@ pages:
 
 lists: []
 sections: []
-conditions:
-  - name: landIsUpToDateCondition
-    displayName: notCorrect
-    value:
-      name: notCorrect
-      conditions:
-        - field:
-            name: hasCheckedLandIsUpToDate
-            type: YesNoField
-            display: Do your digital maps show the correct land details?
-          operator: is
-          value:
-            type: Value
-            value: 'false'
-            display: 'No'

--- a/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
+++ b/src/server/common/forms/definitions/find-funding-for-land-or-farms.yaml
@@ -20,6 +20,10 @@ pages:
     path: /confirm-you-will-be-eligible
     view: confirm-you-will-be-eligible.html
 
+  - title: Confirm your land details are up to date
+    path: /confirm-your-land-details-are-up-to-date
+    view: confirm-your-land-details-are-up-to-date.html
+
   - title: Select Land Parcel
     controller: LandParcelPageController
     path: /select-land-parcel

--- a/src/server/land-grants/mappers/state-to-gas-answers-mapper.js
+++ b/src/server/land-grants/mappers/state-to-gas-answers-mapper.js
@@ -91,7 +91,7 @@ function processParcelActions(actionsObj, sheetId, parcelId) {
 export function stateToLandGrantsGasAnswers(state) {
   const { landParcels } = state
   const result = {
-    hasCheckedLandIsUpToDate: state.hasCheckedLandIsUpToDate,
+    hasCheckedLandIsUpToDate: true,
     agreementName: 'NO_LONGER_REQUIRED',
     scheme: 'SFI',
     year: 2025,

--- a/src/server/land-grants/mappers/state-to-gas-answers-mapper.test.js
+++ b/src/server/land-grants/mappers/state-to-gas-answers-mapper.test.js
@@ -70,6 +70,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -162,6 +163,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -196,6 +198,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -229,6 +232,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -262,6 +266,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -292,6 +297,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -319,6 +325,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -341,6 +348,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -353,6 +361,7 @@ describe('stateToLandGrantsGasAnswers', () => {
   it('should return minimal object when input is empty', () => {
     const input = {}
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -377,6 +386,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -410,6 +420,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -444,6 +455,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -475,6 +487,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -508,6 +521,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -557,6 +571,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -591,6 +606,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',
@@ -622,6 +638,7 @@ describe('stateToLandGrantsGasAnswers', () => {
     }
 
     const expected = {
+      hasCheckedLandIsUpToDate: true,
       scheme: 'SFI',
       year: 2025,
       agreementName: 'NO_LONGER_REQUIRED',

--- a/src/server/land-grants/views/confirm-your-land-details-are-up-to-date.html
+++ b/src/server/land-grants/views/confirm-your-land-details-are-up-to-date.html
@@ -1,0 +1,42 @@
+{% extends baseLayoutPath %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "support-details/macro.njk" import defraSupportDetails %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h1 class="govuk-heading-l">
+        {{ pageTitle }}
+      </h1>
+
+      <p class="govuk-body">You confirm you have checked your digital maps are up to date and show:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>all the land parcels you want to include in your application</li>
+        <li>the correct total area (in hectares) for each land parcel</li>
+        <li>the correct land covers for each land parcel, for example, arable land, permanent grassland, permanent crops or relevant non-agricultural land cover</li>
+      </ul>
+
+      <p class="govuk-body">You confirm you have declared the correct land use codes for each land parcel in the Rural Payments service.</p>
+
+      <p class="govuk-body">If your land details are not up to date:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>you may not be able to apply for the actions you select</li>
+        <li>the total area of land available to enter into an action may not be accurate</li>
+      </ul>
+
+      <form method="post" novalidate>
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+        {{ govukButton({
+            text: "Continue",
+            preventDoubleClick: true
+          })
+        }}
+      </form>
+
+      {{ defraSupportDetails() }}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This pr adds a new confirm land details page, and also removes the digital maps show the correct page

https://eaflood.atlassian.net/browse/SFIR-163

- remove `digital maps show the correct` page
- remove the condition for this page
- remove the `You must correct your land details` page
- set `hasCheckedLandIsUpToDate` = true on sending application to gas
