### PR TITLE
Actions review page style fixes

### DIFF
--- a/src/server/land-grants/controllers/land-actions-check-page.controller.js
+++ b/src/server/land-grants/controllers/land-actions-check-page.controller.js
@@ -20,7 +20,7 @@ const createLinks = (data) => {
   )
 
   return {
-    html: `<ul class='govuk-summary-list__actions-list govuk-!-text-align-right'>${links.join('')}</ul>`
+    html: `<ul class='govuk-summary-list__actions-list'>${links.join('')}</ul>`
   }
 }
 
@@ -102,7 +102,9 @@ export default class LandActionsCheckPageController extends QuestionPageControll
             text: `One-off payment per agreement per year for ${landActionWithCode(data.description, data.code)}`
           },
           {
-            text: this.getPrice(data.annualPaymentPence)
+            html: `<div class="govuk-!-width-one-half">${this.getPrice(data.annualPaymentPence)}</div>`,
+            format: 'numeric',
+            classes: 'govuk-!-padding-right-5'
           }
         ]
       ]
@@ -119,8 +121,8 @@ export default class LandActionsCheckPageController extends QuestionPageControll
 
     return [
       { text: landActionWithCode(data.description, data.code) },
-      { text: data.quantity },
-      { text: this.getPrice(data.annualPaymentPence) },
+      { text: data.quantity, format: 'numeric' },
+      { text: this.getPrice(data.annualPaymentPence), format: 'numeric' },
       linksCell
     ]
   }

--- a/src/server/land-grants/controllers/land-actions-check-page.controller.test.js
+++ b/src/server/land-grants/controllers/land-actions-check-page.controller.test.js
@@ -413,7 +413,7 @@ describe('LandActionsCheckPageController', () => {
       const result = controller.getAdditionalYearlyPayments(paymentData)
 
       expect(result[0].items[0][0].text).toBe('One-off payment per agreement per year for Management fee: MAN1')
-      expect(result[0].items[0][1].text).toBe('£50.00')
+      expect(result[0].items[0][1].html).toContain('£50.00')
     })
   })
 

--- a/src/server/land-grants/views/land-actions-check.html
+++ b/src/server/land-grants/views/land-actions-check.html
@@ -58,13 +58,12 @@
                 classes: "govuk-!-width-one-half"
               },
               {
-                text: "Quantity (ha)"
+                text: "Quantity (ha)",
+                format: "numeric"
               },
               {
-                text: "Yearly payment"
-              },
-              {
-                text: ""
+                text: "Yearly payment",
+                format: "numeric"
               },
               {
                 text: ""
@@ -91,7 +90,9 @@
                 classes: "govuk-!-width-two-thirds"
               },
               {
-                text: "Yearly payment"
+                html: "<div class='govuk-!-width-one-half'>Yearly payment</div>",
+                format: "numeric",
+                classes: "govuk-!-padding-right-5"
               }
             ],
             rows: item.items,


### PR DESCRIPTION
As per GOVUK guidelines, numeric values should be aligned to the right. Also, the yearly payments columns are on the same position between tables. 

Before:

<img width="1271" height="957" alt="image" src="https://github.com/user-attachments/assets/5f595188-3bd8-4fb1-b3dc-d3c406500817" />

After:

<img width="1271" height="957" alt="image" src="https://github.com/user-attachments/assets/ddcfedd0-e38c-47e6-9842-8118620581f8" />

