### PR TITLE
Update "Select actions for land parcel" page

### DIFF
--- a/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
@@ -156,10 +156,7 @@ export default class SelectActionsForLandParcelPageController extends QuestionPa
       }
     }
 
-    // Filter actionsObj to only include items with non-null values and ready to be validated by the api
-    const readyForValidationsActionsObj = this.getCompletedFormFieldsForApiValidation(actionsObj)
-
-    if (Object.keys(readyForValidationsActionsObj).length > 0) {
+    if (Object.keys(actionsObj).length > 0) {
       const { valid, errorMessages = [] } = await triggerApiActionsValidation({
         sheetId,
         parcelId,
@@ -181,14 +178,6 @@ export default class SelectActionsForLandParcelPageController extends QuestionPa
     }))
 
     return { errors, errorSummary }
-  }
-
-  getCompletedFormFieldsForApiValidation = (actionsObj) => {
-    return Object.fromEntries(
-      Object.entries(actionsObj).filter(
-        ([, action]) => action.value !== null && action.value !== undefined && action.value !== ''
-      )
-    )
   }
 
   buildNewState = async (state, selectedActionsQuantities, actionsObj) => {

--- a/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
@@ -121,6 +121,21 @@ export default class SelectActionsForLandParcelPageController extends QuestionPa
       const payload = request.payload ?? {}
       const [sheetId, parcelId] = parseLandParcel(state.selectedLandParcel)
 
+      // Load available actions for the land parcel
+      try {
+        const data = await fetchAvailableActionsForParcel({ parcelId, sheetId })
+        this.availableActions = data.actions || []
+        if (!this.availableActions.length) {
+          request.logger.error({
+            message: `No actions found for parcel ${sheetId}-${parcelId}`,
+            selectedLandParcel: state.selectedLandParcel
+          })
+        }
+      } catch (error) {
+        this.availableActions = []
+        request.logger.error(error, `Failed to fetch land parcel data for id ${sheetId}-${parcelId}`)
+      }
+
       const { actionsObj } = this.extractActionsDataFromPayload(payload)
       // Create an updated state with the new action data
       const newState = await this.buildNewState(state, actionsObj)

--- a/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
@@ -19,10 +19,10 @@ export default class SelectActionsForLandParcelPageController extends QuestionPa
   viewName = 'select-actions-for-land-parcel'
   availableActions = []
 
-  processPayloadAction(selectedActions, landAction) {
+  processPayloadAction(landAction) {
     const actionInfo = this.availableActions.find((a) => a.code === landAction)
 
-    if (!selectedActions.includes(landAction) || !actionInfo) {
+    if (!actionInfo) {
       return {}
     }
 
@@ -41,20 +41,11 @@ export default class SelectActionsForLandParcelPageController extends QuestionPa
    */
   extractActionsDataFromPayload(payload) {
     const actionsObj = {}
-    const { selectedActions = [] } = payload
+    const { landAction } = payload
 
-    if (Array.isArray(selectedActions) && selectedActions.length > 0) {
-      for (const landAction of selectedActions) {
-        const result = this.processPayloadAction(selectedActions, landAction)
-        if (Object.keys(result).length > 0) {
-          actionsObj[landAction] = result
-        }
-      }
-    } else {
-      const result = this.processPayloadAction(selectedActions, selectedActions)
-      if (Object.keys(result).length > 0) {
-        actionsObj[selectedActions] = result
-      }
+    const result = this.processPayloadAction(landAction)
+    if (Object.keys(result).length > 0) {
+      actionsObj[landAction] = result
     }
 
     return { actionsObj }
@@ -159,8 +150,8 @@ export default class SelectActionsForLandParcelPageController extends QuestionPa
   validatePayload = async (payload, actionsObj, sheetId, parcelId) => {
     const errors = {}
 
-    if (!payload?.selectedActions || payload.selectedActions.length === 0) {
-      errors.selectedActions = {
+    if (!payload?.landAction || payload.landAction.length === 0) {
+      errors.landAction = {
         text: 'Please select at least one action'
       }
     }
@@ -186,7 +177,7 @@ export default class SelectActionsForLandParcelPageController extends QuestionPa
 
     const errorSummary = Object.entries(errors).map(([, { text }]) => ({
       text,
-      href: '#selectedActions'
+      href: '#landAction'
     }))
 
     return { errors, errorSummary }

--- a/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.test.js
@@ -51,7 +51,7 @@ describe('SelectActionsForLandParcelPageController', () => {
 
     mockRequest = {
       payload: {
-        selectedActions: ['CMOR1', 'UPL1']
+        landAction: 'CMOR1'
       },
       logger: {
         error: jest.fn()
@@ -87,7 +87,7 @@ describe('SelectActionsForLandParcelPageController', () => {
   describe('extractActionsDataFromPayload', () => {
     test('should extract action data correctly from payload', () => {
       const payload = {
-        selectedActions: ['CMOR1', 'UPL1']
+        landAction: 'CMOR1'
       }
 
       const result = controller.extractActionsDataFromPayload(payload)
@@ -99,12 +99,6 @@ describe('SelectActionsForLandParcelPageController', () => {
             value: 10,
             unit: 'ha',
             annualPaymentPence: 100
-          },
-          UPL1: {
-            description: 'UPL1: Moderate livestock grazing on moorland',
-            value: 5,
-            unit: 'ha',
-            annualPaymentPence: 200
           }
         }
       })
@@ -112,7 +106,7 @@ describe('SelectActionsForLandParcelPageController', () => {
 
     test('should ignore action codes not present in availableActions', () => {
       const payload = {
-        selectedActions: ['unknownAction']
+        landAction: 'unknownAction'
       }
 
       const result = controller.extractActionsDataFromPayload(payload)
@@ -130,7 +124,7 @@ describe('SelectActionsForLandParcelPageController', () => {
 
     test('should skip actions not included in actions array', () => {
       const payload = {
-        selectedActions: ['CMOR1']
+        landAction: 'CMOR1'
       }
 
       const result = controller.extractActionsDataFromPayload(payload)
@@ -142,31 +136,6 @@ describe('SelectActionsForLandParcelPageController', () => {
             value: 10,
             unit: 'ha',
             annualPaymentPence: 100
-          }
-        }
-      })
-    })
-
-    test('should skip actions with empty quantity values', () => {
-      const payload = {
-        selectedActions: ['CMOR1', 'UPL1']
-      }
-
-      const result = controller.extractActionsDataFromPayload(payload)
-
-      expect(result).toEqual({
-        actionsObj: {
-          CMOR1: {
-            description: 'CMOR1: Assess moorland and produce a written record',
-            value: 10,
-            unit: 'ha',
-            annualPaymentPence: 100
-          },
-          UPL1: {
-            description: 'UPL1: Moderate livestock grazing on moorland',
-            unit: 'ha',
-            value: 5,
-            annualPaymentPence: 200
           }
         }
       })
@@ -182,7 +151,7 @@ describe('SelectActionsForLandParcelPageController', () => {
       ]
 
       const payload = {
-        selectedActions: ['CMOR1']
+        landAction: 'CMOR1'
       }
 
       const result = controller.extractActionsDataFromPayload(payload)
@@ -238,7 +207,7 @@ describe('SelectActionsForLandParcelPageController', () => {
         actions: availableActions
       })
 
-      mockContext.state.selectedActions = ['CMOR1', 'UPL1']
+      mockContext.state.landAction = 'CMOR1'
       if (!mockContext.state.landParcels) {
         mockContext.state.landParcels = {}
       }
@@ -389,12 +358,6 @@ describe('SelectActionsForLandParcelPageController', () => {
               parcelId: 'parcel1',
               code: 'CMOR1',
               annualPaymentPence: 50
-            },
-            {
-              sheetId: 'sheet1',
-              parcelId: 'parcel1',
-              code: 'UPL1',
-              annualPaymentPence: 50
             }
           ]
         },
@@ -419,13 +382,7 @@ describe('SelectActionsForLandParcelPageController', () => {
                   description: 'CMOR1: Assess moorland and produce a written record',
                   unit: 'ha',
                   value: 10,
-                  annualPaymentPence: 50
-                },
-                UPL1: {
-                  description: 'UPL1: Moderate livestock grazing on moorland',
-                  unit: 'ha',
-                  value: 5,
-                  annualPaymentPence: 50
+                  annualPaymentPence: 100
                 }
               }
             }
@@ -470,12 +427,7 @@ describe('SelectActionsForLandParcelPageController', () => {
 
         triggerApiActionsValidation.mockResolvedValue({ valid: true, errorMessages: [] })
 
-        await controller.validatePayload(
-          { selectedActions: ['CMOR1'] },
-          readyForValidationsActionsObj,
-          sheetId,
-          parcelId
-        )
+        await controller.validatePayload({ landAction: 'CMOR1' }, readyForValidationsActionsObj, sheetId, parcelId)
 
         expect(triggerApiActionsValidation).toHaveBeenCalledWith({
           sheetId,
@@ -490,7 +442,7 @@ describe('SelectActionsForLandParcelPageController', () => {
         triggerApiActionsValidation.mockResolvedValue({ valid: true, errorMessages: [] })
 
         const result = await controller.validatePayload(
-          { selectedActions: ['CMOR1'] },
+          { landAction: 'CMOR1' },
           { CMOR1: { value: 10 } },
           'sheet1',
           'parcel1'
@@ -507,7 +459,7 @@ describe('SelectActionsForLandParcelPageController', () => {
         triggerApiActionsValidation.mockResolvedValue({ valid: false, errorMessages })
 
         const result = await controller.validatePayload(
-          { selectedActions: ['CMOR1'] },
+          { landAction: 'CMOR1' },
           { CMOR1: { value: 10 } },
           'sheet1',
           'parcel1'
@@ -516,12 +468,12 @@ describe('SelectActionsForLandParcelPageController', () => {
         expect(result.errors).toEqual({
           CMOR1: { text: 'Invalid quantity for CMOR1' }
         })
-        expect(result.errorSummary).toEqual([{ text: 'Invalid quantity for CMOR1', href: '#selectedActions' }])
+        expect(result.errorSummary).toEqual([{ text: 'Invalid quantity for CMOR1', href: '#landAction' }])
       })
 
       test('should handle no actions selected', async () => {
         mockRequest.payload = {
-          selectedActions: [],
+          landAction: '',
           action: 'validate'
         }
 
@@ -537,11 +489,11 @@ describe('SelectActionsForLandParcelPageController', () => {
             errorSummary: [
               {
                 text: 'Please select at least one action',
-                href: '#selectedActions'
+                href: '#landAction'
               }
             ],
             errors: {
-              selectedActions: {
+              landAction: {
                 text: 'Please select at least one action'
               }
             }
@@ -552,7 +504,7 @@ describe('SelectActionsForLandParcelPageController', () => {
 
     test('should validate actions when validate action is requested', async () => {
       mockRequest.payload = {
-        selectedActions: ['CMOR1'],
+        landAction: 'CMOR1',
         action: 'validate'
       }
 
@@ -625,11 +577,11 @@ describe('SelectActionsForLandParcelPageController', () => {
           errorSummary: [
             {
               text: 'Please select at least one action',
-              href: '#selectedActions'
+              href: '#landAction'
             }
           ],
           errors: {
-            selectedActions: {
+            landAction: {
               text: 'Please select at least one action'
             }
           },

--- a/src/server/land-grants/views/select-actions-for-land-parcel.html
+++ b/src/server/land-grants/views/select-actions-for-land-parcel.html
@@ -1,7 +1,7 @@
 {% extends baseLayoutPath %}
 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
@@ -53,50 +53,60 @@
         <form method="post" novalidate>
           <input type="hidden" name="crumb" value="{{ crumb }}">
 
-          {% set actionsCheckboxes = [] %}
-          {% set action = actionId or actions[0].id %}
+          {{ govukRadios({
+            name: "landAction",
+            fieldset: {
+              legend: {
+                text: "Assess moorland",
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            items: [
+              {
+                value: "CMOR1",
+                text: "CMOR1: Assess moorland and produce a written record"
+              }
+            ]
+          }) }}
 
-          {% for action in availableActions %}
-            {% set actionsCheckboxes = actionsCheckboxes.concat([{
-              value: action.code,
-              text: action.description,
-              checked: actions and actions.includes(action.code)
-            }]) %}
-          {% endfor %}
-
-          {% if actionsCheckboxes.length > 0 %}
-
-            {{ govukCheckboxes({
-              name: "selectedActions",
-              fieldset: {
-                legend: {
-                  text: "Available actions",
-                  classes: "govuk-fieldset__legend--m"
-                }
+          {{ govukRadios({
+            name: "landAction",
+            fieldset: {
+              legend: {
+                text: "Livestock grazing on moorland",
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            items: [
+              {
+                value: "UPL1",
+                text: "UPL1: Moderate livestock grazing on moorland"
               },
-              hint: {
-                text: "Select all the actions you want to do for this land parcel"
+              {
+                value: "UPL2",
+                text: "UPL2: Low livestock grazing on moorland"
               },
-              items: actionsCheckboxes,
-              errorMessage: errors["selectedActions"]
+              {
+                value: "UPL3",
+                text: "UPL3: Limited livestock grazing on moorland"
+              }
+            ]
+          }) }}
 
-            }) }}
-
-            <div class="govuk-button-group">
-              {% block form %}
-                {{ govukButton({
-                  text: "Continue",
-                  preventDoubleClick: true
-                }) }}
-              {% endblock %}
-            </div>
-          {% else %}
-            {{ govukWarningText({
-              text: "No actions available to select.",
-              iconFallbackText: "Warning"
-            }) }}
-          {% endif %}
+          <div class="govuk-button-group">
+            {% block form %}
+              {{ govukButton({
+                text: "Continue",
+                preventDoubleClick: true
+              }) }}
+            {% endblock %}
+          </div>
         </form>
+      {% else %}
+        {{ govukWarningText({
+          text: "No actions available to select.",
+          iconFallbackText: "Warning"
+        }) }}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Previously, farmers were able to select multiple actions for a specific land parcel at a time. The new behaviour is that they will only be able to select one land action for a specific land parcel

## Before
<img width="1368" height="1385" alt="image" src="https://github.com/user-attachments/assets/1b115c84-41bc-46cc-a7a5-aa874c92b215" />

## After

<img width="1368" height="1375" alt="image" src="https://github.com/user-attachments/assets/ab37ad7a-a6d5-45c1-af13-6dbf01e532f1" />
