### PR TITLE
Extend consolidated view service to support fetching permissionGroups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35231,9 +35231,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "sirv": "3.0.2",
     "follow-redirects": "^1.16.0",
     "underscore": "^1.13.8",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "webpack-dev-server": "5.2.4"
   },
   "dependencies": {
     "@babel/runtime": "7.29.2",

--- a/src/server/common/services/consolidated-view/consolidated-view.service.js
+++ b/src/server/common/services/consolidated-view/consolidated-view.service.js
@@ -218,6 +218,35 @@ async function makeStubRequest({ query, sbi, crn }) {
 }
 
 /**
+ * Fetches permission groups for a customer/business relationship from DAL.
+ *
+ * @param {AnyFormRequest} request
+ * @returns {Promise<Array<{
+ *   id: string,
+ *   level: string,
+ *   functions: string[]
+ * }>>}
+ */
+export const fetchBusinessPermissions = async (request) => {
+  const { credentials: { sbi, crn } = {} } = request.auth ?? {}
+  const query = `
+    query GetBusinessPermissions {
+      customer(crn: "${escapeGraphQLString(crn)}") {
+        business(sbi: "${escapeGraphQLString(sbi)}") {
+          permissionGroups {
+            id
+            level
+            functions
+          }
+        }
+      }
+    }
+  `
+  const formatResponse = (r) => r.data?.customer?.business?.permissionGroups || []
+  return fetchFromConsolidatedView(request, { query, formatResponse })
+}
+
+/**
  * Fetches business parcels data from Consolidated View
  * @param {AnyFormRequest} request
  * @returns {Promise<Array>} - Promise that resolves to the parcels array

--- a/src/server/common/services/consolidated-view/consolidated-view.service.test.js
+++ b/src/server/common/services/consolidated-view/consolidated-view.service.test.js
@@ -5,6 +5,7 @@ import { getValidToken } from '~/src/server/common/helpers/entra/token-manager.j
 import {
   fetchBusinessAndCustomerInformation,
   fetchParcelsFromDal,
+  fetchBusinessPermissions,
   executeConfigDrivenQuery,
   hasOnlyToleratedFailures,
   fetchBusinessAndCPH
@@ -408,6 +409,136 @@ describe('Consolidated View Service', () => {
         expect(error.details.status).toBe(500)
         expect(error.details.responseBody).toBe('Server error')
       }
+    })
+  })
+
+  describe('fetchBusinessPermissions', () => {
+    const mockPermissionGroups = [
+      {
+        id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
+        level: 'SUBMIT',
+        functions: ['View Applications', 'Submit CS Application']
+      },
+      {
+        id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS',
+        level: 'NO_ACCESS',
+        functions: []
+      }
+    ]
+
+    it('should fetch business permissions successfully', async () => {
+      mockFetchInstance.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              customer: {
+                business: {
+                  permissionGroups: mockPermissionGroups
+                }
+              }
+            }
+          })
+      })
+
+      const result = await fetchBusinessPermissions(mockRequest)
+
+      expect(result).toEqual(mockPermissionGroups)
+
+      expect(mockFetchInstance).toHaveBeenCalledTimes(1)
+
+      const [[, calledOptions]] = mockFetchInstance.mock.calls
+
+      expect(calledOptions.headers.Authorization).toBe(`Bearer ${mockToken}`)
+      expect(calledOptions.headers['Content-Type']).toBe('application/json')
+
+      const body = JSON.parse(calledOptions.body)
+
+      expect(body.query).toContain(`business(sbi: "${mockSbi}")`)
+      expect(body.query).toContain(`customer(crn: "${mockCrn}")`)
+      expect(body.query).toContain('query GetBusinessPermissions')
+      expect(body.query).toContain('permissionGroups')
+      expect(body.query).toContain('id')
+      expect(body.query).toContain('level')
+      expect(body.query).toContain('functions')
+    })
+
+    it('should return empty array when business is null', async () => {
+      mockFetchInstance.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              customer: {
+                business: null
+              }
+            }
+          })
+      })
+
+      const result = await fetchBusinessPermissions(mockRequest)
+
+      expect(result).toEqual([])
+    })
+
+    it('should return empty array when permissionGroups are missing', async () => {
+      mockFetchInstance.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              customer: {
+                business: {}
+              }
+            }
+          })
+      })
+
+      const result = await fetchBusinessPermissions(mockRequest)
+
+      expect(result).toEqual([])
+    })
+
+    it('should throw error when API call fails', async () => {
+      mockFetchInstance.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: () => Promise.resolve('Server error')
+      })
+
+      await expect(fetchBusinessPermissions(mockRequest)).rejects.toThrow(
+        'Failed to fetch business data: 500 Internal Server Error'
+      )
+    })
+
+    it('should execute query against stub in mock mode', async () => {
+      config.set('consolidatedView', {
+        apiEndpoint: 'https://api.example.com/graphql',
+        mockDALEnabled: true,
+        stubUrl: 'http://stub/graphql'
+      })
+
+      mockFetchInstance.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            customer: {
+              business: {
+                permissionGroups: mockPermissionGroups
+              }
+            }
+          }
+        })
+      })
+
+      const result = await fetchBusinessPermissions(mockRequest)
+
+      expect(result).toEqual(mockPermissionGroups)
+
+      const [url] = mockFetchInstance.mock.calls[0]
+
+      expect(url).toBe('http://stub/graphql')
     })
   })
 


### PR DESCRIPTION
This PR extends the existing consolidated-view.service.js DAL client to support fetching permissionGroups for a customer/business relationship.

It introduces a new helper function fetchBusinessPermissions which retrieves business-level permissions from the consolidated GraphQL API via the existing DAL abstraction.

This PR does not introduce any UI or business logic changes. It only exposes DAL capability required for upcoming permission-based UI decisions.

This enables downstream work to gate UI features based on permissionGroups and implement permission-aware routing and access control in grants UI