### PR TITLE
TGC-1194 - Attempt to fix pact flakiness

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -51,6 +51,7 @@ jobs:
           npm run format:check
           npm run lint
           npm test
+          npm run test:contracts
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v5

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -33,6 +33,7 @@ jobs:
           npm run format:check
           npm run lint
           npm test
+          npm run test:contracts
 
       - name: Publish Hot Fix
         uses: DEFRA/cdp-build-action/build-hotfix@main

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "vitest run --coverage",
     "test:unit": "vitest run --config vitest.unit.config.js",
     "test:stryker": "vitest run --config vitest.stryker.config.js",
-    "test:contracts": "vitest run src/contracts",
+    "test:contracts": "vitest run --config vitest.contracts.config.js",
     "test:acceptance": "./tools/run-acceptance-tests.sh",
     "test:performance": "./tools/run-performance-tests.sh",
     "test:all": "./tools/run-all-tests.sh",

--- a/src/contracts/grants-ui-gas.contract.test.js
+++ b/src/contracts/grants-ui-gas.contract.test.js
@@ -1,8 +1,18 @@
 import fs from 'fs'
 import path from 'path'
 import { PactV4, SpecificationVersion, MatchersV3 } from '@pact-foundation/pact'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { makeGasApiRequest } from '../server/common/services/grant-application/grant-application.service.js'
+
+vi.mock('../server/common/helpers/retry.js', () => ({
+  retry: (operation) => operation()
+}))
+
+vi.mock('../server/common/helpers/logging/log.js', () => ({
+  debug: vi.fn(),
+  log: vi.fn(),
+  logger: { debug: vi.fn(), info: vi.fn(), error: vi.fn(), warn: vi.fn() }
+}))
 
 function createProvider() {
   return new PactV4({

--- a/src/contracts/v1/land-grants.client.contract.test.js
+++ b/src/contracts/v1/land-grants.client.contract.test.js
@@ -16,6 +16,10 @@ vi.mock('~/src/server/common/helpers/logging/log.js', () => ({
   }
 }))
 
+vi.mock('~/src/server/common/helpers/retry.js', () => ({
+  retry: (operation) => operation()
+}))
+
 const { like, eachLike, string } = MatchersV3
 
 function createProvider() {

--- a/src/contracts/v2/land-grants.client.contract.test.js
+++ b/src/contracts/v2/land-grants.client.contract.test.js
@@ -17,6 +17,10 @@ vi.mock('~/src/server/common/helpers/logging/log.js', () => ({
   }
 }))
 
+vi.mock('~/src/server/common/helpers/retry.js', () => ({
+  retry: (operation) => operation()
+}))
+
 const { like, eachLike, string } = MatchersV3
 
 function createProvider() {

--- a/src/server/land-grants/services/land-grants.client.js
+++ b/src/server/land-grants/services/land-grants.client.js
@@ -24,6 +24,7 @@ export async function postToLandGrantsApi(endpoint, body, baseUrl) {
     })
 
     if (!response.ok) {
+      await response.arrayBuffer()
       /**
        * @type {Error & {code?: number, status?: number}}
        */

--- a/src/server/land-grants/services/land-grants.client.test.js
+++ b/src/server/land-grants/services/land-grants.client.test.js
@@ -81,7 +81,8 @@ describe('Land Grants client', () => {
       mockFetch.mockResolvedValue({
         ok: false,
         status: 404,
-        statusText: 'Not Found'
+        statusText: 'Not Found',
+        arrayBuffer: vi.fn().mockResolvedValue(undefined)
       })
 
       await expect(postToLandGrantsApi('/invalid', {}, mockApiEndpoint)).rejects.toThrow('Not Found')
@@ -113,7 +114,8 @@ describe('Land Grants client', () => {
       mockFetch.mockResolvedValue({
         ok: false,
         status: 500,
-        statusText: 'Internal Server Error'
+        statusText: 'Internal Server Error',
+        arrayBuffer: vi.fn().mockResolvedValue(undefined)
       })
 
       try {
@@ -144,7 +146,8 @@ describe('Land Grants client', () => {
         ok: false,
         status: 400,
         statusText: 'Bad Request',
-        json: mockJson
+        json: mockJson,
+        arrayBuffer: vi.fn().mockResolvedValue(undefined)
       })
 
       try {
@@ -228,7 +231,8 @@ describe('Land Grants client', () => {
         mockFetch.mockResolvedValueOnce({
           ok: false,
           status,
-          statusText: `Error ${status}`
+          statusText: `Error ${status}`,
+          arrayBuffer: vi.fn().mockResolvedValue(undefined)
         })
 
         try {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,7 +8,7 @@ export default {
     environment: 'jsdom',
     setupFiles: ['./.vitest/setup-file.js'],
     include: ['**/src/**/*.test.js'],
-    exclude: ['**/node_modules/**', '**/.stryker-tmp/**'],
+    exclude: ['**/node_modules/**', '**/.stryker-tmp/**', '**/*.contract.test.js'],
     env: {
       GAS_API_AUTH_TOKEN: '00000000-0000-0000-0000-000000000000'
     },

--- a/vitest.contracts.config.js
+++ b/vitest.contracts.config.js
@@ -9,6 +9,7 @@ export default {
     include: ['src/contracts/**/*.contract.test.js'],
     exclude: ['**/node_modules/**', '**/.stryker-tmp/**'],
     fileParallelism: false,
+    sequence: { concurrent: false },
     setupFiles: [],
     coverage: {
       enabled: false

--- a/vitest.contracts.config.js
+++ b/vitest.contracts.config.js
@@ -7,6 +7,7 @@ export default {
     globals: true,
     environment: 'node',
     include: ['src/contracts/**/*.contract.test.js'],
+    exclude: ['**/node_modules/**', '**/.stryker-tmp/**'],
     fileParallelism: false,
     setupFiles: [],
     coverage: {

--- a/vitest.contracts.config.js
+++ b/vitest.contracts.config.js
@@ -1,0 +1,20 @@
+import baseConfig from './vitest.config.js'
+
+export default {
+  ...baseConfig,
+  test: {
+    ...baseConfig.test,
+    globals: true,
+    environment: 'node',
+    include: ['src/contracts/**/*.contract.test.js'],
+    fileParallelism: false,
+    setupFiles: [],
+    coverage: {
+      enabled: false
+    },
+    reporters: ['default'],
+    env: {
+      GAS_API_AUTH_TOKEN: '00000000-0000-0000-0000-000000000000'
+    }
+  }
+}


### PR DESCRIPTION
Two things were contributing to the flakiness:

1. Tests within a file running concurrently

fileParallelism: false serialises test files but not tests within a file. Multiple Pact mock servers were starting in parallel and racing on writes to the same pact file.

Fix: sequence: { concurrent: false } in the contracts vitest config.

2. retry not mocked in some contract test files

The client wraps requests in a retry helper. Without mocking it, retries could fire during the Pact mock server lifecycle and cause unexpected behaviour.

Fix: added a passthrough vi.mock for retry.js to the affected files, matching what was already done elsewhere.