### PR TITLE
Add `performAuthCheck` verification in tests & call it correctly

### DIFF
--- a/src/server/land-grants/controllers/land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/land-parcel-page.controller.js
@@ -44,7 +44,7 @@ export default class LandParcelPageController extends LandGrantsQuestionWithAuth
 
       this.selectedLandParcel = selectedLandParcel
 
-      const authResult = await this.performAuthCheck(request, context, h)
+      const authResult = await this.performAuthCheck(request, h)
       if (authResult) {
         return authResult
       }

--- a/src/server/land-grants/controllers/land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/land-parcel-page.controller.test.js
@@ -256,6 +256,7 @@ describe('LandParcelPageController', () => {
 
       const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
 
+      expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH)
       expect(controller.setState).toHaveBeenCalledWith(mockRequest, {
         existing: 'value',
         selectedLandParcel: state.selectedLandParcel

--- a/src/server/land-grants/controllers/remove-action-page.controller.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.js
@@ -176,7 +176,7 @@ export default class RemoveActionPageController extends LandGrantsQuestionWithAu
       }
       this.selectedLandParcel = parcelKey
 
-      const authResult = await this.performAuthCheck(request, context, h)
+      const authResult = await this.performAuthCheck(request, h)
       if (authResult) {
         return authResult
       }
@@ -202,7 +202,7 @@ export default class RemoveActionPageController extends LandGrantsQuestionWithAu
 
       this.selectedLandParcel = this.parcel
 
-      const authResult = await this.performAuthCheck(request, context, h)
+      const authResult = await this.performAuthCheck(request, h)
       if (authResult) {
         return authResult
       }

--- a/src/server/land-grants/controllers/remove-action-page.controller.test.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.test.js
@@ -564,6 +564,7 @@ describe('RemoveActionPageController', () => {
 
       const result = await handler(mockRequest, mockContext, mockH)
 
+      expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH)
       expect(controller.action).toBe('CMOR1')
       expect(controller.parcel).toBe('SD6743-8083')
       expect(controller.actionDescription).toBe('Assess moorland and produce a written record: CMOR1')
@@ -645,6 +646,8 @@ describe('RemoveActionPageController', () => {
 
         const result = await handler(mockRequest, mockContext, mockH)
 
+        expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH)
+
         expect(result).toEqual('failed auth check')
       })
     })
@@ -696,6 +699,8 @@ describe('RemoveActionPageController', () => {
 
       const handler = controller.makePostRouteHandler()
       const result = await handler(mockRequest, mockContext, mockH)
+
+      expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH)
 
       expect(controller.setState).toHaveBeenCalledWith(
         mockRequest,
@@ -807,6 +812,8 @@ describe('RemoveActionPageController', () => {
         const handler = controller.makePostRouteHandler()
 
         const result = await handler(mockRequest, mockContext, mockH)
+
+        expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH)
 
         expect(result).toEqual('failed auth check')
       })

--- a/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.js
@@ -334,7 +334,7 @@ export default class SelectActionsForLandParcelPageController extends LandGrants
       this.selectedLandParcel = request?.query?.parcelId || state.selectedLandParcel
       const [sheetId = '', parcelId = ''] = parseLandParcel(this.selectedLandParcel)
 
-      const authResult = await this.performAuthCheck(request, context, h)
+      const authResult = await this.performAuthCheck(request, h)
       if (authResult) {
         return authResult
       }
@@ -385,7 +385,7 @@ export default class SelectActionsForLandParcelPageController extends LandGrants
       const payload = request.payload ?? {}
       const [sheetId, parcelId] = parseLandParcel(this.selectedLandParcel)
 
-      const authResult = await this.performAuthCheck(request, context, h)
+      const authResult = await this.performAuthCheck(request, h)
       if (authResult) {
         return authResult
       }

--- a/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-actions-for-land-parcel-page.controller.test.js
@@ -537,6 +537,8 @@ describe('SelectActionsForLandParcelPageController', () => {
       const handler = controller.makeGetRouteHandler()
       await handler(mockRequest, mockContext, mockH)
 
+      expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH)
+
       expect(parseLandParcel).toHaveBeenCalledWith('sheet1-parcel1')
       expect(fetchAvailableActionsForParcel).toHaveBeenCalledWith({
         parcelId: 'parcel1',
@@ -637,6 +639,8 @@ describe('SelectActionsForLandParcelPageController', () => {
 
         const result = await controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
 
+        expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH)
+
         expect(result).toEqual('failed auth check')
       })
     })
@@ -664,6 +668,8 @@ describe('SelectActionsForLandParcelPageController', () => {
           }
         })
       )
+
+      expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH)
 
       expect(controller.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/next-path')
       expect(result).toBe('redirected')
@@ -768,6 +774,8 @@ describe('SelectActionsForLandParcelPageController', () => {
         controller.performAuthCheck.mockResolvedValue('failed auth check')
 
         const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+
+        expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH)
 
         expect(result).toEqual('failed auth check')
       })


### PR DESCRIPTION
I accidentally called performAuthCheck with three arguments rather than two. I have also added some specs to catch this sort of error out again.