### PR TITLE
Change auth mode to 'required' and update route configurations

### DIFF
--- a/src/plugins/auth.js
+++ b/src/plugins/auth.js
@@ -84,10 +84,6 @@ function setupAuthStrategies(server, oidcConfig) {
     const bellOptions = getBellOptions(oidcConfig)
     server.auth.strategy('defra-id', 'bell', bellOptions)
   }
-
-  // Set the default authentication strategy to session
-  // All routes will require authentication unless explicitly set to 'defra-id' or `auth: false`
-  server.auth.default('session')
 }
 
 export default {

--- a/src/plugins/auth.test.js
+++ b/src/plugins/auth.test.js
@@ -240,8 +240,6 @@ describe('Auth Plugin', () => {
     expect(server.auth.strategy).toHaveBeenCalledTimes(2)
     expect(server.auth.strategy).toHaveBeenCalledWith('defra-id', 'bell', expect.any(Object))
     expect(server.auth.strategy).toHaveBeenCalledWith('session', 'cookie', expect.any(Object))
-
-    expect(server.auth.default).toHaveBeenCalledWith('session')
   })
 
   test('logs plugin registration start and completion', async () => {

--- a/src/server/home/index.js
+++ b/src/server/home/index.js
@@ -15,9 +15,6 @@ export const home = {
         {
           method: 'GET',
           path: '/home',
-          // options: {
-          //   auth: { mode: 'required' }
-          // },
           ...homeController
         }
       ])
@@ -25,9 +22,9 @@ export const home = {
         {
           method: 'GET',
           path: '/',
-          // options: {
-          //   auth: { mode: 'optional' }
-          // },
+          options: {
+            auth: false
+          },
           ...indexController
         }
       ])

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -81,7 +81,7 @@ const createHapiServer = () => {
         }
       },
       auth: {
-        mode: 'try',
+        mode: 'required',
         strategy: 'session'
       },
       files: {


### PR DESCRIPTION
Set global auth mode to 'required' for enhanced security. Removed unused default strategy setup and updated specific routes to explicitly define their auth requirements. This ensures better clarity and consistency in authentication handling.