### PR TITLE
Use pull_policy:always for acceptance tests image

### DIFF
--- a/acceptance/gae-compose.yml
+++ b/acceptance/gae-compose.yml
@@ -2,6 +2,7 @@ services:
  
   gae-acceptance-tests:
     image: defradigital/grants-ui-acceptance-tests
+    pull_policy: always
     depends_on:
       selenium-chrome:
         condition: service_healthy


### PR DESCRIPTION
As per the grants-ui-backend and ffc-grants-scoring images, ensure we always pull the latest test suite when working with acceptance tests.