### PR TITLE
Create helper to format land action description and code

### DIFF
--- a/src/server/land-grants/controllers/land-actions-check-page.controller.js
+++ b/src/server/land-grants/controllers/land-actions-check-page.controller.js
@@ -2,6 +2,7 @@ import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/Q
 import { formatCurrency } from '~/src/config/nunjucks/filters/filters.js'
 import { sbiStore } from '~/src/server/sbi/state.js'
 import { actionGroups, calculateGrantPayment, stringifyParcel } from '../services/land-grants.service.js'
+import { landActionWithCode } from '~/src/server/land-grants/utils/land-action-with-code.js'
 
 const createLinks = (data, foundGroup) => {
   const parcelParam = stringifyParcel({
@@ -100,7 +101,7 @@ export default class LandActionsCheckPageController extends QuestionPageControll
       items: [
         [
           {
-            text: `One-off payment per agreement per year for ${data.description}`
+            text: `One-off payment per agreement per year for ${landActionWithCode(data.description, data.code)}`
           },
           {
             text: this.getPrice(data.annualPaymentPence)
@@ -120,7 +121,7 @@ export default class LandActionsCheckPageController extends QuestionPageControll
     const linksCell = createLinks(data, foundGroup)
 
     return [
-      { text: `${data.description}: ${data.code}` },
+      { text: landActionWithCode(data.description, data.code) },
       { text: data.quantity },
       { text: this.getPrice(data.annualPaymentPence) },
       linksCell

--- a/src/server/land-grants/controllers/land-actions-check-page.controller.test.js
+++ b/src/server/land-grants/controllers/land-actions-check-page.controller.test.js
@@ -28,7 +28,8 @@ describe('LandActionsCheckPageController', () => {
       annualTotalPence: 32006,
       parcelItems: {
         1: {
-          description: 'CMOR1: Assess moorland and produce a written record',
+          code: 'CMOR1',
+          description: 'Assess moorland and produce a written record: CMOR1',
           quantity: 4.53,
           annualPaymentPence: 4806,
           sheetId: 'SD6743',
@@ -37,6 +38,7 @@ describe('LandActionsCheckPageController', () => {
       },
       agreementLevelItems: {
         1: {
+          code: 'MAN1',
           description: 'Management payment',
           annualPaymentPence: 27200
         }
@@ -264,9 +266,30 @@ describe('LandActionsCheckPageController', () => {
     test('should group parcel items by parcel ID', () => {
       const paymentData = {
         parcelItems: {
-          1: { description: 'CMOR1', quantity: 5, annualPaymentPence: 1000, sheetId: 'SD01', parcelId: '001' },
-          2: { description: 'UPL1', quantity: 3, annualPaymentPence: 500, sheetId: 'SD01', parcelId: '001' },
-          3: { description: 'UPL2', quantity: 2, annualPaymentPence: 200, sheetId: 'SD02', parcelId: '002' }
+          1: {
+            code: 'CMOR1',
+            description: 'Land Action 1',
+            quantity: 5,
+            annualPaymentPence: 1000,
+            sheetId: 'SD01',
+            parcelId: '001'
+          },
+          2: {
+            code: 'UPL1',
+            description: 'Land Action 2',
+            quantity: 3,
+            annualPaymentPence: 500,
+            sheetId: 'SD01',
+            parcelId: '001'
+          },
+          3: {
+            code: 'UPL2',
+            description: 'Land Action 3',
+            quantity: 2,
+            annualPaymentPence: 200,
+            sheetId: 'SD02',
+            parcelId: '002'
+          }
         }
       }
 
@@ -359,13 +382,13 @@ describe('LandActionsCheckPageController', () => {
     test('should format additional yearly payments', () => {
       const paymentData = {
         agreementLevelItems: {
-          1: { description: 'Management fee', annualPaymentPence: 5000 }
+          1: { description: 'Management fee', annualPaymentPence: 5000, code: 'MAN1' }
         }
       }
 
       const result = controller.getAdditionalYearlyPayments(paymentData)
 
-      expect(result[0].items[0][0].text).toBe('One-off payment per agreement per year for Management fee')
+      expect(result[0].items[0][0].text).toBe('One-off payment per agreement per year for Management fee: MAN1')
       expect(result[0].items[0][1].text).toBe('£50.00')
     })
   })
@@ -487,7 +510,7 @@ describe('LandActionsCheckPageController', () => {
         parcelItems: {
           1: {
             code: 'UPL1',
-            description: 'UPL1: Action description',
+            description: 'Action description',
             quantity: 5,
             annualPaymentPence: 1000,
             sheetId: 'SD01',
@@ -532,7 +555,7 @@ describe('LandActionsCheckPageController', () => {
         parcelItems: {
           1: {
             code: 'CMOR1',
-            description: 'CMOR1: Assess moorland',
+            description: 'Assess moorland',
             quantity: 2,
             annualPaymentPence: 600,
             sheetId: 'SD03',
@@ -540,7 +563,7 @@ describe('LandActionsCheckPageController', () => {
           },
           2: {
             code: 'UPL2',
-            description: 'UPL2: Upland action',
+            description: 'Upland action',
             quantity: 4,
             annualPaymentPence: 1200,
             sheetId: 'SD03',

--- a/src/server/land-grants/controllers/remove-action-page.controller.test.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.test.js
@@ -12,12 +12,12 @@ describe('RemoveActionPageController', () => {
     'SD6743-8083': {
       actionsObj: {
         CMOR1: {
-          description: 'CMOR1: Assess moorland and produce a written record',
+          description: 'Assess moorland and produce a written record',
           value: '4.53',
           unit: 'ha'
         },
         UPL1: {
-          description: 'UPL1: Moderate livestock grazing on moorland',
+          description: 'Moderate livestock grazing on moorland',
           value: '2.5',
           unit: 'ha'
         }
@@ -26,7 +26,7 @@ describe('RemoveActionPageController', () => {
     'SD6944-0085': {
       actionsObj: {
         CMOR1: {
-          description: 'CMOR1: Assess moorland and produce a written record',
+          description: 'Assess moorland and produce a written record',
           value: '1.0',
           unit: 'ha'
         }
@@ -116,7 +116,7 @@ describe('RemoveActionPageController', () => {
       const result = controller.findActionInfo(mockLandParcels, 'SD6743-8083', 'CMOR1')
 
       expect(result).toEqual({
-        description: 'CMOR1: Assess moorland and produce a written record',
+        description: 'Assess moorland and produce a written record',
         value: '4.53',
         unit: 'ha'
       })
@@ -151,7 +151,7 @@ describe('RemoveActionPageController', () => {
         landParcels: {
           'SD6743-8083': {
             actionsObj: {
-              UPL1: { description: 'UPL1: Moderate livestock grazing on moorland' }
+              UPL1: { description: 'Moderate livestock grazing on moorland' }
             }
           }
         }
@@ -274,7 +274,7 @@ describe('RemoveActionPageController', () => {
         landParcels: {
           'SD6944-0085': {
             actionsObj: {
-              CMOR1: { description: 'CMOR1: Test action' }
+              CMOR1: { description: 'Test action' }
             }
           }
         }
@@ -323,11 +323,11 @@ describe('RemoveActionPageController', () => {
 
       expect(controller.action).toBe('CMOR1')
       expect(controller.parcel).toBe('SD6743-8083')
-      expect(controller.actionDescription).toBe('CMOR1: Assess moorland and produce a written record')
+      expect(controller.actionDescription).toBe('Assess moorland and produce a written record')
       expect(mockH.view).toHaveBeenCalledWith('remove-action', {
         pageTitle: 'Remove action',
         parcel: 'SD6743-8083',
-        actionDescription: 'CMOR1: Assess moorland and produce a written record'
+        actionDescription: 'Assess moorland and produce a written record'
       })
       expect(result).toBe('rendered view')
     })
@@ -380,7 +380,7 @@ describe('RemoveActionPageController', () => {
       // Set up controller state as if GET request was processed
       controller.action = 'CMOR1'
       controller.parcel = 'SD6743-8083'
-      controller.actionDescription = 'CMOR1: Assess moorland and produce a written record'
+      controller.actionDescription = 'Assess moorland and produce a written record'
     })
 
     test('should show validation error when removeAction not provided', async () => {
@@ -392,7 +392,7 @@ describe('RemoveActionPageController', () => {
       expect(mockH.view).toHaveBeenCalledWith('remove-action', {
         pageTitle: 'Remove action',
         parcel: 'SD6743-8083',
-        actionDescription: 'CMOR1: Assess moorland and produce a written record',
+        actionDescription: 'Assess moorland and produce a written record',
         errorMessage: 'Please select if you want to remove the action'
       })
       expect(controller.setState).not.toHaveBeenCalled()

--- a/src/server/land-grants/services/land-grants.service.js
+++ b/src/server/land-grants/services/land-grants.service.js
@@ -2,6 +2,7 @@ import { config } from '~/src/config/config.js'
 import { formatCurrency } from '~/src/config/nunjucks/filters/format-currency.js'
 import { fetchParcelsForSbi } from '~/src/server/common/services/consolidated-view/consolidated-view.service.js'
 import { sbiStore } from '../../sbi/state.js'
+import { landActionWithCode } from '~/src/server/land-grants/utils/land-action-with-code.js'
 
 const LAND_GRANTS_API_URL = config.get('landGrants.grantsServiceApiEndpoint')
 
@@ -141,7 +142,7 @@ export async function fetchAvailableActionsForParcel({ parcelId = '', sheetId = 
 function mapAction(action) {
   return {
     ...action,
-    description: `${action.description}: ${action.code}`
+    description: landActionWithCode(action.description, action.code)
   }
 }
 

--- a/src/server/land-grants/utils/land-action-with-code.js
+++ b/src/server/land-grants/utils/land-action-with-code.js
@@ -1,0 +1,15 @@
+/**
+ * @param {string} description
+ * @param {string} code
+ */
+export const landActionWithCode = (description, code) => {
+  if (!code) {
+    throw new Error(`Missing land action code for "${description}"`)
+  }
+
+  if (!description) {
+    throw new Error(`Missing land action description for "${code}"`)
+  }
+
+  return `${description}: ${code}`
+}

--- a/src/server/land-grants/utils/land-action-with-code.test.js
+++ b/src/server/land-grants/utils/land-action-with-code.test.js
@@ -1,0 +1,16 @@
+import { landActionWithCode } from './land-action-with-code.js'
+
+describe('landActionWithCode', () => {
+  it('should format land action with code', () => {
+    const result = landActionWithCode('My secret code is', '07123456789')
+    expect(result).toBe('My secret code is: 07123456789')
+  })
+
+  it('should raise an error if no code is provided', () => {
+    expect(() => landActionWithCode('My secret code is')).toThrow('Missing land action code for "My secret code is"')
+  })
+
+  it('should raise an error if no description is provided', () => {
+    expect(() => landActionWithCode(null, 'CMOR1')).toThrow('Missing land action description for "CMOR1"')
+  })
+})


### PR DESCRIPTION
Introduce `landActionWithCode` utility and apply across controllers and services.

- Created a new utility `landActionWithCode` to standardise the formatting of land actions with their codes.
- Added tests for `landActionWithCode` to ensure proper error handling and formatting.
- Refactored controllers and services to use `landActionWithCode`, removing redundant concatenation logic.
- Updated related test files to align with the new formatting.