### PR TITLE
Reorder `performAuthCheck` to execute after validation logic in `select-land-parcel-page.controller`. Update tests accordingly.

### DIFF
--- a/src/server/land-grants/controllers/select-land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/select-land-parcel-page.controller.js
@@ -44,11 +44,6 @@ export default class SelectLandParcelPageController extends LandGrantsQuestionWi
 
       this.selectedLandParcel = selectedLandParcel
 
-      const authResult = await this.performAuthCheck(request, h)
-      if (authResult) {
-        return authResult
-      }
-
       if (action === 'validate' && !selectedLandParcel) {
         return h.view(this.viewName, {
           ...super.getViewModel(request, context),
@@ -56,6 +51,11 @@ export default class SelectLandParcelPageController extends LandGrantsQuestionWi
           parcels: this.parcels,
           errorMessage: 'Please select a land parcel from the list'
         })
+      }
+
+      const authResult = await this.performAuthCheck(request, h)
+      if (authResult) {
+        return authResult
       }
 
       await this.setState(request, {

--- a/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
@@ -285,6 +285,7 @@ describe('SelectLandParcelPageController', () => {
 
       expect(controller.setState).not.toHaveBeenCalled()
       expect(controller.proceed).not.toHaveBeenCalled()
+      expect(controller.performAuthCheck).not.toHaveBeenCalled()
       expect(mockH.view).toHaveBeenCalledWith(
         'select-land-parcel',
         expect.objectContaining({


### PR DESCRIPTION
…ct-land-parcel-page.controller`. Update tests accordingly.