### PR TITLE
Ignore stylelint major updates as stylelint-config-gds 2.0.0 does not…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "stylelint"
+        update-types: ["version-update:semver-major"]
     groups:
       weekly-dependencies:
         patterns:


### PR DESCRIPTION
… support anything beyond 16.x and has not been updated in 2 years.