### PR TITLE
Remove inline error message

### DIFF
--- a/src/server/land-grants/views/select-actions-for-land-parcel.html
+++ b/src/server/land-grants/views/select-actions-for-land-parcel.html
@@ -66,8 +66,7 @@
                 value: "CMOR1",
                 text: "CMOR1: Assess moorland and produce a written record"
               }
-            ],
-          errorMessage: errors.landAction
+            ]
           }) }}
 
           {{ govukRadios({


### PR DESCRIPTION
We removing this error message as we have two "groupings" of radio buttons which we would want to show as being invalid. The GOV.UK Design System doesn't support what we want to do on this page. We also know the design of this page will change to help support farmers select multiple land actions/land parcels.


### Before
<img width="639" height="720" alt="image" src="https://github.com/user-attachments/assets/b2d9bd5d-b201-41d3-9a23-f994e7c8d17f" />



### After
<img width="1481" height="1595" alt="image" src="https://github.com/user-attachments/assets/bbac3b4f-e33c-4f57-9aef-0d21b678d04d" />
