### PR TITLE
refactor: remove SummaryPageController to align session handling with adding-value journey

### DIFF
--- a/src/server/common/forms/definitions/example-grant-with-auth.yaml
+++ b/src/server/common/forms/definitions/example-grant-with-auth.yaml
@@ -363,8 +363,6 @@ pages:
     id: 089374a5-13e7-494d-994e-9b38c4b7392c
   - title: Check your details
     path: /summary
-    controller: SummaryPageController
-    components: []
     id: aa34c1e0-e119-4e69-ab91-06d6b092055e
   - title: Confirm and send
     path: /declaration


### PR DESCRIPTION
### Summary

This PR removes the use of SummaryPageController from the /check-details page configuration for example-grant-with-auth and aligns the flow with adding-value.yaml.

### Background

The current configuration for example-grant-with-auth was creating an extra Redis session key after form submission:

```
grants-ui:formSubmission:<sessionId>:example-grant-with-auth # additional key being created unnecessarily
grants-ui:formSubmission:<sessionId>:example-grant-with-auth:confirmation # expected key after submission
```

This occurred because SummaryPageController was being invoked before final submission, which triggered a session update unnecessarily.

adding-value.yaml does not use SummaryPageController for its /check-details page and does not create redundant keys.

### Change Details

Removed SummaryPageController from /check-details route.

The page now acts as a simple step before the declaration page without mutating session data.

Aligns behaviuor with adding-value.yaml to avoid duplicate key creation.

### Benefits

- Prevents main issue which is the creation of unnecessary Redis session keys after submission.
- Prevents other side effects which is double submission of form data (it is either SummaryPageController or DeclarationPageController + ConfirmationPageController but not all 3 together)
- Simplifies page flow and reduces potential confusion around session handling.
- Keeps behaviour consistent across journeys.