### PR TITLE
Fix styling of signout link

### DIFF
--- a/src/server/common/components/account-bar/template.njk
+++ b/src/server/common/components/account-bar/template.njk
@@ -9,11 +9,11 @@
         </div>
 
         <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-2 defra-account-bar__headings defra-account-bar__headings--right-aligned">
-          <span class="govuk-!-display-block">
-            <span class="govuk-visually-hidden">Signed in as </span>
-            {{ params.name }}
-          </span>
-          <a class="govuk-!-font-size-16 govuk-link--no-underline" href="/auth/sign-out">Sign out</a>
+          <span class="govuk-visually-hidden">Signed in as </span>
+          {{ params.name }}
+          <div class="govuk-!-font-size-16 govuk-!-font-weight-regular govuk-!-margin-top-1"">
+            <a class="govuk-link govuk-link--no-visited-state" href="/auth/sign-out">Sign out</a>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Use GOV.UK Lint styling rather than default browser font colour
- Change sign-out link font weight to regular so it's not so dominant  on the page

### Before
<img width="1030" height="257" alt="image" src="https://github.com/user-attachments/assets/a3a3b58e-e622-4fbb-849a-2e1d7df0aa6d" />

### After
<img width="995" height="253" alt="image" src="https://github.com/user-attachments/assets/e7c44653-3162-4d8f-a2ad-6f692529913d" />
