### PR TITLE
Fix land actions validations

### DIFF
--- a/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
@@ -19,21 +19,6 @@ export default class SelectActionsForLandParcelPageController extends QuestionPa
   viewName = 'select-actions-for-land-parcel'
   availableActions = []
 
-  processPayloadAction(landAction) {
-    const actionInfo = this.availableActions.find((a) => a.code === landAction)
-
-    if (!actionInfo) {
-      return {}
-    }
-
-    return {
-      description: actionInfo.description,
-      value: actionInfo?.availableArea?.value ?? '',
-      unit: actionInfo?.availableArea?.unit ?? '',
-      annualPaymentPence: unitRatesForActions[landAction]
-    }
-  }
-
   /**
    * Extract action data from the form payload
    * @param {object} payload - The form payload
@@ -42,9 +27,17 @@ export default class SelectActionsForLandParcelPageController extends QuestionPa
   extractActionsDataFromPayload(payload) {
     const actionsObj = {}
     const { landAction } = payload
+    let result = {}
 
-    const result = this.processPayloadAction(landAction)
-    if (Object.keys(result).length > 0) {
+    const actionInfo = this.availableActions.find((a) => a.code === landAction) || {}
+
+    if (Object.keys(actionInfo).length > 0) {
+      result = {
+        description: actionInfo.description,
+        value: actionInfo?.availableArea?.value ?? '',
+        unit: actionInfo?.availableArea?.unit ?? '',
+        annualPaymentPence: unitRatesForActions[landAction]
+      }
       actionsObj[landAction] = result
     }
 

--- a/src/server/land-grants/views/select-actions-for-land-parcel.html
+++ b/src/server/land-grants/views/select-actions-for-land-parcel.html
@@ -50,7 +50,7 @@
       }) }}
 
       {% if availableActions %}
-        <form method="post" novalidate>
+        <form method="post" novalidate data-actions="{{ actions }}" >
           <input type="hidden" name="crumb" value="{{ crumb }}">
 
           {{ govukRadios({
@@ -66,7 +66,8 @@
                 value: "CMOR1",
                 text: "CMOR1: Assess moorland and produce a written record"
               }
-            ]
+            ],
+          errorMessage: errors.landAction
           }) }}
 
           {{ govukRadios({


### PR DESCRIPTION
Currently if the user does not select a land action and tried to move to the next page, they would get a 500 error page.