### PR TITLE
Update land parcels in the mock dal data

### DIFF
--- a/src/server/common/services/consolidated-view/land-data/106238911.json
+++ b/src/server/common/services/consolidated-view/land-data/106238911.json
@@ -7,153 +7,123 @@
         "parcels": [
           {
             "parcelId": "0155",
-            "sheetId": "SD7946",
-            "area": 4.0383
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "4509",
-            "sheetId": "SD7846",
-            "area": 0.0633
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "7245",
-            "sheetId": "SD7846",
-            "area": 6.7412
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "0926",
-            "sheetId": "SD7846",
-            "area": 1.7908
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "9135",
-            "sheetId": "SD7846",
-            "area": 2.9989
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "0638",
-            "sheetId": "SD7946",
-            "area": 0.9335
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "1215",
-            "sheetId": "SD7846",
-            "area": 0.0972
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "0617",
-            "sheetId": "SD7846",
-            "area": 0.7099
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "7013",
-            "sheetId": "SD7846",
-            "area": 8.9902
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "0155",
-            "sheetId": "SD7642",
-            "area": 1.2324
+            "sheetId": "SD7642"
           },
           {
             "parcelId": "0412",
-            "sheetId": "SD7846",
-            "area": 0.4666
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "4503",
-            "sheetId": "SD7846",
-            "area": 0.7252
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "5103",
-            "sheetId": "SD7846",
-            "area": 0.0585
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "5197",
-            "sheetId": "SD7845",
-            "area": 0.9849
+            "sheetId": "SD7845"
           },
           {
             "parcelId": "9420",
-            "sheetId": "SD7746",
-            "area": 0.1854
+            "sheetId": "SD7746"
           },
           {
             "parcelId": "2147",
-            "sheetId": "SD7946",
-            "area": 2.5796
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "1533",
-            "sheetId": "SD7946",
-            "area": 3.2249
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "9538",
-            "sheetId": "SD7542",
-            "area": 1.2224
+            "sheetId": "SD7542"
           },
           {
             "parcelId": "2024",
-            "sheetId": "SD7846",
-            "area": 0.8704
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "8954",
-            "sheetId": "SD7846",
-            "area": 2.5109
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "5637",
-            "sheetId": "SD7846",
-            "area": 3.5502
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "8408",
-            "sheetId": "SD7746",
-            "area": 7.2496
+            "sheetId": "SD7746"
           },
           {
             "parcelId": "1162",
-            "sheetId": "SD7946",
-            "area": 2.2103
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "0345",
-            "sheetId": "SD7642",
-            "area": 2.3867
+            "sheetId": "SD7642"
           },
           {
             "parcelId": "4510",
-            "sheetId": "SD7846",
-            "area": 0.0368
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "5112",
-            "sheetId": "SD7846",
-            "area": 0.4277
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "4624",
-            "sheetId": "SD7846",
-            "area": 3.4107
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "4156",
-            "sheetId": "SD7946",
-            "area": 5.1567
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "5465",
-            "sheetId": "SD7946",
-            "area": 1.2932
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "2533",
-            "sheetId": "SD7946",
-            "area": 0.1052
+            "sheetId": "SD7946"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/106238988.json
+++ b/src/server/common/services/consolidated-view/land-data/106238988.json
@@ -7,153 +7,123 @@
         "parcels": [
           {
             "parcelId": "0155",
-            "sheetId": "SD7946",
-            "area": 4.0383
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "4509",
-            "sheetId": "SD7846",
-            "area": 0.0633
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "7245",
-            "sheetId": "SD7846",
-            "area": 6.7412
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "0926",
-            "sheetId": "SD7846",
-            "area": 1.7908
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "9135",
-            "sheetId": "SD7846",
-            "area": 2.9989
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "0638",
-            "sheetId": "SD7946",
-            "area": 0.9335
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "1215",
-            "sheetId": "SD7846",
-            "area": 0.0972
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "0617",
-            "sheetId": "SD7846",
-            "area": 0.7099
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "7013",
-            "sheetId": "SD7846",
-            "area": 8.9902
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "0155",
-            "sheetId": "SD7642",
-            "area": 1.2324
+            "sheetId": "SD7642"
           },
           {
             "parcelId": "0412",
-            "sheetId": "SD7846",
-            "area": 0.4666
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "4503",
-            "sheetId": "SD7846",
-            "area": 0.7252
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "5103",
-            "sheetId": "SD7846",
-            "area": 0.0585
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "5197",
-            "sheetId": "SD7845",
-            "area": 0.9849
+            "sheetId": "SD7845"
           },
           {
             "parcelId": "9420",
-            "sheetId": "SD7746",
-            "area": 0.1854
+            "sheetId": "SD7746"
           },
           {
             "parcelId": "2147",
-            "sheetId": "SD7946",
-            "area": 2.5796
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "1533",
-            "sheetId": "SD7946",
-            "area": 3.2249
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "9538",
-            "sheetId": "SD7542",
-            "area": 1.2224
+            "sheetId": "SD7542"
           },
           {
             "parcelId": "2024",
-            "sheetId": "SD7846",
-            "area": 0.8704
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "8954",
-            "sheetId": "SD7846",
-            "area": 2.5109
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "5637",
-            "sheetId": "SD7846",
-            "area": 3.5502
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "8408",
-            "sheetId": "SD7746",
-            "area": 7.2496
+            "sheetId": "SD7746"
           },
           {
             "parcelId": "1162",
-            "sheetId": "SD7946",
-            "area": 2.2103
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "0345",
-            "sheetId": "SD7642",
-            "area": 2.3867
+            "sheetId": "SD7642"
           },
           {
             "parcelId": "4510",
-            "sheetId": "SD7846",
-            "area": 0.0368
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "5112",
-            "sheetId": "SD7846",
-            "area": 0.4277
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "4624",
-            "sheetId": "SD7846",
-            "area": 3.4107
+            "sheetId": "SD7846"
           },
           {
             "parcelId": "4156",
-            "sheetId": "SD7946",
-            "area": 5.1567
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "5465",
-            "sheetId": "SD7946",
-            "area": 1.2932
+            "sheetId": "SD7946"
           },
           {
             "parcelId": "2533",
-            "sheetId": "SD7946",
-            "area": 0.1052
+            "sheetId": "SD7946"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/106284736.json
+++ b/src/server/common/services/consolidated-view/land-data/106284736.json
@@ -7,243 +7,195 @@
         "parcels": [
           {
             "parcelId": "7039",
-            "sheetId": "SD6843",
-            "area": 1.3308
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "6292",
-            "sheetId": "SD6743",
-            "area": 7.5713
+            "sheetId": "SD6743"
           },
           {
             "parcelId": "1785",
-            "sheetId": "SD6842",
-            "area": 4.6925
+            "sheetId": "SD6842"
           },
           {
             "parcelId": "8083",
-            "sheetId": "SD6743",
-            "area": 4.5341
+            "sheetId": "SD6743"
           },
           {
             "parcelId": "8120",
-            "sheetId": "SD6743",
-            "area": 2.9859
+            "sheetId": "SD6743"
           },
           {
             "parcelId": "2122",
-            "sheetId": "SD6843",
-            "area": 6.7943
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "4925",
-            "sheetId": "SD6843",
-            "area": 0.1638
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "8333",
-            "sheetId": "SD6743",
-            "area": 3.3189
+            "sheetId": "SD6743"
           },
           {
             "parcelId": "0307",
-            "sheetId": "SD6944",
-            "area": 4.9762
+            "sheetId": "SD6944"
           },
           {
             "parcelId": "9664",
-            "sheetId": "SD6843",
-            "area": 2.964
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "5533",
-            "sheetId": "SD6843",
-            "area": 3.0535
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "1162",
-            "sheetId": "SD6842",
-            "area": 2.7838
+            "sheetId": "SD6842"
           },
           {
             "parcelId": "7067",
-            "sheetId": "SD6844",
-            "area": 3.1023
+            "sheetId": "SD6844"
           },
           {
             "parcelId": "2399",
-            "sheetId": "SD6943",
-            "area": 3.0124
+            "sheetId": "SD6943"
           },
           {
             "parcelId": "8473",
-            "sheetId": "SD6743",
-            "area": 0.5824
+            "sheetId": "SD6743"
           },
           {
             "parcelId": "5426",
-            "sheetId": "SD6843",
-            "area": 0.0152
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "3088",
-            "sheetId": "SD6842",
-            "area": 0.0289
+            "sheetId": "SD6842"
           },
           {
             "parcelId": "8055",
-            "sheetId": "SD6743",
-            "area": 4.6998
+            "sheetId": "SD6743"
           },
           {
             "parcelId": "3979",
-            "sheetId": "SD6943",
-            "area": 7.1039
+            "sheetId": "SD6943"
           },
           {
             "parcelId": "5422",
-            "sheetId": "SD6743",
-            "area": 5.1299
+            "sheetId": "SD6743"
           },
           {
             "parcelId": "3514",
-            "sheetId": "SD6843",
-            "area": 3.2396
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "5580",
-            "sheetId": "SD6842",
-            "area": 2.5813
+            "sheetId": "SD6842"
           },
           {
             "parcelId": "4921",
-            "sheetId": "SD6843",
-            "area": 0.1087
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "3841",
-            "sheetId": "SD6843",
-            "area": 3.385
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "6455",
-            "sheetId": "SD6843",
-            "area": 5.7015
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "0447",
-            "sheetId": "SD6943",
-            "area": 8.7602
+            "sheetId": "SD6943"
           },
           {
             "parcelId": "1385",
-            "sheetId": "SD6943",
-            "area": 2.3609
+            "sheetId": "SD6943"
           },
           {
             "parcelId": "8467",
-            "sheetId": "SD6843",
-            "area": 3.0254
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "7272",
-            "sheetId": "SD6843",
-            "area": 1.6722
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "5461",
-            "sheetId": "SD6743",
-            "area": 9.0771
+            "sheetId": "SD6743"
           },
           {
             "parcelId": "7435",
-            "sheetId": "SD6843",
-            "area": 1.4056
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "7268",
-            "sheetId": "SD6743",
-            "area": 0.6564
+            "sheetId": "SD6743"
           },
           {
             "parcelId": "5419",
-            "sheetId": "SD6843",
-            "area": 0.3933
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "2447",
-            "sheetId": "SD6843",
-            "area": 3.5109
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "8889",
-            "sheetId": "SD6843",
-            "area": 5.132
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "4301",
-            "sheetId": "SD6843",
-            "area": 6.3008
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "4282",
-            "sheetId": "SD6842",
-            "area": 3.08
+            "sheetId": "SD6842"
           },
           {
             "parcelId": "0784",
-            "sheetId": "SD6842",
-            "area": 4.2022
+            "sheetId": "SD6842"
           },
           {
             "parcelId": "9977",
-            "sheetId": "SD6843",
-            "area": 1.2006
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "6006",
-            "sheetId": "SD6743",
-            "area": 3.4
+            "sheetId": "SD6743"
           },
           {
             "parcelId": "8077",
-            "sheetId": "SD6843",
-            "area": 0.0691
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "0882",
-            "sheetId": "SD6943",
-            "area": 0.0185
+            "sheetId": "SD6943"
           },
           {
             "parcelId": "0977",
-            "sheetId": "SD6943",
-            "area": 0.0315
+            "sheetId": "SD6943"
           },
           {
             "parcelId": "3625",
-            "sheetId": "SD6743",
-            "area": 4.0902
+            "sheetId": "SD6743"
           },
           {
             "parcelId": "5424",
-            "sheetId": "SD6843",
-            "area": 0.1642
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "9381",
-            "sheetId": "SD6843",
-            "area": 0.3822
+            "sheetId": "SD6843"
           },
           {
             "parcelId": "0085",
-            "sheetId": "SD6943",
-            "area": 0.5984
+            "sheetId": "SD6943"
           },
           {
             "parcelId": "9485",
-            "sheetId": "SD6843",
-            "area": 0.1447
+            "sheetId": "SD6843"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/121428499.json
+++ b/src/server/common/services/consolidated-view/land-data/121428499.json
@@ -8,512 +8,427 @@
           {
             "id": "4528473",
             "parcelId": "8781",
-            "sheetId": "SD6351",
-            "area": 68.0498
+            "sheetId": "SD6351"
           },
           {
             "id": "1957166",
             "parcelId": "8774",
-            "sheetId": "SD6352",
-            "area": 11.1006
+            "sheetId": "SD6352"
           },
           {
             "id": "6452787",
             "parcelId": "7537",
-            "sheetId": "SD6252",
-            "area": 0.3361
+            "sheetId": "SD6252"
           },
           {
             "id": "4976152",
             "parcelId": "3140",
-            "sheetId": "SD6950",
-            "area": 4.5699
+            "sheetId": "SD6950"
           },
           {
             "id": "6487326",
             "parcelId": "3232",
-            "sheetId": "SD5851",
-            "area": 42.2833
+            "sheetId": "SD5851"
           },
           {
             "id": "2026447",
             "parcelId": "7174",
-            "sheetId": "SD6251",
-            "area": 8.9349
+            "sheetId": "SD6251"
           },
           {
             "id": "2021709",
             "parcelId": "4310",
-            "sheetId": "SD6352",
-            "area": 6.5942
+            "sheetId": "SD6352"
           },
           {
             "id": "1902050",
             "parcelId": "8442",
-            "sheetId": "SD6252",
-            "area": 3.6248
+            "sheetId": "SD6252"
           },
           {
             "id": "1959466",
             "parcelId": "4413",
-            "sheetId": "SD6351",
-            "area": 3.0395
+            "sheetId": "SD6351"
           },
           {
             "id": "6611820",
             "parcelId": "5509",
-            "sheetId": "SD6252",
-            "area": 1.8477
+            "sheetId": "SD6252"
           },
           {
             "id": "2022012",
             "parcelId": "0161",
-            "sheetId": "SD6351",
-            "area": 2.436
+            "sheetId": "SD6351"
           },
           {
             "id": "1928160",
             "parcelId": "7889",
-            "sheetId": "SD6251",
-            "area": 0.3572
+            "sheetId": "SD6251"
           },
           {
             "id": "1961457",
             "parcelId": "4624",
-            "sheetId": "SD7155",
-            "area": 3.3462
+            "sheetId": "SD7155"
           },
           {
             "id": "1951009",
             "parcelId": "9861",
-            "sheetId": "SD6352",
-            "area": 1.7721
+            "sheetId": "SD6352"
           },
           {
             "id": "1984017",
             "parcelId": "3772",
-            "sheetId": "SD6352",
-            "area": 0.4845
+            "sheetId": "SD6352"
           },
           {
             "id": "7347864",
             "parcelId": "1441",
-            "sheetId": "SD6351",
-            "area": 0.9175
+            "sheetId": "SD6351"
           },
           {
             "id": "1993681",
             "parcelId": "2185",
-            "sheetId": "SD6351",
-            "area": 4.419
+            "sheetId": "SD6351"
           },
           {
             "id": "1941243",
             "parcelId": "2602",
-            "sheetId": "SD6353",
-            "area": 0.4599
+            "sheetId": "SD6353"
           },
           {
             "id": "6611821",
             "parcelId": "2415",
-            "sheetId": "SD6252",
-            "area": 64.1389
+            "sheetId": "SD6252"
           },
           {
             "id": "6452788",
             "parcelId": "8023",
-            "sheetId": "SD6252",
-            "area": 0.4578
+            "sheetId": "SD6252"
           },
           {
             "id": "6611822",
             "parcelId": "4796",
-            "sheetId": "SD6251",
-            "area": 1.8591
+            "sheetId": "SD6251"
           },
           {
             "id": "1902514",
             "parcelId": "3622",
-            "sheetId": "SD6252",
-            "area": 0.5482
+            "sheetId": "SD6252"
           },
           {
             "id": "4528495",
             "parcelId": "8609",
-            "sheetId": "SD7155",
-            "area": 7.5229
+            "sheetId": "SD7155"
           },
           {
             "id": "2032945",
             "parcelId": "6308",
-            "sheetId": "SD7155",
-            "area": 1.705
+            "sheetId": "SD7155"
           },
           {
             "id": "6457103",
             "parcelId": "2654",
-            "sheetId": "SD6351",
-            "area": 5.9945
+            "sheetId": "SD6351"
           },
           {
             "id": "6611828",
             "parcelId": "0998",
-            "sheetId": "SD6250",
-            "area": 1.7798
+            "sheetId": "SD6250"
           },
           {
             "id": "7290752",
             "parcelId": "7554",
-            "sheetId": "SD7155",
-            "area": 7.0501
+            "sheetId": "SD7155"
           },
           {
             "id": "2035937",
             "parcelId": "5164",
-            "sheetId": "SD6352",
-            "area": 6.3924
+            "sheetId": "SD6352"
           },
           {
             "id": "2043962",
             "parcelId": "4593",
-            "sheetId": "SD6352",
-            "area": 6.9321
+            "sheetId": "SD6352"
           },
           {
             "id": "6611826",
             "parcelId": "3851",
-            "sheetId": "SD6050",
-            "area": 2.0376
+            "sheetId": "SD6050"
           },
           {
             "id": "6611831",
             "parcelId": "8778",
-            "sheetId": "SD6150",
-            "area": 0.2202
+            "sheetId": "SD6150"
           },
           {
             "id": "6611833",
             "parcelId": "4796",
-            "sheetId": "SD6150",
-            "area": 0.3067
+            "sheetId": "SD6150"
           },
           {
             "id": "4636328",
             "parcelId": "4373",
-            "sheetId": "SD7255",
-            "area": 14.0581
+            "sheetId": "SD7255"
           },
           {
             "id": "1943822",
             "parcelId": "0872",
-            "sheetId": "SD7244",
-            "area": 3.0774
+            "sheetId": "SD7244"
           },
           {
             "id": "6611825",
             "parcelId": "9265",
-            "sheetId": "SD6050",
-            "area": 7.8436
+            "sheetId": "SD6050"
           },
           {
             "id": "6611832",
             "parcelId": "8088",
-            "sheetId": "SD6150",
-            "area": 0.4432
+            "sheetId": "SD6150"
           },
           {
             "id": "4528470",
             "parcelId": "6030",
-            "sheetId": "SD6252",
-            "area": 10.6865
+            "sheetId": "SD6252"
           },
           {
             "id": "6457105",
             "parcelId": "1332",
-            "sheetId": "SD6351",
-            "area": 0.1012
+            "sheetId": "SD6351"
           },
           {
             "id": "2005866",
             "parcelId": "6685",
-            "sheetId": "SD6252",
-            "area": 18.1473
+            "sheetId": "SD6252"
           },
           {
             "id": "2053766",
             "parcelId": "2465",
-            "sheetId": "SD7244",
-            "area": 4.5855
+            "sheetId": "SD7244"
           },
           {
             "id": "2037180",
             "parcelId": "8952",
-            "sheetId": "SD6251",
-            "area": 0.7196
+            "sheetId": "SD6251"
           },
           {
             "id": "2061561",
             "parcelId": "2253",
-            "sheetId": "SD6352",
-            "area": 6.458
+            "sheetId": "SD6352"
           },
           {
             "id": "2036519",
             "parcelId": "8868",
-            "sheetId": "SD6251",
-            "area": 0.1889
+            "sheetId": "SD6251"
           },
           {
             "id": "2039491",
             "parcelId": "2085",
-            "sheetId": "SD7244",
-            "area": 4.9215
+            "sheetId": "SD7244"
           },
           {
             "id": "2041277",
             "parcelId": "5174",
-            "sheetId": "SD6252",
-            "area": 12.2583
+            "sheetId": "SD6252"
           },
           {
             "id": "6611827",
             "parcelId": "1717",
-            "sheetId": "SD6151",
-            "area": 233.4926
+            "sheetId": "SD6151"
           },
           {
             "id": "6954670",
             "parcelId": "6001",
-            "sheetId": "SD6351",
-            "area": 1.795
+            "sheetId": "SD6351"
           },
           {
             "id": "1982723",
             "parcelId": "1073",
-            "sheetId": "SD6352",
-            "area": 13.7223
+            "sheetId": "SD6352"
           },
           {
             "id": "1927304",
             "parcelId": "8731",
-            "sheetId": "SD6352",
-            "area": 14.1486
+            "sheetId": "SD6352"
           },
           {
             "id": "6457104",
             "parcelId": "1766",
-            "sheetId": "SD6351",
-            "area": 2.1324
+            "sheetId": "SD6351"
           },
           {
             "id": "6102886",
             "parcelId": "4091",
-            "sheetId": "SD6351",
-            "area": 0.4614
+            "sheetId": "SD6351"
           },
           {
             "id": "6611824",
             "parcelId": "1739",
-            "sheetId": "SD6352",
-            "area": 2.7069
+            "sheetId": "SD6352"
           },
           {
             "id": "4636317",
             "parcelId": "2638",
-            "sheetId": "SD6251",
-            "area": 0.8531
+            "sheetId": "SD6251"
           },
           {
             "id": "1866216",
             "parcelId": "8047",
-            "sheetId": "SD6251",
-            "area": 1.5728
+            "sheetId": "SD6251"
           },
           {
             "id": "1990267",
             "parcelId": "9638",
-            "sheetId": "SD6252",
-            "area": 1.3588
+            "sheetId": "SD6252"
           },
           {
             "id": "6102880",
             "parcelId": "7605",
-            "sheetId": "SD6251",
-            "area": 0.7098
+            "sheetId": "SD6251"
           },
           {
             "id": "4636318",
             "parcelId": "4625",
-            "sheetId": "SD6251",
-            "area": 1.014
+            "sheetId": "SD6251"
           },
           {
             "id": "2003234",
             "parcelId": "3560",
-            "sheetId": "SD6352",
-            "area": 1.1954
+            "sheetId": "SD6352"
           },
           {
             "id": "2016423",
             "parcelId": "8789",
-            "sheetId": "SD6251",
-            "area": 5.2698
+            "sheetId": "SD6251"
           },
           {
             "id": "6456148",
             "parcelId": "7656",
-            "sheetId": "SD6352",
-            "area": 1.569
+            "sheetId": "SD6352"
           },
           {
             "id": "6456149",
             "parcelId": "5781",
-            "sheetId": "SD6352",
-            "area": 1.1351
+            "sheetId": "SD6352"
           },
           {
             "id": "6456150",
             "parcelId": "3193",
-            "sheetId": "SD6352",
-            "area": 1.0654
+            "sheetId": "SD6352"
           },
           {
             "id": "6456147",
             "parcelId": "3108",
-            "sheetId": "SD6353",
-            "area": 0.2791
+            "sheetId": "SD6353"
           },
           {
             "id": "1916529",
             "parcelId": "1921",
-            "sheetId": "SD6352",
-            "area": 29.6734
+            "sheetId": "SD6352"
           },
           {
             "id": "6742706",
             "parcelId": "9840",
-            "sheetId": "SD6050",
-            "area": 0.8242
+            "sheetId": "SD6050"
           },
           {
             "id": "6611823",
             "parcelId": "8726",
-            "sheetId": "SD6251",
-            "area": 8.308
+            "sheetId": "SD6251"
           },
           {
             "id": "6457108",
             "parcelId": "1426",
-            "sheetId": "SD6351",
-            "area": 0.43
+            "sheetId": "SD6351"
           },
           {
             "id": "6611830",
             "parcelId": "5078",
-            "sheetId": "SD6150",
-            "area": 2.892
+            "sheetId": "SD6150"
           },
           {
             "id": "4551399",
             "parcelId": "1028",
-            "sheetId": "SD6351",
-            "area": 0.8992
+            "sheetId": "SD6351"
           },
           {
             "id": "6742704",
             "parcelId": "8972",
-            "sheetId": "SD6150",
-            "area": 0.6489
+            "sheetId": "SD6150"
           },
           {
             "id": "4551398",
             "parcelId": "0615",
-            "sheetId": "SD6351",
-            "area": 2.5984
+            "sheetId": "SD6351"
           },
           {
             "id": "4551395",
             "parcelId": "9215",
-            "sheetId": "SD6251",
-            "area": 0.2104
+            "sheetId": "SD6251"
           },
           {
             "id": "6102881",
             "parcelId": "9232",
-            "sheetId": "SD6251",
-            "area": 1.1608
+            "sheetId": "SD6251"
           },
           {
             "id": "7298154",
             "parcelId": "5684",
-            "sheetId": "SD6049",
-            "area": 4.683
+            "sheetId": "SD6049"
           },
           {
             "id": "6101802",
             "parcelId": "6060",
-            "sheetId": "SD5949",
-            "area": 681.6199
+            "sheetId": "SD5949"
           },
           {
             "id": "4976153",
             "parcelId": "2440",
-            "sheetId": "SD6950",
-            "area": 0.1227
+            "sheetId": "SD6950"
           },
           {
             "id": "6102884",
             "parcelId": "6608",
-            "sheetId": "SD6353",
-            "area": 59.5602
+            "sheetId": "SD6353"
           },
           {
             "id": "6457106",
             "parcelId": "5181",
-            "sheetId": "SD6351",
-            "area": 10.6684
+            "sheetId": "SD6351"
           },
           {
             "id": "6719017",
             "parcelId": "4693",
-            "sheetId": "SD6351",
-            "area": 3.6555
+            "sheetId": "SD6351"
           },
           {
             "id": "7347866",
             "parcelId": "0050",
-            "sheetId": "SD6351",
-            "area": 0.1118
+            "sheetId": "SD6351"
           },
           {
             "id": "7347868",
             "parcelId": "9456",
-            "sheetId": "SD6251",
-            "area": 0.146
+            "sheetId": "SD6251"
           },
           {
             "id": "7347869",
             "parcelId": "9751",
-            "sheetId": "SD6251",
-            "area": 0.0359
+            "sheetId": "SD6251"
           },
           {
             "id": "7347870",
             "parcelId": "9949",
-            "sheetId": "SD6251",
-            "area": 0.0261
+            "sheetId": "SD6251"
           },
           {
             "id": "7347867",
             "parcelId": "0839",
-            "sheetId": "SD6351",
-            "area": 0.2343
+            "sheetId": "SD6351"
           },
           {
             "id": "7347865",
             "parcelId": "0351",
-            "sheetId": "SD6351",
-            "area": 0.0813
+            "sheetId": "SD6351"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000001.json
+++ b/src/server/common/services/consolidated-view/land-data/300000001.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8654",
-            "sheetId": "SD4858",
-            "area": 3.7035
+            "parcelId": "1022",
+            "sheetId": "SD6246"
+          },
+          {
+            "parcelId": "1056",
+            "sheetId": "SD8343"
+          },
+          {
+            "parcelId": "1059",
+            "sheetId": "SD7858"
+          },
+          {
+            "parcelId": "1063",
+            "sheetId": "SD5547"
+          },
+          {
+            "parcelId": "1071",
+            "sheetId": "SD5964"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000002.json
+++ b/src/server/common/services/consolidated-view/land-data/300000002.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8890",
-            "sheetId": "SD4858",
-            "area": 2.8728
+            "parcelId": "1073",
+            "sheetId": "SD6352"
+          },
+          {
+            "parcelId": "1081",
+            "sheetId": "SD6246"
+          },
+          {
+            "parcelId": "1081",
+            "sheetId": "SD7448"
+          },
+          {
+            "parcelId": "1085",
+            "sheetId": "SD5656"
+          },
+          {
+            "parcelId": "1090",
+            "sheetId": "SD8744"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000003.json
+++ b/src/server/common/services/consolidated-view/land-data/300000003.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9884",
-            "sheetId": "SD4858",
-            "area": 1.5786
+            "parcelId": "1107",
+            "sheetId": "SD5551"
+          },
+          {
+            "parcelId": "1139",
+            "sheetId": "SD7553"
+          },
+          {
+            "parcelId": "1153",
+            "sheetId": "SD6960"
+          },
+          {
+            "parcelId": "1161",
+            "sheetId": "SD8067"
+          },
+          {
+            "parcelId": "1220",
+            "sheetId": "SD8067"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000004.json
+++ b/src/server/common/services/consolidated-view/land-data/300000004.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "2681",
-            "sheetId": "SD4957",
-            "area": 1.3331
+            "parcelId": "1235",
+            "sheetId": "SD8566"
+          },
+          {
+            "parcelId": "1236",
+            "sheetId": "SD8242"
+          },
+          {
+            "parcelId": "1261",
+            "sheetId": "SD7057"
+          },
+          {
+            "parcelId": "1305",
+            "sheetId": "SD8460"
+          },
+          {
+            "parcelId": "1344",
+            "sheetId": "SD6155"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000005.json
+++ b/src/server/common/services/consolidated-view/land-data/300000005.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "5485",
-            "sheetId": "SD4957",
-            "area": 2.0077
+            "parcelId": "1436",
+            "sheetId": "SD5852"
+          },
+          {
+            "parcelId": "1441",
+            "sheetId": "SD6163"
+          },
+          {
+            "parcelId": "1461",
+            "sheetId": "SD7147"
+          },
+          {
+            "parcelId": "1488",
+            "sheetId": "SD8542"
+          },
+          {
+            "parcelId": "1499",
+            "sheetId": "SD7446"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000006.json
+++ b/src/server/common/services/consolidated-view/land-data/300000006.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "5567",
-            "sheetId": "SD4957",
-            "area": 2.3811
+            "parcelId": "1598",
+            "sheetId": "SD6856"
+          },
+          {
+            "parcelId": "1599",
+            "sheetId": "SD8241"
+          },
+          {
+            "parcelId": "1602",
+            "sheetId": "SD8744"
+          },
+          {
+            "parcelId": "1609",
+            "sheetId": "SD8068"
+          },
+          {
+            "parcelId": "1643",
+            "sheetId": "SD8243"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000007.json
+++ b/src/server/common/services/consolidated-view/land-data/300000007.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "6697",
-            "sheetId": "SD4957",
-            "area": 5.7775
+            "parcelId": "1649",
+            "sheetId": "SD6765"
+          },
+          {
+            "parcelId": "1651",
+            "sheetId": "SD6065"
+          },
+          {
+            "parcelId": "1673",
+            "sheetId": "SD6560"
+          },
+          {
+            "parcelId": "1674",
+            "sheetId": "SD6153"
+          },
+          {
+            "parcelId": "1675",
+            "sheetId": "SD5647"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000008.json
+++ b/src/server/common/services/consolidated-view/land-data/300000008.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7673",
-            "sheetId": "SD4957",
-            "area": 8.8276
+            "parcelId": "1717",
+            "sheetId": "SD6151"
+          },
+          {
+            "parcelId": "1733",
+            "sheetId": "SD8443"
+          },
+          {
+            "parcelId": "1738",
+            "sheetId": "SD5945"
+          },
+          {
+            "parcelId": "1762",
+            "sheetId": "SD6065"
+          },
+          {
+            "parcelId": "1774",
+            "sheetId": "SD6549"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000009.json
+++ b/src/server/common/services/consolidated-view/land-data/300000009.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8154",
-            "sheetId": "SD4957",
-            "area": 2.7134
+            "parcelId": "1853",
+            "sheetId": "SD7159"
+          },
+          {
+            "parcelId": "1857",
+            "sheetId": "SD7058"
+          },
+          {
+            "parcelId": "1870",
+            "sheetId": "SD7659"
+          },
+          {
+            "parcelId": "1905",
+            "sheetId": "SD7158"
+          },
+          {
+            "parcelId": "1911",
+            "sheetId": "SD6162"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000010.json
+++ b/src/server/common/services/consolidated-view/land-data/300000010.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8781",
-            "sheetId": "SD5065",
-            "area": 3.2298
+            "parcelId": "1921",
+            "sheetId": "SD7360"
+          },
+          {
+            "parcelId": "1926",
+            "sheetId": "SD5961"
+          },
+          {
+            "parcelId": "1965",
+            "sheetId": "SD5360"
+          },
+          {
+            "parcelId": "1974",
+            "sheetId": "SD6463"
+          },
+          {
+            "parcelId": "2023",
+            "sheetId": "SD8460"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000011.json
+++ b/src/server/common/services/consolidated-view/land-data/300000011.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9765",
-            "sheetId": "SD5065",
-            "area": 5.4065
+            "parcelId": "2069",
+            "sheetId": "SD8365"
+          },
+          {
+            "parcelId": "2070",
+            "sheetId": "SD6354"
+          },
+          {
+            "parcelId": "2087",
+            "sheetId": "SD6654"
+          },
+          {
+            "parcelId": "2090",
+            "sheetId": "SD7259"
+          },
+          {
+            "parcelId": "2111",
+            "sheetId": "SD8745"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000012.json
+++ b/src/server/common/services/consolidated-view/land-data/300000012.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9837",
-            "sheetId": "SD5065",
-            "area": 2.5298
+            "parcelId": "2122",
+            "sheetId": "SD5946"
+          },
+          {
+            "parcelId": "2131",
+            "sheetId": "SD6046"
+          },
+          {
+            "parcelId": "2140",
+            "sheetId": "SD6350"
+          },
+          {
+            "parcelId": "2143",
+            "sheetId": "SD8644"
+          },
+          {
+            "parcelId": "2145",
+            "sheetId": "SD6464"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000013.json
+++ b/src/server/common/services/consolidated-view/land-data/300000013.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "1180",
-            "sheetId": "SD4958",
-            "area": 1.7972
+            "parcelId": "2158",
+            "sheetId": "SD8465"
+          },
+          {
+            "parcelId": "2219",
+            "sheetId": "SD6055"
+          },
+          {
+            "parcelId": "2222",
+            "sheetId": "SD6261"
+          },
+          {
+            "parcelId": "2233",
+            "sheetId": "SD5853"
+          },
+          {
+            "parcelId": "2265",
+            "sheetId": "SD8242"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000014.json
+++ b/src/server/common/services/consolidated-view/land-data/300000014.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "1251",
-            "sheetId": "SD4958",
-            "area": 1.8188
+            "parcelId": "2268",
+            "sheetId": "SD8765"
+          },
+          {
+            "parcelId": "2295",
+            "sheetId": "SD7158"
+          },
+          {
+            "parcelId": "2296",
+            "sheetId": "SD6860"
+          },
+          {
+            "parcelId": "2327",
+            "sheetId": "SD7447"
+          },
+          {
+            "parcelId": "2333",
+            "sheetId": "SD6955"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000015.json
+++ b/src/server/common/services/consolidated-view/land-data/300000015.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "1610",
-            "sheetId": "SD4958",
-            "area": 2.0167
+            "parcelId": "2353",
+            "sheetId": "SD7367"
+          },
+          {
+            "parcelId": "2389",
+            "sheetId": "SD7155"
+          },
+          {
+            "parcelId": "2403",
+            "sheetId": "SD7968"
+          },
+          {
+            "parcelId": "2415",
+            "sheetId": "SD6252"
+          },
+          {
+            "parcelId": "2417",
+            "sheetId": "SD5651"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000016.json
+++ b/src/server/common/services/consolidated-view/land-data/300000016.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "1625",
-            "sheetId": "SD4958",
-            "area": 1.9021
+            "parcelId": "2469",
+            "sheetId": "SD8558"
+          },
+          {
+            "parcelId": "2484",
+            "sheetId": "SD5148"
+          },
+          {
+            "parcelId": "2489",
+            "sheetId": "SD8542"
+          },
+          {
+            "parcelId": "2520",
+            "sheetId": "SD8667"
+          },
+          {
+            "parcelId": "2526",
+            "sheetId": "SD6348"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000017.json
+++ b/src/server/common/services/consolidated-view/land-data/300000017.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "1991",
-            "sheetId": "SD4958",
-            "area": 1.7225
+            "parcelId": "2535",
+            "sheetId": "SD8563"
+          },
+          {
+            "parcelId": "2536",
+            "sheetId": "SD8142"
+          },
+          {
+            "parcelId": "2578",
+            "sheetId": "SD8565"
+          },
+          {
+            "parcelId": "2615",
+            "sheetId": "SD7553"
+          },
+          {
+            "parcelId": "2629",
+            "sheetId": "SD7548"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000018.json
+++ b/src/server/common/services/consolidated-view/land-data/300000018.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "2805",
-            "sheetId": "SD4958",
-            "area": 1.3221
+            "parcelId": "2653",
+            "sheetId": "SD8764"
+          },
+          {
+            "parcelId": "2657",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "2657",
+            "sheetId": "SD8761"
+          },
+          {
+            "parcelId": "2670",
+            "sheetId": "SD7159"
+          },
+          {
+            "parcelId": "2677",
+            "sheetId": "SD5459"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000019.json
+++ b/src/server/common/services/consolidated-view/land-data/300000019.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "3700",
-            "sheetId": "SD4958",
-            "area": 3.3122
+            "parcelId": "2682",
+            "sheetId": "SD7047"
+          },
+          {
+            "parcelId": "2682",
+            "sheetId": "SD8644"
+          },
+          {
+            "parcelId": "2699",
+            "sheetId": "SD6162"
+          },
+          {
+            "parcelId": "2707",
+            "sheetId": "SD8153"
+          },
+          {
+            "parcelId": "2708",
+            "sheetId": "SD5962"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000020.json
+++ b/src/server/common/services/consolidated-view/land-data/300000020.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "4199",
-            "sheetId": "SD4958",
-            "area": 5.918
+            "parcelId": "2774",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "2782",
+            "sheetId": "SD8662"
+          },
+          {
+            "parcelId": "2807",
+            "sheetId": "SD7447"
+          },
+          {
+            "parcelId": "2818",
+            "sheetId": "SD7660"
+          },
+          {
+            "parcelId": "2826",
+            "sheetId": "SD6555"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000021.json
+++ b/src/server/common/services/consolidated-view/land-data/300000021.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "4880",
-            "sheetId": "SD4958",
-            "area": 6.8239
+            "parcelId": "2837",
+            "sheetId": "SD6955"
+          },
+          {
+            "parcelId": "2862",
+            "sheetId": "SD6347"
+          },
+          {
+            "parcelId": "2880",
+            "sheetId": "SD6659"
+          },
+          {
+            "parcelId": "2887",
+            "sheetId": "SD8042"
+          },
+          {
+            "parcelId": "2888",
+            "sheetId": "SD6960"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000022.json
+++ b/src/server/common/services/consolidated-view/land-data/300000022.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "4914",
-            "sheetId": "SD4958",
-            "area": 1.202
+            "parcelId": "2903",
+            "sheetId": "SD7662"
+          },
+          {
+            "parcelId": "2915",
+            "sheetId": "SD6749"
+          },
+          {
+            "parcelId": "2918",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "2938",
+            "sheetId": "SD7261"
+          },
+          {
+            "parcelId": "2938",
+            "sheetId": "SD7261"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000023.json
+++ b/src/server/common/services/consolidated-view/land-data/300000023.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "4918",
-            "sheetId": "SD4958",
-            "area": 1.2861
+            "parcelId": "2968",
+            "sheetId": "SD6057"
+          },
+          {
+            "parcelId": "2976",
+            "sheetId": "SD5549"
+          },
+          {
+            "parcelId": "3023",
+            "sheetId": "SD8664"
+          },
+          {
+            "parcelId": "3050",
+            "sheetId": "SD8763"
+          },
+          {
+            "parcelId": "3053",
+            "sheetId": "SD6664"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000024.json
+++ b/src/server/common/services/consolidated-view/land-data/300000024.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "5863",
-            "sheetId": "SD4958",
-            "area": 4.1521
+            "parcelId": "3065",
+            "sheetId": "SD6747"
+          },
+          {
+            "parcelId": "3074",
+            "sheetId": "SD8363"
+          },
+          {
+            "parcelId": "3095",
+            "sheetId": "SD8142"
+          },
+          {
+            "parcelId": "3101",
+            "sheetId": "SD6262"
+          },
+          {
+            "parcelId": "3142",
+            "sheetId": "SD8464"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000025.json
+++ b/src/server/common/services/consolidated-view/land-data/300000025.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "6532",
-            "sheetId": "SD4958",
-            "area": 1.7757
+            "parcelId": "3150",
+            "sheetId": "SD7448"
+          },
+          {
+            "parcelId": "3166",
+            "sheetId": "SD8762"
+          },
+          {
+            "parcelId": "3227",
+            "sheetId": "SD6264"
+          },
+          {
+            "parcelId": "3232",
+            "sheetId": "SD5851"
+          },
+          {
+            "parcelId": "3256",
+            "sheetId": "SD8365"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000026.json
+++ b/src/server/common/services/consolidated-view/land-data/300000026.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "6983",
-            "sheetId": "SD4958",
-            "area": 2.4342
+            "parcelId": "3264",
+            "sheetId": "SD8743"
+          },
+          {
+            "parcelId": "3270",
+            "sheetId": "SD8364"
+          },
+          {
+            "parcelId": "3273",
+            "sheetId": "SD6551"
+          },
+          {
+            "parcelId": "3285",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "3293",
+            "sheetId": "SD8364"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000027.json
+++ b/src/server/common/services/consolidated-view/land-data/300000027.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7044",
-            "sheetId": "SD4958",
-            "area": 2.3219
+            "parcelId": "3294",
+            "sheetId": "SD8761"
+          },
+          {
+            "parcelId": "3315",
+            "sheetId": "SD6554"
+          },
+          {
+            "parcelId": "3320",
+            "sheetId": "SD7659"
+          },
+          {
+            "parcelId": "3324",
+            "sheetId": "SD8661"
+          },
+          {
+            "parcelId": "3337",
+            "sheetId": "SD8364"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000028.json
+++ b/src/server/common/services/consolidated-view/land-data/300000028.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8053",
-            "sheetId": "SD4958",
-            "area": 1.8223
+            "parcelId": "3351",
+            "sheetId": "SD7653"
+          },
+          {
+            "parcelId": "3365",
+            "sheetId": "SD6253"
+          },
+          {
+            "parcelId": "3387",
+            "sheetId": "SD6346"
+          },
+          {
+            "parcelId": "3415",
+            "sheetId": "SD6865"
+          },
+          {
+            "parcelId": "3416",
+            "sheetId": "SD6249"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000029.json
+++ b/src/server/common/services/consolidated-view/land-data/300000029.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8670",
-            "sheetId": "SD4958",
-            "area": 1.9903
+            "parcelId": "3445",
+            "sheetId": "SD6955"
+          },
+          {
+            "parcelId": "3454",
+            "sheetId": "SD8243"
+          },
+          {
+            "parcelId": "3492",
+            "sheetId": "SD6863"
+          },
+          {
+            "parcelId": "3492",
+            "sheetId": "SD7047"
+          },
+          {
+            "parcelId": "3497",
+            "sheetId": "SD6162"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000030.json
+++ b/src/server/common/services/consolidated-view/land-data/300000030.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8729",
-            "sheetId": "SD4958",
-            "area": 2.7983
+            "parcelId": "3498",
+            "sheetId": "SD8459"
+          },
+          {
+            "parcelId": "3501",
+            "sheetId": "SD5861"
+          },
+          {
+            "parcelId": "3536",
+            "sheetId": "SD5665"
+          },
+          {
+            "parcelId": "3544",
+            "sheetId": "SD6762"
+          },
+          {
+            "parcelId": "3552",
+            "sheetId": "SD5964"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000031.json
+++ b/src/server/common/services/consolidated-view/land-data/300000031.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8844",
-            "sheetId": "SD4958",
-            "area": 1.3264
+            "parcelId": "3560",
+            "sheetId": "SD7155"
+          },
+          {
+            "parcelId": "3568",
+            "sheetId": "SD6453"
+          },
+          {
+            "parcelId": "3586",
+            "sheetId": "SD7658"
+          },
+          {
+            "parcelId": "3589",
+            "sheetId": "SD6551"
+          },
+          {
+            "parcelId": "3590",
+            "sheetId": "SD5657"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000032.json
+++ b/src/server/common/services/consolidated-view/land-data/300000032.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8906",
-            "sheetId": "SD4958",
-            "area": 1.9958
+            "parcelId": "3592",
+            "sheetId": "SD7157"
+          },
+          {
+            "parcelId": "3593",
+            "sheetId": "SD8562"
+          },
+          {
+            "parcelId": "3601",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "3606",
+            "sheetId": "SD5549"
+          },
+          {
+            "parcelId": "3618",
+            "sheetId": "SD5862"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000033.json
+++ b/src/server/common/services/consolidated-view/land-data/300000033.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9753",
-            "sheetId": "SD4958",
-            "area": 1.1484
+            "parcelId": "3633",
+            "sheetId": "SD8243"
+          },
+          {
+            "parcelId": "3668",
+            "sheetId": "SD6350"
+          },
+          {
+            "parcelId": "3716",
+            "sheetId": "SD6761"
+          },
+          {
+            "parcelId": "3793",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "3806",
+            "sheetId": "SD6552"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000034.json
+++ b/src/server/common/services/consolidated-view/land-data/300000034.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7708",
-            "sheetId": "SD5066",
-            "area": 4.9336
+            "parcelId": "3815",
+            "sheetId": "SD5349"
+          },
+          {
+            "parcelId": "3851",
+            "sheetId": "SD6050"
+          },
+          {
+            "parcelId": "3851",
+            "sheetId": "SD8042"
+          },
+          {
+            "parcelId": "3857",
+            "sheetId": "SD6759"
+          },
+          {
+            "parcelId": "3880",
+            "sheetId": "SD6159"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000035.json
+++ b/src/server/common/services/consolidated-view/land-data/300000035.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8222",
-            "sheetId": "SD5066",
-            "area": 2.5242
+            "parcelId": "3919",
+            "sheetId": "SD5458"
+          },
+          {
+            "parcelId": "3930",
+            "sheetId": "SD5764"
+          },
+          {
+            "parcelId": "3967",
+            "sheetId": "SD5557"
+          },
+          {
+            "parcelId": "3969",
+            "sheetId": "SD7657"
+          },
+          {
+            "parcelId": "3975",
+            "sheetId": "SD6661"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000036.json
+++ b/src/server/common/services/consolidated-view/land-data/300000036.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "2303",
-            "sheetId": "SD4959",
-            "area": 2.7867
+            "parcelId": "3975",
+            "sheetId": "SD7659"
+          },
+          {
+            "parcelId": "3988",
+            "sheetId": "SD5652"
+          },
+          {
+            "parcelId": "3988",
+            "sheetId": "SD7058"
+          },
+          {
+            "parcelId": "4034",
+            "sheetId": "SD7562"
+          },
+          {
+            "parcelId": "4045",
+            "sheetId": "SD7347"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000037.json
+++ b/src/server/common/services/consolidated-view/land-data/300000037.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "2543",
-            "sheetId": "SD4959",
-            "area": 3.637
+            "parcelId": "4060",
+            "sheetId": "SD6363"
+          },
+          {
+            "parcelId": "4060",
+            "sheetId": "SD8443"
+          },
+          {
+            "parcelId": "4064",
+            "sheetId": "SD6046"
+          },
+          {
+            "parcelId": "4081",
+            "sheetId": "SD6364"
+          },
+          {
+            "parcelId": "4122",
+            "sheetId": "SD7447"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000038.json
+++ b/src/server/common/services/consolidated-view/land-data/300000038.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "3185",
-            "sheetId": "SD4959",
-            "area": 2.7279
+            "parcelId": "4128",
+            "sheetId": "SD8462"
+          },
+          {
+            "parcelId": "4135",
+            "sheetId": "SD8365"
+          },
+          {
+            "parcelId": "4136",
+            "sheetId": "SD7447"
+          },
+          {
+            "parcelId": "4137",
+            "sheetId": "SD8242"
+          },
+          {
+            "parcelId": "4147",
+            "sheetId": "SD6551"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000039.json
+++ b/src/server/common/services/consolidated-view/land-data/300000039.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "3218",
-            "sheetId": "SD4959",
-            "area": 2.6112
+            "parcelId": "4149",
+            "sheetId": "SD5847"
+          },
+          {
+            "parcelId": "4174",
+            "sheetId": "SD5551"
+          },
+          {
+            "parcelId": "4207",
+            "sheetId": "SD8243"
+          },
+          {
+            "parcelId": "4210",
+            "sheetId": "SD7159"
+          },
+          {
+            "parcelId": "4245",
+            "sheetId": "SD7047"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000040.json
+++ b/src/server/common/services/consolidated-view/land-data/300000040.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "3695",
-            "sheetId": "SD4959",
-            "area": 3.3174
+            "parcelId": "4265",
+            "sheetId": "SD6162"
+          },
+          {
+            "parcelId": "4280",
+            "sheetId": "SD6661"
+          },
+          {
+            "parcelId": "4290",
+            "sheetId": "SD6560"
+          },
+          {
+            "parcelId": "4291",
+            "sheetId": "SD7761"
+          },
+          {
+            "parcelId": "4330",
+            "sheetId": "SD8460"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000041.json
+++ b/src/server/common/services/consolidated-view/land-data/300000041.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "4039",
-            "sheetId": "SD4959",
-            "area": 3.1077
+            "parcelId": "4373",
+            "sheetId": "SD5148"
+          },
+          {
+            "parcelId": "4375",
+            "sheetId": "SD8744"
+          },
+          {
+            "parcelId": "4401",
+            "sheetId": "SD6555"
+          },
+          {
+            "parcelId": "4404",
+            "sheetId": "SD6461"
+          },
+          {
+            "parcelId": "4413",
+            "sheetId": "SD6351"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000042.json
+++ b/src/server/common/services/consolidated-view/land-data/300000042.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "4699",
-            "sheetId": "SD4959",
-            "area": 1.18
+            "parcelId": "4425",
+            "sheetId": "SD8344"
+          },
+          {
+            "parcelId": "4427",
+            "sheetId": "SD5945"
+          },
+          {
+            "parcelId": "4473",
+            "sheetId": "SD7148"
+          },
+          {
+            "parcelId": "4508",
+            "sheetId": "SD5451"
+          },
+          {
+            "parcelId": "4508",
+            "sheetId": "SD7157"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000043.json
+++ b/src/server/common/services/consolidated-view/land-data/300000043.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "4772",
-            "sheetId": "SD4959",
-            "area": 2.1609
+            "parcelId": "4555",
+            "sheetId": "SD8663"
+          },
+          {
+            "parcelId": "4573",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "4580",
+            "sheetId": "SD5861"
+          },
+          {
+            "parcelId": "4599",
+            "sheetId": "SD5846"
+          },
+          {
+            "parcelId": "4620",
+            "sheetId": "SD6362"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000044.json
+++ b/src/server/common/services/consolidated-view/land-data/300000044.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "5435",
-            "sheetId": "SD4959",
-            "area": 3.821
+            "parcelId": "4625",
+            "sheetId": "SD5947"
+          },
+          {
+            "parcelId": "4625",
+            "sheetId": "SD6251"
+          },
+          {
+            "parcelId": "4626",
+            "sheetId": "SD5350"
+          },
+          {
+            "parcelId": "4642",
+            "sheetId": "SD8444"
+          },
+          {
+            "parcelId": "4660",
+            "sheetId": "SD8242"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000045.json
+++ b/src/server/common/services/consolidated-view/land-data/300000045.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "5617",
-            "sheetId": "SD4959",
-            "area": 2.3268
+            "parcelId": "4675",
+            "sheetId": "SD5762"
+          },
+          {
+            "parcelId": "4703",
+            "sheetId": "SD6653"
+          },
+          {
+            "parcelId": "4758",
+            "sheetId": "SD7967"
+          },
+          {
+            "parcelId": "4796",
+            "sheetId": "SD6251"
+          },
+          {
+            "parcelId": "4824",
+            "sheetId": "SD8242"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000046.json
+++ b/src/server/common/services/consolidated-view/land-data/300000046.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "6583",
-            "sheetId": "SD4959",
-            "area": 9.6042
+            "parcelId": "4825",
+            "sheetId": "SD5965"
+          },
+          {
+            "parcelId": "4845",
+            "sheetId": "SD7548"
+          },
+          {
+            "parcelId": "4858",
+            "sheetId": "SD6955"
+          },
+          {
+            "parcelId": "4879",
+            "sheetId": "SD8065"
+          },
+          {
+            "parcelId": "4896",
+            "sheetId": "SD8465"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000047.json
+++ b/src/server/common/services/consolidated-view/land-data/300000047.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7197",
-            "sheetId": "SD4959",
-            "area": 3.5328
+            "parcelId": "4904",
+            "sheetId": "SD7447"
+          },
+          {
+            "parcelId": "4915",
+            "sheetId": "SD5360"
+          },
+          {
+            "parcelId": "4933",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "4961",
+            "sheetId": "SD6146"
+          },
+          {
+            "parcelId": "5028",
+            "sheetId": "SD5856"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000048.json
+++ b/src/server/common/services/consolidated-view/land-data/300000048.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7439",
-            "sheetId": "SD4959",
-            "area": 1.7246
+            "parcelId": "5039",
+            "sheetId": "SD7157"
+          },
+          {
+            "parcelId": "5040",
+            "sheetId": "SD6862"
+          },
+          {
+            "parcelId": "5042",
+            "sheetId": "SD8052"
+          },
+          {
+            "parcelId": "5044",
+            "sheetId": "SD6163"
+          },
+          {
+            "parcelId": "5050",
+            "sheetId": "SD7063"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000049.json
+++ b/src/server/common/services/consolidated-view/land-data/300000049.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8569",
-            "sheetId": "SD4959",
-            "area": 2.8419
+            "parcelId": "5054",
+            "sheetId": "SD7156"
+          },
+          {
+            "parcelId": "5078",
+            "sheetId": "SD6150"
+          },
+          {
+            "parcelId": "5080",
+            "sheetId": "SD8343"
+          },
+          {
+            "parcelId": "5090",
+            "sheetId": "SD5757"
+          },
+          {
+            "parcelId": "5102",
+            "sheetId": "SD8545"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000050.json
+++ b/src/server/common/services/consolidated-view/land-data/300000050.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8655",
-            "sheetId": "SD4959",
-            "area": 2.246
+            "parcelId": "5143",
+            "sheetId": "SD7247"
+          },
+          {
+            "parcelId": "5174",
+            "sheetId": "SD6252"
+          },
+          {
+            "parcelId": "5185",
+            "sheetId": "SD5846"
+          },
+          {
+            "parcelId": "5191",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "5205",
+            "sheetId": "SD7657"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000051.json
+++ b/src/server/common/services/consolidated-view/land-data/300000051.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "3612",
-            "sheetId": "SD4960",
-            "area": 2.1116
+            "parcelId": "5222",
+            "sheetId": "SD6163"
+          },
+          {
+            "parcelId": "5225",
+            "sheetId": "SD6754"
+          },
+          {
+            "parcelId": "5240",
+            "sheetId": "SD8363"
+          },
+          {
+            "parcelId": "5246",
+            "sheetId": "SD5665"
+          },
+          {
+            "parcelId": "5278",
+            "sheetId": "SD8042"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000052.json
+++ b/src/server/common/services/consolidated-view/land-data/300000052.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "4523",
-            "sheetId": "SD4960",
-            "area": 2.1073
+            "parcelId": "5287",
+            "sheetId": "SD6666"
+          },
+          {
+            "parcelId": "5305",
+            "sheetId": "SD8667"
+          },
+          {
+            "parcelId": "5323",
+            "sheetId": "SD6661"
+          },
+          {
+            "parcelId": "5346",
+            "sheetId": "SD7447"
+          },
+          {
+            "parcelId": "5355",
+            "sheetId": "SD6461"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000053.json
+++ b/src/server/common/services/consolidated-view/land-data/300000053.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "4932",
-            "sheetId": "SD4960",
-            "area": 1.0608
+            "parcelId": "5358",
+            "sheetId": "SD8460"
+          },
+          {
+            "parcelId": "5370",
+            "sheetId": "SD8462"
+          },
+          {
+            "parcelId": "5393",
+            "sheetId": "SD7059"
+          },
+          {
+            "parcelId": "5434",
+            "sheetId": "SD6460"
+          },
+          {
+            "parcelId": "5447",
+            "sheetId": "SD7248"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000054.json
+++ b/src/server/common/services/consolidated-view/land-data/300000054.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "5447",
-            "sheetId": "SD4960",
-            "area": 2.2001
+            "parcelId": "5479",
+            "sheetId": "SD8052"
+          },
+          {
+            "parcelId": "5487",
+            "sheetId": "SD5863"
+          },
+          {
+            "parcelId": "5509",
+            "sheetId": "SD6252"
+          },
+          {
+            "parcelId": "5515",
+            "sheetId": "SD5761"
+          },
+          {
+            "parcelId": "5535",
+            "sheetId": "SD7448"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000055.json
+++ b/src/server/common/services/consolidated-view/land-data/300000055.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "6111",
-            "sheetId": "SD4960",
-            "area": 3.7922
+            "parcelId": "5540",
+            "sheetId": "SD8464"
+          },
+          {
+            "parcelId": "5542",
+            "sheetId": "SD8564"
+          },
+          {
+            "parcelId": "5547",
+            "sheetId": "SD7058"
+          },
+          {
+            "parcelId": "5561",
+            "sheetId": "SD6346"
+          },
+          {
+            "parcelId": "5568",
+            "sheetId": "SD8460"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000056.json
+++ b/src/server/common/services/consolidated-view/land-data/300000056.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "6641",
-            "sheetId": "SD4960",
-            "area": 2.0238
+            "parcelId": "5583",
+            "sheetId": "SD8662"
+          },
+          {
+            "parcelId": "5617",
+            "sheetId": "SD6461"
+          },
+          {
+            "parcelId": "5618",
+            "sheetId": "SD5946"
+          },
+          {
+            "parcelId": "5623",
+            "sheetId": "SD5448"
+          },
+          {
+            "parcelId": "5630",
+            "sheetId": "SD7553"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000057.json
+++ b/src/server/common/services/consolidated-view/land-data/300000057.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "6818",
-            "sheetId": "SD4960",
-            "area": 1.735
+            "parcelId": "5652",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "5677",
+            "sheetId": "SD7861"
+          },
+          {
+            "parcelId": "5684",
+            "sheetId": "SD6049"
+          },
+          {
+            "parcelId": "5720",
+            "sheetId": "SD6348"
+          },
+          {
+            "parcelId": "5721",
+            "sheetId": "SD6664"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000058.json
+++ b/src/server/common/services/consolidated-view/land-data/300000058.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7677",
-            "sheetId": "SD4960",
-            "area": 4.715
+            "parcelId": "5726",
+            "sheetId": "SD8444"
+          },
+          {
+            "parcelId": "5745",
+            "sheetId": "SD6054"
+          },
+          {
+            "parcelId": "5764",
+            "sheetId": "SD6553"
+          },
+          {
+            "parcelId": "5785",
+            "sheetId": "SD7459"
+          },
+          {
+            "parcelId": "5807",
+            "sheetId": "SD6359"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000059.json
+++ b/src/server/common/services/consolidated-view/land-data/300000059.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7830",
-            "sheetId": "SD4960",
-            "area": 4.427
+            "parcelId": "5822",
+            "sheetId": "SD8243"
+          },
+          {
+            "parcelId": "5829",
+            "sheetId": "SD8052"
+          },
+          {
+            "parcelId": "5841",
+            "sheetId": "SD5448"
+          },
+          {
+            "parcelId": "5846",
+            "sheetId": "SD7258"
+          },
+          {
+            "parcelId": "5849",
+            "sheetId": "SD6154"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000060.json
+++ b/src/server/common/services/consolidated-view/land-data/300000060.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8092",
-            "sheetId": "SD4960",
-            "area": 1.3079
+            "parcelId": "5854",
+            "sheetId": "SD6246"
+          },
+          {
+            "parcelId": "5864",
+            "sheetId": "SD8052"
+          },
+          {
+            "parcelId": "5876",
+            "sheetId": "SD6359"
+          },
+          {
+            "parcelId": "5879",
+            "sheetId": "SD5458"
+          },
+          {
+            "parcelId": "5887",
+            "sheetId": "SD8643"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000061.json
+++ b/src/server/common/services/consolidated-view/land-data/300000061.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8307",
-            "sheetId": "SD4960",
-            "area": 2.5689
+            "parcelId": "5898",
+            "sheetId": "SD7967"
+          },
+          {
+            "parcelId": "5903",
+            "sheetId": "SD7842"
+          },
+          {
+            "parcelId": "5909",
+            "sheetId": "SD7067"
+          },
+          {
+            "parcelId": "5927",
+            "sheetId": "SD7659"
+          },
+          {
+            "parcelId": "5939",
+            "sheetId": "SD7447"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000062.json
+++ b/src/server/common/services/consolidated-view/land-data/300000062.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8453",
-            "sheetId": "SD4960",
-            "area": 3.5902
+            "parcelId": "5973",
+            "sheetId": "SD8545"
+          },
+          {
+            "parcelId": "6001",
+            "sheetId": "SD6351"
+          },
+          {
+            "parcelId": "6030",
+            "sheetId": "SD6252"
+          },
+          {
+            "parcelId": "6042",
+            "sheetId": "SD7266"
+          },
+          {
+            "parcelId": "6042",
+            "sheetId": "SD7266"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000063.json
+++ b/src/server/common/services/consolidated-view/land-data/300000063.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8599",
-            "sheetId": "SD4960",
-            "area": 1.2831
+            "parcelId": "6060",
+            "sheetId": "SD5949"
+          },
+          {
+            "parcelId": "6097",
+            "sheetId": "SD6347"
+          },
+          {
+            "parcelId": "6108",
+            "sheetId": "SD6164"
+          },
+          {
+            "parcelId": "6117",
+            "sheetId": "SD8052"
+          },
+          {
+            "parcelId": "6135",
+            "sheetId": "SD6451"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000064.json
+++ b/src/server/common/services/consolidated-view/land-data/300000064.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9119",
-            "sheetId": "SD4960",
-            "area": 2.9625
+            "parcelId": "6152",
+            "sheetId": "SD6450"
+          },
+          {
+            "parcelId": "6181",
+            "sheetId": "SD6145"
+          },
+          {
+            "parcelId": "6185",
+            "sheetId": "SD7361"
+          },
+          {
+            "parcelId": "6189",
+            "sheetId": "SD6648"
+          },
+          {
+            "parcelId": "6213",
+            "sheetId": "SD6649"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000065.json
+++ b/src/server/common/services/consolidated-view/land-data/300000065.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9209",
-            "sheetId": "SD4961",
-            "area": 2.9021
+            "parcelId": "6222",
+            "sheetId": "SD5853"
+          },
+          {
+            "parcelId": "6234",
+            "sheetId": "SD6964"
+          },
+          {
+            "parcelId": "6284",
+            "sheetId": "SD7056"
+          },
+          {
+            "parcelId": "6334",
+            "sheetId": "SD8643"
+          },
+          {
+            "parcelId": "6345",
+            "sheetId": "SD8052"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000066.json
+++ b/src/server/common/services/consolidated-view/land-data/300000066.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9819",
-            "sheetId": "SD4961",
-            "area": 1.4607
+            "parcelId": "6381",
+            "sheetId": "SD8365"
+          },
+          {
+            "parcelId": "6405",
+            "sheetId": "SD8052"
+          },
+          {
+            "parcelId": "6414",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "6424",
+            "sheetId": "SD6748"
+          },
+          {
+            "parcelId": "6431",
+            "sheetId": "SD6453"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000067.json
+++ b/src/server/common/services/consolidated-view/land-data/300000067.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9193",
-            "sheetId": "SD4962",
-            "area": 9.5322
+            "parcelId": "6497",
+            "sheetId": "SD7258"
+          },
+          {
+            "parcelId": "6516",
+            "sheetId": "SD7759"
+          },
+          {
+            "parcelId": "6525",
+            "sheetId": "SD6855"
+          },
+          {
+            "parcelId": "6526",
+            "sheetId": "SD5952"
+          },
+          {
+            "parcelId": "6527",
+            "sheetId": "SD7147"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000068.json
+++ b/src/server/common/services/consolidated-view/land-data/300000068.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7238",
-            "sheetId": "SD4963",
-            "area": 8.373
+            "parcelId": "6537",
+            "sheetId": "SD8460"
+          },
+          {
+            "parcelId": "6541",
+            "sheetId": "SD6350"
+          },
+          {
+            "parcelId": "6542",
+            "sheetId": "SD5361"
+          },
+          {
+            "parcelId": "6542",
+            "sheetId": "SD6648"
+          },
+          {
+            "parcelId": "6573",
+            "sheetId": "SD8665"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000069.json
+++ b/src/server/common/services/consolidated-view/land-data/300000069.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9081",
-            "sheetId": "SD4963",
-            "area": 2.1293
+            "parcelId": "6608",
+            "sheetId": "SD6353"
+          },
+          {
+            "parcelId": "6615",
+            "sheetId": "SD6364"
+          },
+          {
+            "parcelId": "6646",
+            "sheetId": "SD7659"
+          },
+          {
+            "parcelId": "6647",
+            "sheetId": "SD8264"
+          },
+          {
+            "parcelId": "6662",
+            "sheetId": "SD5954"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000070.json
+++ b/src/server/common/services/consolidated-view/land-data/300000070.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9554",
-            "sheetId": "SD4963",
-            "area": 2.3287
+            "parcelId": "6680",
+            "sheetId": "SD5560"
+          },
+          {
+            "parcelId": "6685",
+            "sheetId": "SD6252"
+          },
+          {
+            "parcelId": "6693",
+            "sheetId": "SD5964"
+          },
+          {
+            "parcelId": "6698",
+            "sheetId": "SD6661"
+          },
+          {
+            "parcelId": "6716",
+            "sheetId": "SD6262"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000071.json
+++ b/src/server/common/services/consolidated-view/land-data/300000071.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9899",
-            "sheetId": "SD4963",
-            "area": 5.7663
+            "parcelId": "6761",
+            "sheetId": "SD8558"
+          },
+          {
+            "parcelId": "6785",
+            "sheetId": "SD6955"
+          },
+          {
+            "parcelId": "6786",
+            "sheetId": "SD6162"
+          },
+          {
+            "parcelId": "6786",
+            "sheetId": "SD7562"
+          },
+          {
+            "parcelId": "6814",
+            "sheetId": "SD6247"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000072.json
+++ b/src/server/common/services/consolidated-view/land-data/300000072.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7210",
-            "sheetId": "SD4964",
-            "area": 2.2459
+            "parcelId": "6818",
+            "sheetId": "SD8644"
+          },
+          {
+            "parcelId": "6830",
+            "sheetId": "SD5653"
+          },
+          {
+            "parcelId": "6851",
+            "sheetId": "SD7249"
+          },
+          {
+            "parcelId": "6853",
+            "sheetId": "SD8661"
+          },
+          {
+            "parcelId": "6881",
+            "sheetId": "SD6045"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000073.json
+++ b/src/server/common/services/consolidated-view/land-data/300000073.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8708",
-            "sheetId": "SD5046",
-            "area": 1.0642
+            "parcelId": "6884",
+            "sheetId": "SD6962"
+          },
+          {
+            "parcelId": "6935",
+            "sheetId": "SD6348"
+          },
+          {
+            "parcelId": "6943",
+            "sheetId": "SD8343"
+          },
+          {
+            "parcelId": "7008",
+            "sheetId": "SD8460"
+          },
+          {
+            "parcelId": "7018",
+            "sheetId": "SD5965"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000074.json
+++ b/src/server/common/services/consolidated-view/land-data/300000074.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9156",
-            "sheetId": "SD5046",
-            "area": 4.1429
+            "parcelId": "7025",
+            "sheetId": "SD6165"
+          },
+          {
+            "parcelId": "7106",
+            "sheetId": "SD8462"
+          },
+          {
+            "parcelId": "7115",
+            "sheetId": "SD8243"
+          },
+          {
+            "parcelId": "7123",
+            "sheetId": "SD7661"
+          },
+          {
+            "parcelId": "7174",
+            "sheetId": "SD6251"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000075.json
+++ b/src/server/common/services/consolidated-view/land-data/300000075.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "2483",
-            "sheetId": "SD5054",
-            "area": 3.4866
+            "parcelId": "7178",
+            "sheetId": "SD7146"
+          },
+          {
+            "parcelId": "7197",
+            "sheetId": "SD6759"
+          },
+          {
+            "parcelId": "7221",
+            "sheetId": "SD8464"
+          },
+          {
+            "parcelId": "7226",
+            "sheetId": "SD5856"
+          },
+          {
+            "parcelId": "7227",
+            "sheetId": "SD6162"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000076.json
+++ b/src/server/common/services/consolidated-view/land-data/300000076.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "3363",
-            "sheetId": "SD5054",
-            "area": 2.1331
+            "parcelId": "7230",
+            "sheetId": "SD6649"
+          },
+          {
+            "parcelId": "7236",
+            "sheetId": "SD8052"
+          },
+          {
+            "parcelId": "7238",
+            "sheetId": "SD8260"
+          },
+          {
+            "parcelId": "7258",
+            "sheetId": "SD6560"
+          },
+          {
+            "parcelId": "7270",
+            "sheetId": "SD6647"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000077.json
+++ b/src/server/common/services/consolidated-view/land-data/300000077.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "5752",
-            "sheetId": "SD5054",
-            "area": 3.3009
+            "parcelId": "7274",
+            "sheetId": "SD7359"
+          },
+          {
+            "parcelId": "7304",
+            "sheetId": "SD7759"
+          },
+          {
+            "parcelId": "7306",
+            "sheetId": "SD8662"
+          },
+          {
+            "parcelId": "7310",
+            "sheetId": "SD5260"
+          },
+          {
+            "parcelId": "7310",
+            "sheetId": "SD5260"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000078.json
+++ b/src/server/common/services/consolidated-view/land-data/300000078.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7685",
-            "sheetId": "SD5054",
-            "area": 4.7903
+            "parcelId": "7332",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "7345",
+            "sheetId": "SD7367"
+          },
+          {
+            "parcelId": "7354",
+            "sheetId": "SD8767"
+          },
+          {
+            "parcelId": "7394",
+            "sheetId": "SD5663"
+          },
+          {
+            "parcelId": "7409",
+            "sheetId": "SD7447"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000079.json
+++ b/src/server/common/services/consolidated-view/land-data/300000079.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9385",
-            "sheetId": "SD5054",
-            "area": 3.2899
+            "parcelId": "7423",
+            "sheetId": "SD6866"
+          },
+          {
+            "parcelId": "7423",
+            "sheetId": "SD6866"
+          },
+          {
+            "parcelId": "7432",
+            "sheetId": "SD5865"
+          },
+          {
+            "parcelId": "7494",
+            "sheetId": "SD8051"
+          },
+          {
+            "parcelId": "7496",
+            "sheetId": "SD6648"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000080.json
+++ b/src/server/common/services/consolidated-view/land-data/300000080.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "3718",
-            "sheetId": "SD5055",
-            "area": 4.1306
+            "parcelId": "7514",
+            "sheetId": "SD7057"
+          },
+          {
+            "parcelId": "7556",
+            "sheetId": "SD8460"
+          },
+          {
+            "parcelId": "7588",
+            "sheetId": "SD6846"
+          },
+          {
+            "parcelId": "7591",
+            "sheetId": "SD8242"
+          },
+          {
+            "parcelId": "7594",
+            "sheetId": "SD8643"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000081.json
+++ b/src/server/common/services/consolidated-view/land-data/300000081.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "3854",
-            "sheetId": "SD5055",
-            "area": 2.5329
+            "parcelId": "7596",
+            "sheetId": "SD6863"
+          },
+          {
+            "parcelId": "7604",
+            "sheetId": "SD8052"
+          },
+          {
+            "parcelId": "7608",
+            "sheetId": "SD8360"
+          },
+          {
+            "parcelId": "7623",
+            "sheetId": "SD5361"
+          },
+          {
+            "parcelId": "7636",
+            "sheetId": "SD5260"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000082.json
+++ b/src/server/common/services/consolidated-view/land-data/300000082.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "4636",
-            "sheetId": "SD5055",
-            "area": 5.051
+            "parcelId": "7636",
+            "sheetId": "SD5260"
+          },
+          {
+            "parcelId": "7656",
+            "sheetId": "SD6352"
+          },
+          {
+            "parcelId": "7663",
+            "sheetId": "SD5357"
+          },
+          {
+            "parcelId": "7683",
+            "sheetId": "SD6647"
+          },
+          {
+            "parcelId": "7690",
+            "sheetId": "SD6560"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000083.json
+++ b/src/server/common/services/consolidated-view/land-data/300000083.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "5086",
-            "sheetId": "SD5055",
-            "area": 3.174
+            "parcelId": "7695",
+            "sheetId": "SD6249"
+          },
+          {
+            "parcelId": "7704",
+            "sheetId": "SD6855"
+          },
+          {
+            "parcelId": "7743",
+            "sheetId": "SD5361"
+          },
+          {
+            "parcelId": "7755",
+            "sheetId": "SD6449"
+          },
+          {
+            "parcelId": "7759",
+            "sheetId": "SD5846"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000084.json
+++ b/src/server/common/services/consolidated-view/land-data/300000084.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "5173",
-            "sheetId": "SD5055",
-            "area": 3.8023
+            "parcelId": "7784",
+            "sheetId": "SD8343"
+          },
+          {
+            "parcelId": "7795",
+            "sheetId": "SD6154"
+          },
+          {
+            "parcelId": "7805",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "7890",
+            "sheetId": "SD5642"
+          },
+          {
+            "parcelId": "7915",
+            "sheetId": "SD7156"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000085.json
+++ b/src/server/common/services/consolidated-view/land-data/300000085.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "5511",
-            "sheetId": "SD5055",
-            "area": 1.5835
+            "parcelId": "7950",
+            "sheetId": "SD8544"
+          },
+          {
+            "parcelId": "7955",
+            "sheetId": "SD5456"
+          },
+          {
+            "parcelId": "7984",
+            "sheetId": "SD8051"
+          },
+          {
+            "parcelId": "7999",
+            "sheetId": "SD6558"
+          },
+          {
+            "parcelId": "8013",
+            "sheetId": "SD8052"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000086.json
+++ b/src/server/common/services/consolidated-view/land-data/300000086.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "6057",
-            "sheetId": "SD5055",
-            "area": 5.6565
+            "parcelId": "8028",
+            "sheetId": "SD7247"
+          },
+          {
+            "parcelId": "8036",
+            "sheetId": "SD7447"
+          },
+          {
+            "parcelId": "8087",
+            "sheetId": "SD5862"
+          },
+          {
+            "parcelId": "8096",
+            "sheetId": "SD8465"
+          },
+          {
+            "parcelId": "8097",
+            "sheetId": "SD5560"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000087.json
+++ b/src/server/common/services/consolidated-view/land-data/300000087.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "6221",
-            "sheetId": "SD5055",
-            "area": 1.4839
+            "parcelId": "8122",
+            "sheetId": "SD6859"
+          },
+          {
+            "parcelId": "8132",
+            "sheetId": "SD6556"
+          },
+          {
+            "parcelId": "8179",
+            "sheetId": "SD7758"
+          },
+          {
+            "parcelId": "8194",
+            "sheetId": "SD7247"
+          },
+          {
+            "parcelId": "8219",
+            "sheetId": "SD8463"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000088.json
+++ b/src/server/common/services/consolidated-view/land-data/300000088.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "6537",
-            "sheetId": "SD5055",
-            "area": 5.4269
+            "parcelId": "8248",
+            "sheetId": "SD6348"
+          },
+          {
+            "parcelId": "8251",
+            "sheetId": "SD5965"
+          },
+          {
+            "parcelId": "8264",
+            "sheetId": "SD8052"
+          },
+          {
+            "parcelId": "8305",
+            "sheetId": "SD5663"
+          },
+          {
+            "parcelId": "8355",
+            "sheetId": "SD8242"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000089.json
+++ b/src/server/common/services/consolidated-view/land-data/300000089.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7009",
-            "sheetId": "SD5055",
-            "area": 2.9628
+            "parcelId": "8362",
+            "sheetId": "SD5856"
+          },
+          {
+            "parcelId": "8364",
+            "sheetId": "SD5862"
+          },
+          {
+            "parcelId": "8377",
+            "sheetId": "SD5659"
+          },
+          {
+            "parcelId": "8421",
+            "sheetId": "SD8065"
+          },
+          {
+            "parcelId": "8423",
+            "sheetId": "SD7965"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000090.json
+++ b/src/server/common/services/consolidated-view/land-data/300000090.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7278",
-            "sheetId": "SD5055",
-            "area": 1.8038
+            "parcelId": "8431",
+            "sheetId": "SD7157"
+          },
+          {
+            "parcelId": "8446",
+            "sheetId": "SD8052"
+          },
+          {
+            "parcelId": "8457",
+            "sheetId": "SD6061"
+          },
+          {
+            "parcelId": "8475",
+            "sheetId": "SD6560"
+          },
+          {
+            "parcelId": "8501",
+            "sheetId": "SD7842"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000091.json
+++ b/src/server/common/services/consolidated-view/land-data/300000091.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "7662",
-            "sheetId": "SD5055",
-            "area": 1.0765
+            "parcelId": "8502",
+            "sheetId": "SD7350"
+          },
+          {
+            "parcelId": "8520",
+            "sheetId": "SD8645"
+          },
+          {
+            "parcelId": "8522",
+            "sheetId": "SD7347"
+          },
+          {
+            "parcelId": "8541",
+            "sheetId": "SD7156"
+          },
+          {
+            "parcelId": "8545",
+            "sheetId": "SD8664"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000092.json
+++ b/src/server/common/services/consolidated-view/land-data/300000092.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8085",
-            "sheetId": "SD5055",
-            "area": 1.9662
+            "parcelId": "8555",
+            "sheetId": "SD6649"
+          },
+          {
+            "parcelId": "8596",
+            "sheetId": "SD8051"
+          },
+          {
+            "parcelId": "8602",
+            "sheetId": "SD5945"
+          },
+          {
+            "parcelId": "8613",
+            "sheetId": "SD6666"
+          },
+          {
+            "parcelId": "8619",
+            "sheetId": "SD6847"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000093.json
+++ b/src/server/common/services/consolidated-view/land-data/300000093.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8372",
-            "sheetId": "SD5055",
-            "area": 2.1139
+            "parcelId": "8630",
+            "sheetId": "SD6250"
+          },
+          {
+            "parcelId": "8651",
+            "sheetId": "SD7059"
+          },
+          {
+            "parcelId": "8666",
+            "sheetId": "SD6947"
+          },
+          {
+            "parcelId": "8701",
+            "sheetId": "SD5664"
+          },
+          {
+            "parcelId": "8712",
+            "sheetId": "SD7247"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000094.json
+++ b/src/server/common/services/consolidated-view/land-data/300000094.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8445",
-            "sheetId": "SD5055",
-            "area": 1.9664
+            "parcelId": "8717",
+            "sheetId": "SD8142"
+          },
+          {
+            "parcelId": "8728",
+            "sheetId": "SD8443"
+          },
+          {
+            "parcelId": "8731",
+            "sheetId": "SD6352"
+          },
+          {
+            "parcelId": "8744",
+            "sheetId": "SD6959"
+          },
+          {
+            "parcelId": "8780",
+            "sheetId": "SD5656"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000095.json
+++ b/src/server/common/services/consolidated-view/land-data/300000095.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "8533",
-            "sheetId": "SD5055",
-            "area": 2.5403
+            "parcelId": "8781",
+            "sheetId": "SD6351"
+          },
+          {
+            "parcelId": "8789",
+            "sheetId": "SD8462"
+          },
+          {
+            "parcelId": "8790",
+            "sheetId": "SD7657"
+          },
+          {
+            "parcelId": "8814",
+            "sheetId": "SD7059"
+          },
+          {
+            "parcelId": "8814",
+            "sheetId": "SD7260"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000096.json
+++ b/src/server/common/services/consolidated-view/land-data/300000096.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9112",
-            "sheetId": "SD5055",
-            "area": 4.7141
+            "parcelId": "8823",
+            "sheetId": "SD7267"
+          },
+          {
+            "parcelId": "8856",
+            "sheetId": "SD6052"
+          },
+          {
+            "parcelId": "8867",
+            "sheetId": "SD6264"
+          },
+          {
+            "parcelId": "8930",
+            "sheetId": "SD8143"
+          },
+          {
+            "parcelId": "8936",
+            "sheetId": "SD7553"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000097.json
+++ b/src/server/common/services/consolidated-view/land-data/300000097.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9269",
-            "sheetId": "SD5055",
-            "area": 1.8377
+            "parcelId": "8973",
+            "sheetId": "SD6154"
+          },
+          {
+            "parcelId": "8977",
+            "sheetId": "SD8042"
+          },
+          {
+            "parcelId": "9003",
+            "sheetId": "SD6664"
+          },
+          {
+            "parcelId": "9005",
+            "sheetId": "SD7868"
+          },
+          {
+            "parcelId": "9010",
+            "sheetId": "SD7059"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000098.json
+++ b/src/server/common/services/consolidated-view/land-data/300000098.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9619",
-            "sheetId": "SD5055",
-            "area": 1.7609
+            "parcelId": "9049",
+            "sheetId": "SD6362"
+          },
+          {
+            "parcelId": "9063",
+            "sheetId": "SD5863"
+          },
+          {
+            "parcelId": "9110",
+            "sheetId": "SD8052"
+          },
+          {
+            "parcelId": "9121",
+            "sheetId": "SD7447"
+          },
+          {
+            "parcelId": "9139",
+            "sheetId": "SD8645"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000099.json
+++ b/src/server/common/services/consolidated-view/land-data/300000099.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9648",
-            "sheetId": "SD5055",
-            "area": 1.7908
+            "parcelId": "9142",
+            "sheetId": "SD5761"
+          },
+          {
+            "parcelId": "9150",
+            "sheetId": "SD8558"
+          },
+          {
+            "parcelId": "9160",
+            "sheetId": "SD7148"
+          },
+          {
+            "parcelId": "9177",
+            "sheetId": "SD7246"
+          },
+          {
+            "parcelId": "9179",
+            "sheetId": "SD7553"
           }
         ]
       },

--- a/src/server/common/services/consolidated-view/land-data/300000100.json
+++ b/src/server/common/services/consolidated-view/land-data/300000100.json
@@ -6,9 +6,24 @@
       "land": {
         "parcels": [
           {
-            "parcelId": "9966",
-            "sheetId": "SD5055",
-            "area": 1.0703
+            "parcelId": "9193",
+            "sheetId": "SD7560"
+          },
+          {
+            "parcelId": "9205",
+            "sheetId": "SD5848"
+          },
+          {
+            "parcelId": "9215",
+            "sheetId": "SD5649"
+          },
+          {
+            "parcelId": "9218",
+            "sheetId": "SD6165"
+          },
+          {
+            "parcelId": "9223",
+            "sheetId": "SD5763"
           }
         ]
       },


### PR DESCRIPTION
- Update land parcels in the mock dal data.
- Existing land parcels are now not on moorland and can't use for e2e testing and also to add 5 land parcels to each mock sbi instead only one land parcel.