### PR TITLE
Restrict farmers to only Add/Edit/Delete/View land actions for land parcels they own

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,7 @@ export default [
   {
     rules: {
       'no-console': 'error',
-
+      curly: ['error', 'all'],
       '@stylistic/space-before-function-paren': 'off',
       '@stylistic/quotes': 'off',
       '@stylistic/eol-last': 'off',

--- a/src/plugins/auth.test.js
+++ b/src/plugins/auth.test.js
@@ -179,15 +179,21 @@ const createMockConfigWithOverrides = (overrides = {}) => {
 
 const createMockError = (message, name = 'Error', stack = null) => {
   const error = new Error(message)
-  if (name) error.name = name
-  if (stack) error.stack = stack
+  if (name) {
+    error.name = name
+  }
+  if (stack) {
+    error.stack = stack
+  }
   return error
 }
 
 vi.mock('~/src/config/config', () => ({
   config: {
     get: vi.fn((key) => {
-      if (key === 'defraId.enabled') return true
+      if (key === 'defraId.enabled') {
+        return true
+      }
       return undefined
     })
   }
@@ -777,7 +783,9 @@ describe('Auth Plugin', () => {
       const options = getCookieOptions()
 
       config.get.mockImplementation((key) => {
-        if (key === 'defraId.refreshTokens') return false
+        if (key === 'defraId.refreshTokens') {
+          return false
+        }
 
         const mockConfig = {
           'defraId.enabled': true,

--- a/src/server/common/helpers/redis-client.test.js
+++ b/src/server/common/helpers/redis-client.test.js
@@ -30,8 +30,12 @@ describe('#buildRedisClient', () => {
 
     test('Should log Redis connect and error events', () => {
       const mockOn = vi.fn((event, cb) => {
-        if (event === 'connect') cb()
-        if (event === 'error') cb(new Error('fail'))
+        if (event === 'connect') {
+          cb()
+        }
+        if (event === 'error') {
+          cb(new Error('fail'))
+        }
       })
 
       vi.mocked(Redis).mockReturnValue({ on: mockOn })

--- a/src/server/common/helpers/state/backend-auth-helper.test.js
+++ b/src/server/common/helpers/state/backend-auth-helper.test.js
@@ -26,8 +26,12 @@ const TEST_HEADERS = {
 }
 
 const mockConfigGet = vi.fn((key) => {
-  if (key === 'session.cache.authToken') return 'default-token'
-  if (key === 'session.cache.encryptionKey') return TEST_ENCRYPTION_KEY
+  if (key === 'session.cache.authToken') {
+    return 'default-token'
+  }
+  if (key === 'session.cache.encryptionKey') {
+    return TEST_ENCRYPTION_KEY
+  }
   return null
 })
 

--- a/src/server/land-grants/controllers/auth/land-grants-question-with-auth-check.controller.js
+++ b/src/server/land-grants/controllers/auth/land-grants-question-with-auth-check.controller.js
@@ -1,6 +1,7 @@
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
 import { fetchParcels } from '~/src/server/land-grants/services/land-grants.service.js'
+import { stringifyParcel } from '~/src/server/land-grants/utils/format-parcel'
 
 export default class LandGrantsQuestionWithAuthCheckController extends QuestionPageController {
   landParcelsForSbi = []
@@ -12,15 +13,15 @@ export default class LandGrantsQuestionWithAuthCheckController extends QuestionP
 
   performAuthCheck = async (request, h) => {
     const landParcels = (await fetchParcels(request.auth.credentials.sbi)) || []
-    this.landParcelsForSbi = landParcels.map((parcel) => `${parcel.sheetId}-${parcel.parcelId}`)
+    this.landParcelsForSbi = landParcels.map((parcel) => stringifyParcel(parcel))
 
     if (!this.landParcelBelongsToSbi()) {
-      return this.renderUnauthorisedView(request, h)
+      return this.renderUnauthorisedView(h)
     }
     return null
   }
 
-  renderUnauthorisedView = (request, h) => {
+  renderUnauthorisedView = (h) => {
     return h.response(h.view('unauthorised')).code(statusCodes.forbidden)
   }
 }

--- a/src/server/land-grants/controllers/auth/land-grants-question-with-auth-check.controller.js
+++ b/src/server/land-grants/controllers/auth/land-grants-question-with-auth-check.controller.js
@@ -1,0 +1,26 @@
+import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
+import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+import { fetchParcels } from '~/src/server/land-grants/services/land-grants.service.js'
+
+export default class LandGrantsQuestionWithAuthCheckController extends QuestionPageController {
+  landParcelsForSbi = []
+  selectedLandParcel = ''
+
+  landParcelBelongsToSbi = () => {
+    return this.landParcelsForSbi.includes(this.selectedLandParcel)
+  }
+
+  performAuthCheck = async (request, h) => {
+    const landParcels = (await fetchParcels(request.auth.credentials.sbi)) || []
+    this.landParcelsForSbi = landParcels.map((parcel) => `${parcel.sheetId}-${parcel.parcelId}`)
+
+    if (!this.landParcelBelongsToSbi()) {
+      return this.renderUnauthorisedView(request, h)
+    }
+    return null
+  }
+
+  renderUnauthorisedView = (request, h) => {
+    return h.response(h.view('unauthorised')).code(statusCodes.forbidden)
+  }
+}

--- a/src/server/land-grants/controllers/auth/land-grants-question-with-auth-check.controller.test.js
+++ b/src/server/land-grants/controllers/auth/land-grants-question-with-auth-check.controller.test.js
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import LandGrantsQuestionWithAuthCheckController from './land-grants-question-with-auth-check.controller'
+import { fetchParcels } from '../../services/land-grants.service'
+vi.mock('~/src/server/land-grants/services/land-grants.service.js', () => ({
+  fetchParcels: vi.fn()
+}))
+
+describe('LandGrantsQuestionWithAuthCheckController', () => {
+  let controller
+  let mockRequest
+  let mockH
+
+  beforeEach(() => {
+    controller = new LandGrantsQuestionWithAuthCheckController()
+    mockRequest = {
+      auth: {
+        credentials: {
+          crn: '1234567890',
+          sbi: '987654321'
+        }
+      }
+    }
+    mockH = {
+      response: vi.fn().mockReturnThis(),
+      view: vi.fn(),
+      code: vi.fn()
+    }
+
+    fetchParcels.mockResolvedValue([
+      { sheetId: 'SD7946', parcelId: '0155' },
+      { sheetId: 'SD7846', parcelId: '4509' }
+    ])
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('landParcelBelongsToSbi', () => {
+    test('returns true if selectedLandParcel is in landParcelsForSbi', () => {
+      controller.landParcelsForSbi = ['sheet1-parcel1', 'sheet2-parcel2']
+      controller.selectedLandParcel = 'sheet1-parcel1'
+
+      const result = controller.landParcelBelongsToSbi()
+
+      expect(result).toBe(true)
+    })
+
+    test('returns false if selectedLandParcel is not in landParcelsForSbi', () => {
+      controller.landParcelsForSbi = ['sheet1-parcel1', 'sheet2-parcel2']
+      controller.selectedLandParcel = 'sheet3-parcel3'
+
+      const result = controller.landParcelBelongsToSbi()
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('performAuthCheck', () => {
+    test('fetches parcels and calls renderUnauthorisedView if parcel does not belong to SBI', async () => {
+      fetchParcels.mockResolvedValue([{ sheetId: 'sheet1', parcelId: 'parcel1' }])
+      controller.landParcelsForSbi = []
+      controller.selectedLandParcel = 'sheet3-parcel3'
+      vi.spyOn(controller, 'renderUnauthorisedView')
+
+      await controller.performAuthCheck(mockRequest, mockH)
+
+      expect(fetchParcels).toHaveBeenCalledWith(mockRequest.auth.credentials.sbi)
+      expect(controller.renderUnauthorisedView).toHaveBeenCalledWith(mockRequest, mockH)
+    })
+
+    test('returns null if parcel belongs to SBI', async () => {
+      fetchParcels.mockResolvedValue([{ sheetId: 'sheet1', parcelId: 'parcel1' }])
+      controller.selectedLandParcel = 'sheet1-parcel1'
+
+      const result = await controller.performAuthCheck(mockRequest, mockH)
+
+      expect(fetchParcels).toHaveBeenCalledWith(mockRequest.auth.credentials.sbi)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('renderUnauthorisedView', () => {
+    test('returns a forbidden response', () => {
+      controller.renderUnauthorisedView(mockRequest, mockH)
+
+      expect(mockH.response).toHaveBeenCalledWith(mockH.view('unauthorised'))
+      expect(mockH.response().code).toHaveBeenCalledWith(403)
+    })
+  })
+})

--- a/src/server/land-grants/controllers/auth/land-grants-question-with-auth-check.controller.test.js
+++ b/src/server/land-grants/controllers/auth/land-grants-question-with-auth-check.controller.test.js
@@ -66,7 +66,7 @@ describe('LandGrantsQuestionWithAuthCheckController', () => {
       await controller.performAuthCheck(mockRequest, mockH)
 
       expect(fetchParcels).toHaveBeenCalledWith(mockRequest.auth.credentials.sbi)
-      expect(controller.renderUnauthorisedView).toHaveBeenCalledWith(mockRequest, mockH)
+      expect(controller.renderUnauthorisedView).toHaveBeenCalledWith(mockH)
     })
 
     test('returns null if parcel belongs to SBI', async () => {
@@ -82,7 +82,7 @@ describe('LandGrantsQuestionWithAuthCheckController', () => {
 
   describe('renderUnauthorisedView', () => {
     test('returns a forbidden response', () => {
-      controller.renderUnauthorisedView(mockRequest, mockH)
+      controller.renderUnauthorisedView(mockH)
 
       expect(mockH.response).toHaveBeenCalledWith(mockH.view('unauthorised'))
       expect(mockH.response().code).toHaveBeenCalledWith(403)

--- a/src/server/land-grants/controllers/land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/land-parcel-page.controller.js
@@ -1,10 +1,10 @@
-import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { fetchParcels } from '../services/land-grants.service.js'
+import LandGrantsQuestionWithAuthCheckController from '~/src/server/land-grants/controllers/auth/land-grants-question-with-auth-check.controller.js'
 
 const logger = createLogger()
 
-export default class LandParcelPageController extends QuestionPageController {
+export default class LandParcelPageController extends LandGrantsQuestionWithAuthCheckController {
   viewName = 'select-land-parcel'
   parcels = []
 
@@ -41,6 +41,11 @@ export default class LandParcelPageController extends QuestionPageController {
       const { state } = context
       const payload = request.payload ?? {}
       const { selectedLandParcel, action } = payload
+
+      this.selectedLandParcel = selectedLandParcel
+
+      const authResult = await this.performAuthCheck(request, context, h)
+      if (authResult) return authResult
 
       if (action === 'validate' && !selectedLandParcel) {
         return h.view(this.viewName, {

--- a/src/server/land-grants/controllers/land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/land-parcel-page.controller.js
@@ -45,7 +45,9 @@ export default class LandParcelPageController extends LandGrantsQuestionWithAuth
       this.selectedLandParcel = selectedLandParcel
 
       const authResult = await this.performAuthCheck(request, context, h)
-      if (authResult) return authResult
+      if (authResult) {
+        return authResult
+      }
 
       if (action === 'validate' && !selectedLandParcel) {
         return h.view(this.viewName, {

--- a/src/server/land-grants/controllers/remove-action-page.controller.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.js
@@ -177,7 +177,9 @@ export default class RemoveActionPageController extends LandGrantsQuestionWithAu
       this.selectedLandParcel = parcelKey
 
       const authResult = await this.performAuthCheck(request, context, h)
-      if (authResult) return authResult
+      if (authResult) {
+        return authResult
+      }
 
       const actionInfo = this.findActionInfo(landParcels, parcelKey, action)
 
@@ -201,7 +203,9 @@ export default class RemoveActionPageController extends LandGrantsQuestionWithAu
       this.selectedLandParcel = this.parcel
 
       const authResult = await this.performAuthCheck(request, context, h)
-      if (authResult) return authResult
+      if (authResult) {
+        return authResult
+      }
 
       const validationError = this.validatePostPayload(payload)
       if (validationError) {

--- a/src/server/land-grants/controllers/remove-action-page.controller.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.js
@@ -1,11 +1,11 @@
-import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
+import LandGrantsQuestionWithAuthCheckController from '~/src/server/land-grants/controllers/auth/land-grants-question-with-auth-check.controller.js'
 import { parseLandParcel } from '../utils/format-parcel.js'
 
 const checkSelectedLandActionsPath = '/check-selected-land-actions'
 const selectActionsForParcelPath = '/select-actions-for-land-parcel'
 const selectLandParcelPath = '/select-land-parcel'
 
-export default class RemoveActionPageController extends QuestionPageController {
+export default class RemoveActionPageController extends LandGrantsQuestionWithAuthCheckController {
   viewName = 'remove-action'
   parcel = ''
   actionDescription = ''
@@ -174,6 +174,11 @@ export default class RemoveActionPageController extends QuestionPageController {
       if (!parcel) {
         return this.proceed(request, h, checkSelectedLandActionsPath)
       }
+      this.selectedLandParcel = parcelKey
+
+      const authResult = await this.performAuthCheck(request, context, h)
+      if (authResult) return authResult
+
       const actionInfo = this.findActionInfo(landParcels, parcelKey, action)
 
       this.action = action
@@ -192,6 +197,11 @@ export default class RemoveActionPageController extends QuestionPageController {
     return async (request, context, h) => {
       const { state } = context
       const payload = request.payload ?? {}
+
+      this.selectedLandParcel = this.parcel
+
+      const authResult = await this.performAuthCheck(request, context, h)
+      if (authResult) return authResult
 
       const validationError = this.validatePostPayload(payload)
       if (validationError) {

--- a/src/server/land-grants/controllers/remove-action-page.controller.test.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.test.js
@@ -1,4 +1,3 @@
-import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import RemoveActionPageController from './remove-action-page.controller.js'
 
@@ -35,20 +34,32 @@ describe('RemoveActionPageController', () => {
   }
 
   beforeEach(() => {
-    QuestionPageController.prototype.getViewModel = vi.fn().mockReturnValue({
-      pageTitle: 'Remove action'
-    })
-
     controller = new RemoveActionPageController()
     controller.setState = vi.fn().mockResolvedValue(true)
     controller.proceed = vi.fn().mockReturnValue('redirected')
+    controller.performAuthCheck = vi.fn().mockResolvedValue(null)
+    controller.getViewModel = vi.fn().mockReturnValue({
+      pageTitle: 'Remove action'
+    })
 
     mockRequest = {
       query: {
         parcelId: 'SD6743-8083',
         action: 'CMOR1'
       },
-      payload: {}
+      payload: {},
+      auth: {
+        isAuthenticated: true,
+        credentials: {
+          sbi: '106284736',
+          crn: '1102838829',
+          name: 'John Doe',
+          organisationId: 'org123',
+          organisationName: ' Farm 1',
+          role: 'admin',
+          sessionId: 'valid-session-id'
+        }
+      }
     }
 
     mockContext = {
@@ -390,6 +401,7 @@ describe('RemoveActionPageController', () => {
     test('should render error view with all properties', () => {
       controller.parcel = 'SD6743-8083'
       controller.actionDescription = 'Test Action Description'
+      controller.performAuthCheck = vi.fn().mockResolvedValue(null)
 
       const result = controller.renderPostErrorView(mockH, mockRequest, mockContext, 'Test error message')
 
@@ -635,6 +647,7 @@ describe('RemoveActionPageController', () => {
 
     test('should show validation error when remove not provided and actionDescription exists', async () => {
       mockRequest.payload = {}
+      controller.performAuthCheck = vi.fn().mockResolvedValue(false)
 
       const handler = controller.makePostRouteHandler()
       const result = await handler(mockRequest, mockContext, mockH)

--- a/src/server/land-grants/controllers/remove-action-page.controller.test.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.test.js
@@ -636,6 +636,18 @@ describe('RemoveActionPageController', () => {
       })
       expect(result).toBe('rendered view')
     })
+
+    describe('when the user does not own the land parcel', () => {
+      it('should return unauthorized response when user does not own the selected land parcel', async () => {
+        controller.performAuthCheck.mockResolvedValue('failed auth check')
+
+        const handler = controller.makeGetRouteHandler()
+
+        const result = await handler(mockRequest, mockContext, mockH)
+
+        expect(result).toEqual('failed auth check')
+      })
+    })
   })
 
   describe('makePostRouteHandler', () => {
@@ -786,6 +798,18 @@ describe('RemoveActionPageController', () => {
         })
       )
       expect(result).toBe('rendered view')
+    })
+
+    describe('when the user does not own the land parcel', () => {
+      it('should return unauthorized response when user does not own the selected land parcel', async () => {
+        controller.performAuthCheck.mockResolvedValue('failed auth check')
+
+        const handler = controller.makePostRouteHandler()
+
+        const result = await handler(mockRequest, mockContext, mockH)
+
+        expect(result).toEqual('failed auth check')
+      })
     })
   })
 })

--- a/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
@@ -1,8 +1,8 @@
-import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import {
   fetchAvailableActionsForParcel,
   triggerApiActionsValidation
 } from '~/src/server/land-grants/services/land-grants.service.js'
+import LandGrantsQuestionWithAuthCheckController from '~/src/server/land-grants/controllers/auth/land-grants-question-with-auth-check.controller.js'
 import { parseLandParcel } from '~/src/server/land-grants/utils/format-parcel.js'
 
 const createErrorSummary = (errors) =>
@@ -11,12 +11,11 @@ const createErrorSummary = (errors) =>
     href: `#${field}`
   }))
 
-export default class SelectActionsForLandParcelPageController extends QuestionPageController {
+export default class SelectActionsForLandParcelPageController extends LandGrantsQuestionWithAuthCheckController {
   viewName = 'select-actions-for-land-parcel'
   actionFieldPrefix = 'landAction_'
   groupedActions = []
   addedActions = []
-  selectedLandParcel = ''
 
   extractLandActionFieldsFromPayload(payload) {
     return Object.keys(payload).filter((key) => key.startsWith(this.actionFieldPrefix))
@@ -335,6 +334,9 @@ export default class SelectActionsForLandParcelPageController extends QuestionPa
       this.selectedLandParcel = request?.query?.parcelId || state.selectedLandParcel
       const [sheetId = '', parcelId = ''] = parseLandParcel(this.selectedLandParcel)
 
+      const authResult = await this.performAuthCheck(request, context, h)
+      if (authResult) return authResult
+
       try {
         this.groupedActions = await fetchAvailableActionsForParcel({ parcelId, sheetId })
         if (!this.groupedActions.length) {
@@ -380,6 +382,9 @@ export default class SelectActionsForLandParcelPageController extends QuestionPa
       const { state } = context
       const payload = request.payload ?? {}
       const [sheetId, parcelId] = parseLandParcel(this.selectedLandParcel)
+
+      const authResult = await this.performAuthCheck(request, context, h)
+      if (authResult) return authResult
 
       const inputValidation = this.validateUserInput(payload)
       if (Object.keys(inputValidation.errors).length > 0) {

--- a/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
@@ -335,7 +335,9 @@ export default class SelectActionsForLandParcelPageController extends LandGrants
       const [sheetId = '', parcelId = ''] = parseLandParcel(this.selectedLandParcel)
 
       const authResult = await this.performAuthCheck(request, context, h)
-      if (authResult) return authResult
+      if (authResult) {
+        return authResult
+      }
 
       try {
         this.groupedActions = await fetchAvailableActionsForParcel({ parcelId, sheetId })
@@ -384,7 +386,9 @@ export default class SelectActionsForLandParcelPageController extends LandGrants
       const [sheetId, parcelId] = parseLandParcel(this.selectedLandParcel)
 
       const authResult = await this.performAuthCheck(request, context, h)
-      if (authResult) return authResult
+      if (authResult) {
+        return authResult
+      }
 
       const inputValidation = this.validateUserInput(payload)
       if (Object.keys(inputValidation.errors).length > 0) {

--- a/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.test.js
@@ -3,6 +3,7 @@ import { vi } from 'vitest'
 import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
 import {
   fetchAvailableActionsForParcel,
+  fetchParcels,
   triggerApiActionsValidation
 } from '~/src/server/land-grants/services/land-grants.service.js'
 import { parseLandParcel } from '~/src/server/land-grants/utils/format-parcel.js'
@@ -11,11 +12,25 @@ import SelectActionsForLandParcelPageController from './select-actions-for-land-
 vi.mock('~/src/server/land-grants/services/land-grants.service.js')
 vi.mock('~/src/server/land-grants/utils/format-parcel.js')
 
+const mockParcelsResponse = [
+  {
+    parcelId: '0155',
+    sheetId: 'SD7946',
+    area: { unit: 'ha', value: 4.0383 }
+  },
+  {
+    parcelId: '4509',
+    sheetId: 'SD7846',
+    area: { unit: 'sqm', value: 0.0633 }
+  }
+]
+
 describe('SelectActionsForLandParcelPageController', () => {
   let controller
   let mockRequest
   let mockContext
   let mockH
+  let mockResponseWithCode
 
   const mockGroupedActions = [
     {
@@ -80,6 +95,9 @@ describe('SelectActionsForLandParcelPageController', () => {
     controller.setState = vi.fn().mockResolvedValue(true)
     controller.proceed = vi.fn().mockReturnValue('redirected')
     controller.getNextPath = vi.fn().mockReturnValue('/next-path')
+    controller.performAuthCheck = vi.fn().mockResolvedValue(null)
+
+    fetchParcels.mockResolvedValue(mockParcelsResponse)
 
     mockRequest = {
       payload: {
@@ -103,8 +121,13 @@ describe('SelectActionsForLandParcelPageController', () => {
       state: {}
     }
 
+    mockResponseWithCode = {
+      code: vi.fn().mockReturnValue('final-response')
+    }
+
     mockH = {
-      view: vi.fn().mockReturnValue('rendered view')
+      view: vi.fn().mockReturnValue('rendered view'),
+      response: vi.fn().mockReturnValue(mockResponseWithCode)
     }
 
     parseLandParcel.mockReturnValue(['sheet1', 'parcel1'])

--- a/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.test.js
@@ -630,6 +630,16 @@ describe('SelectActionsForLandParcelPageController', () => {
         sheetId: ''
       })
     })
+
+    describe('when the user does not own the land parcel', () => {
+      it('should return unauthorized response when user does not own the selected land parcel', async () => {
+        controller.performAuthCheck.mockResolvedValue('failed auth check')
+
+        const result = await controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
+
+        expect(result).toEqual('failed auth check')
+      })
+    })
   })
 
   describe('POST route handler', () => {
@@ -751,6 +761,16 @@ describe('SelectActionsForLandParcelPageController', () => {
           }
         })
       )
+    })
+
+    describe('when the user does not own the land parcel', () => {
+      it('should return unauthorized response when user does not own the selected land parcel', async () => {
+        controller.performAuthCheck.mockResolvedValue('failed auth check')
+
+        const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+
+        expect(result).toEqual('failed auth check')
+      })
     })
 
     describe('validations', () => {

--- a/src/server/land-grants/views/unauthorised.html
+++ b/src/server/land-grants/views/unauthorised.html
@@ -1,0 +1,17 @@
+{% extends baseLayoutPath %}
+
+{% block pageTitle %}
+  Unauthorised access
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Unauthorised access</h1>
+
+    <p class="govuk-body">
+      You do not have permission to view or modify land actions for this land parcel.
+    </p>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Use a list of Land Parcels from DAL to determine whether the select land parcel is own by the users SBI before allowing them to Add/Edit/Delete/View

When a farmer tries to access a land parcel that their SBI does not own then they will see the following page

<img width="1090" height="806" alt="image" src="https://github.com/user-attachments/assets/85f838bc-2744-4991-810f-982ebf5f3360" />
