### PR TITLE
Add Google Analytics tracking support

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -342,6 +342,14 @@ export const config = convict({
       env: 'TRACING_HEADER'
     }
   },
+  googleAnalytics: {
+    trackingId: {
+      doc: 'Google Analytics tracking ID',
+      format: String,
+      default: undefined,
+      env: 'GA_TRACKING_ID'
+    }
+  },
   defraId: defraId.getProperties(),
   landGrants: /** @type {Schema<LandGrantsConfig>} */ (landGrants.getProperties()),
   agreements: /** @type {Schema<AgreementsConfig>} */ (agreements.getProperties())

--- a/src/config/nunjucks/nunjucks.js
+++ b/src/config/nunjucks/nunjucks.js
@@ -60,6 +60,8 @@ Object.entries(filters).forEach(([name, filter]) => {
   nunjucksEnvironment.addFilter(name, filter)
 })
 
+nunjucksEnvironment.addGlobal('gaTrackingId', config.get('googleAnalytics.trackingId'))
+
 /**
  * @import { ServerRegisterPluginObject } from '@hapi/hapi'
  * @import { ServerViewsConfiguration } from '@hapi/vision'

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -16,6 +16,22 @@
 
 {% block head %}
   <link href="{{ getAssetPath('stylesheets/application.scss') }}" rel="stylesheet">
+
+  {%  if gaTrackingId %}
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{ gaTrackingId }}');</script>
+  {% endif %}
+{% endblock %}
+
+{% block bodyStart %}
+  {%  if gaTrackingId %}
+  <noscript>
+    <iframe src="ns" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  </noscript>
+  {% endif %}
 {% endblock %}
 
 {% block header %}

--- a/src/server/views/layout.page.njk
+++ b/src/server/views/layout.page.njk
@@ -1,0 +1,5 @@
+{% extends "layouts/page.njk" %}
+
+{% block head %}
+<link href="testing.css" />
+{% endblock %}


### PR DESCRIPTION
Introduced configuration for Google Analytics tracking ID in `config.js`. Updated Nunjucks templates and configuration to include the tracking ID dynamically and embed the required script for Google Tag Manager when the ID is present.