### PR TITLE
Pass authenticated users details to AccountBar component

### DIFF
--- a/src/server/common/components/account-bar/template.njk
+++ b/src/server/common/components/account-bar/template.njk
@@ -1,16 +1,16 @@
-{% if params is defined and params.userName != null and params.userName | length > 0 and params.businessName != null and params.businessName | length > 0 %}
+{% if params is defined and params.name != null and params.name | length > 0 and params.organisationName != null and params.organisationName | length > 0 %}
   <div class="govuk-width-container">
     <div class="defra-account-bar">
       <div class="govuk-grid-row govuk-!-padding-top-3">
         <div class="govuk-grid-column-two-thirds-from-desktop defra-account-bar__headings govuk-!-margin-bottom-2">
             <span class="govuk-visually-hidden">Acting on behalf of </span>
-            {{ params.businessName }}
-            <div class="govuk-!-font-size-16 govuk-!-font-weight-regular govuk-!-margin-top-1">Single business identifier (SBI): {{ params.sbi }} </div>
+            {{ params.organisationName }}
+            <div class="govuk-!-font-size-16 govuk-!-font-weight-regular govuk-!-margin-top-1">Single business identifier (SBI): {{ params.organisationId }} </div>
         </div>
 
         <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-2 defra-account-bar__headings defra-account-bar__headings--right-aligned">
           <span class="govuk-visually-hidden">Signed in as </span>
-          {{ params.userName }}
+          {{ params.name }}
         </div>
       </div>
     </div>

--- a/src/server/common/templates/layouts/dxt-form.njk
+++ b/src/server/common/templates/layouts/dxt-form.njk
@@ -17,18 +17,18 @@
 
   {{ govukServiceNavigation({ serviceName: name | default(serviceName) , serviceUrl: serviceUrl }) }}
 
-  {{ defraAccountBar({
-    businessName: "",
-    sbi: auth.sbi | default(""),
-    userName: ""
-  }) }}
-
   <div class="govuk-width-container">
     {{ govukPhaseBanner({
       tag: {
         text: "Beta"
       },
       text: 'This is a new service - your feedback will help us to improve it.'
+    }) }}
+
+    {{ defraAccountBar({
+      organisationName: auth.organisationName,
+      organisationId: auth.organisationId | default(""),
+      name: auth.name
     }) }}
 
     {% if not defraIdEnabled and serviceUrl == '/find-funding-for-land-or-farms' %}

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -28,14 +28,7 @@
 
   {{ govukServiceNavigation({ serviceName: serviceName, serviceUrl: serviceUrl }) }}
 
-  {{ defraAccountBar({
-    businessName: "",
-    sbi: auth.sbi | default(""),
-    userName: ""
-  }) }}
-
   <div class="govuk-width-container">
-
     {{ govukPhaseBanner({
       tag: {
         text: "Beta"
@@ -43,6 +36,11 @@
       text: 'This is a new service - your feedback will help us to improve it.'
     }) }}
   </div>
+    {{ defraAccountBar({
+      organisationName: auth.organisationName,
+      organisationId: auth.organisationId | default(""),
+      name: auth.name
+    }) }}
 {% endblock %}
 
 {% block pageTitle %}
@@ -50,15 +48,6 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% if auth.isAuthenticated %}
-    <div class="gov-grid-row">
-      <div style="float:right;clear:both;text-align:right;">
-        <p class="govuk-body govuk-!-margin-bottom-0">Signed in as <a href="/home" class="govuk-link govuk-link--no-visited-state">{{ auth.name }}</a></p>
-        <!-- <p class="govuk-body govuk-!-margin-bottom-0"><a href="/auth/organisation" class="govuk-link govuk-link--no-visited-state">Switch organisation</a></p> -->
-        <p class="govuk-body govuk-!-margin-bottom-0"><a href="/auth/sign-out" class="govuk-link govuk-link--no-visited-state">Sign out</a></p>
-      </div>
-    </div>
-  {% endif %}
   {% if breadcrumbs.length > 1 %}
     {{ govukBreadcrumbs({
       items: breadcrumbs


### PR DESCRIPTION
On all pages throughout the service will now include an "Account Bar" directly below the phase banner with the authenticated users details. 

### 
<img width="1014" height="699" alt="image" src="https://github.com/user-attachments/assets/bf6ada33-e5fd-41a3-be0f-0478f9697bea" />


### After

<img width="1013" height="746" alt="image" src="https://github.com/user-attachments/assets/eae13616-de2e-4fb0-9231-a8db41a96cee" />
