### PR TITLE
Pino expects a printf placeholder to output the error

### DIFF
--- a/src/server/agreements/controller.js
+++ b/src/server/agreements/controller.js
@@ -103,7 +103,7 @@ export const getAgreementController = {
 
       return apiResponse
     } catch (error) {
-      request.logger.error('Request failed:', error)
+      request.logger.error('Request failed: %O', error)
 
       if (error.message.includes('Missing required configuration')) {
         return h


### PR DESCRIPTION
Currently the logs don't show the actual error as Pino expects a printf placeholder to output the error