### PR TITLE
Enforce submit permissions for Countryside Stewardship applications

### DIFF
--- a/src/config/nunjucks/filters/format-date.test.js
+++ b/src/config/nunjucks/filters/format-date.test.js
@@ -26,8 +26,8 @@ describe('#formatDate', () => {
 
   describe('With format attribute', () => {
     test('Date should be in provided format', () => {
-      expect(formatDate('2023-02-01T11:40:02.242Z', "h:mm aaa 'on' EEEE do MMMM yyyy")).toBe(
-        '11:40 am on Wednesday 1st February 2023'
+      expect(formatDate('2023-02-01T11:40:02.242Z', "h:mm aaa 'on' EEEE do MMMM yyyy")).toContain(
+        'on Wednesday 1st February 2023'
       )
     })
   })

--- a/src/config/nunjucks/nunjucks.js
+++ b/src/config/nunjucks/nunjucks.js
@@ -28,7 +28,8 @@ export const viewPaths = (() => {
     path.join(serverDir, 'score-results/views'),
     path.join(serverDir, 'task-list/views'),
     path.join(serverDir, 'print-submitted-application/views'),
-    path.join(serverDir, 'woodland/views')
+    path.join(serverDir, 'woodland/views'),
+    path.join(serverDir, 'cannot-submit/views')
   ]
 })()
 

--- a/src/plugins/permissions.js
+++ b/src/plugins/permissions.js
@@ -1,0 +1,30 @@
+import { fetchBusinessPermissions } from '~/src/server/common/services/consolidated-view/consolidated-view.service.js'
+import { can } from '~/src/server/common/helpers/permissions/can.js'
+const EXCLUDED_PATHS = ['/health', '/assets', '/public', '/auth']
+
+function shouldSkip(request) {
+  return EXCLUDED_PATHS.some((path) => request.path.startsWith(path))
+}
+
+export default {
+  plugin: {
+    name: 'permissions',
+
+    register: async (server) => {
+      server.ext('onPostAuth', async (request, h) => {
+        if (!request.auth.isAuthenticated || shouldSkip(request)) {
+          return h.continue
+        }
+
+        const permissionGroups = await fetchBusinessPermissions(request)
+
+        request.auth.credentials.permissions = permissionGroups
+        request.can = (action, resource) => {
+          return can(permissionGroups, action, resource)
+        }
+
+        return h.continue
+      })
+    }
+  }
+}

--- a/src/plugins/permissions.test.js
+++ b/src/plugins/permissions.test.js
@@ -1,0 +1,133 @@
+import permissionsPlugin from './permissions.js'
+import { fetchBusinessPermissions } from '~/src/server/common/services/consolidated-view/consolidated-view.service.js'
+import { can } from '~/src/server/common/helpers/permissions/can.js'
+import { vi } from 'vitest'
+
+vi.mock('~/src/server/common/services/consolidated-view/consolidated-view.service.js', () => ({
+  fetchBusinessPermissions: vi.fn()
+}))
+
+vi.mock('~/src/server/common/helpers/permissions/can.js', () => ({
+  can: vi.fn()
+}))
+
+describe('permissions plugin', () => {
+  let onPostAuthHandler
+  let server
+  let h
+
+  beforeEach(async () => {
+    server = {
+      ext: vi.fn((event, handler) => {
+        onPostAuthHandler = handler
+      })
+    }
+
+    h = {
+      continue: Symbol('continue')
+    }
+
+    await permissionsPlugin.plugin.register(server)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('registers onPostAuth extension', () => {
+    expect(server.ext).toHaveBeenCalledWith('onPostAuth', expect.any(Function))
+  })
+
+  test('skips unauthenticated requests', async () => {
+    const request = {
+      path: '/some-path',
+      auth: {
+        isAuthenticated: false
+      }
+    }
+
+    const result = await onPostAuthHandler(request, h)
+
+    expect(fetchBusinessPermissions).not.toHaveBeenCalled()
+    expect(result).toBe(h.continue)
+  })
+
+  test.each(['/health', '/health/live', '/assets/file.js', '/public/test', '/auth/login'])(
+    'skips excluded path %s',
+    async (path) => {
+      const request = {
+        path,
+        auth: {
+          isAuthenticated: true
+        }
+      }
+
+      const result = await onPostAuthHandler(request, h)
+
+      expect(fetchBusinessPermissions).not.toHaveBeenCalled()
+      expect(result).toBe(h.continue)
+    }
+  )
+
+  test('fetches permissions for authenticated non-excluded requests', async () => {
+    const permissionGroups = ['group-1']
+
+    fetchBusinessPermissions.mockResolvedValue(permissionGroups)
+
+    const request = {
+      path: '/apply',
+      auth: {
+        isAuthenticated: true,
+        credentials: {}
+      }
+    }
+
+    const result = await onPostAuthHandler(request, h)
+
+    expect(fetchBusinessPermissions).toHaveBeenCalledWith(request)
+
+    expect(request.auth.credentials.permissions).toEqual(permissionGroups)
+
+    expect(result).toBe(h.continue)
+  })
+
+  test('adds request.can helper', async () => {
+    const permissionGroups = ['group-1']
+
+    fetchBusinessPermissions.mockResolvedValue(permissionGroups)
+
+    can.mockReturnValue(true)
+
+    const request = {
+      path: '/apply',
+      auth: {
+        isAuthenticated: true,
+        credentials: {}
+      }
+    }
+
+    await onPostAuthHandler(request, h)
+
+    const result = request.can('submit', 'application')
+
+    expect(can).toHaveBeenCalledWith(permissionGroups, 'submit', 'application')
+
+    expect(result).toBe(true)
+  })
+
+  test('propagates errors from fetchBusinessPermissions', async () => {
+    const error = new Error('permissions failed')
+
+    fetchBusinessPermissions.mockRejectedValue(error)
+
+    const request = {
+      path: '/apply',
+      auth: {
+        isAuthenticated: true,
+        credentials: {}
+      }
+    }
+
+    await expect(onPostAuthHandler(request, h)).rejects.toThrow(error)
+  })
+})

--- a/src/server/cannot-submit/cannot-submit.route.js
+++ b/src/server/cannot-submit/cannot-submit.route.js
@@ -1,0 +1,9 @@
+export const cannotSubmitRoute = {
+  method: 'GET',
+  path: '/cannot-submit',
+  handler: (request, h) => {
+    return h.view('cannot-submit', {
+      returnUrl: request.query.returnUrl
+    })
+  }
+}

--- a/src/server/cannot-submit/cannot-submit.route.test.js
+++ b/src/server/cannot-submit/cannot-submit.route.test.js
@@ -1,0 +1,47 @@
+import { describe, test, expect, vi } from 'vitest'
+import { cannotSubmitRoute } from './cannot-submit.route.js'
+
+describe('cannotSubmitRoute', () => {
+  test('has correct method and path', () => {
+    expect(cannotSubmitRoute.method).toBe('GET')
+    expect(cannotSubmitRoute.path).toBe('/cannot-submit')
+  })
+
+  test('renders cannot-submit view with returnUrl from query', () => {
+    const request = {
+      query: {
+        returnUrl: '/task-list'
+      }
+    }
+
+    const h = {
+      view: vi.fn().mockReturnValue('rendered-view')
+    }
+
+    const result = cannotSubmitRoute.handler(request, h)
+
+    expect(h.view).toHaveBeenCalledWith('cannot-submit', {
+      returnUrl: '/task-list'
+    })
+
+    expect(result).toBe('rendered-view')
+  })
+
+  test('renders cannot-submit view with undefined returnUrl when absent', () => {
+    const request = {
+      query: {}
+    }
+
+    const h = {
+      view: vi.fn().mockReturnValue('rendered-view')
+    }
+
+    const result = cannotSubmitRoute.handler(request, h)
+
+    expect(h.view).toHaveBeenCalledWith('cannot-submit', {
+      returnUrl: undefined
+    })
+
+    expect(result).toBe('rendered-view')
+  })
+})

--- a/src/server/cannot-submit/index.js
+++ b/src/server/cannot-submit/index.js
@@ -1,0 +1,11 @@
+import { cannotSubmitRoute } from './cannot-submit.route.js'
+
+export const cannotSubmit = {
+  plugin: {
+    name: 'cannot-submit',
+
+    register: async (server) => {
+      server.route([cannotSubmitRoute])
+    }
+  }
+}

--- a/src/server/cannot-submit/views/cannot-submit.njk
+++ b/src/server/cannot-submit/views/cannot-submit.njk
@@ -1,0 +1,46 @@
+{% extends "layouts/page.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      You cannot submit this application
+    </h1>
+
+    <p class="govuk-body">
+      Your progress has been saved.
+    </p>
+
+    <p class="govuk-body">
+      You do not have permission to submit the application.
+    </p>
+
+    <p class="govuk-body">
+      Contact an authorised person from your business to review and submit the application.
+    </p>
+
+    {{ govukButton({
+      text: "Return to task list",
+      href: returnUrl
+    }) }}
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          If you have a question
+        </span>
+      </summary>
+
+      <div class="govuk-details__text">
+        Contact the support team.
+      </div>
+    </details>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/src/server/common/helpers/permissions/can.js
+++ b/src/server/common/helpers/permissions/can.js
@@ -19,7 +19,7 @@ export const can = (permissionGroups, action, resource) => {
     return false
   }
 
-  const requiredLevel = rule.actions[action]
+  const requiredLevel = rule.permissions[action]
 
   if (!requiredLevel) {
     return false

--- a/src/server/common/helpers/permissions/can.test.js
+++ b/src/server/common/helpers/permissions/can.test.js
@@ -6,18 +6,6 @@ describe('can', () => {
     {
       id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
       level: 'SUBMIT'
-    },
-    {
-      id: 'LAND_DETAILS',
-      level: 'AMEND'
-    },
-    {
-      id: 'BUSINESS_DETAILS',
-      level: 'FULL_PERMISSION'
-    },
-    {
-      id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS',
-      level: 'NO_ACCESS'
     }
   ]
 
@@ -35,49 +23,63 @@ describe('can', () => {
     })
   })
 
-  describe('LAND_DETAILS', () => {
-    it('should allow amend when level is AMEND', () => {
-      expect(can(permissionGroups, 'amend', 'landDetails')).toBe(true)
+  describe('permission hierarchy', () => {
+    it('should allow VIEW when user has VIEW', () => {
+      const permissionGroups = [
+        {
+          id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
+          level: 'VIEW'
+        }
+      ]
+
+      expect(can(permissionGroups, 'view', 'csApplications')).toBe(true)
     })
 
-    it('should allow view when level is AMEND', () => {
-      expect(can(permissionGroups, 'view', 'landDetails')).toBe(true)
+    it('should not allow AMEND when user only has VIEW', () => {
+      const permissionGroups = [
+        {
+          id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
+          level: 'VIEW'
+        }
+      ]
+
+      expect(can(permissionGroups, 'amend', 'csApplications')).toBe(false)
     })
 
-    it('should deny submit when level is AMEND', () => {
-      expect(can(permissionGroups, 'submit', 'landDetails')).toBe(false)
+    it('should not allow SUBMIT when user only has AMEND', () => {
+      const permissionGroups = [
+        {
+          id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
+          level: 'AMEND'
+        }
+      ]
+
+      expect(can(permissionGroups, 'submit', 'csApplications')).toBe(false)
+    })
+
+    it('should allow VIEW when user has AMEND', () => {
+      const permissionGroups = [
+        {
+          id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
+          level: 'AMEND'
+        }
+      ]
+
+      expect(can(permissionGroups, 'view', 'csApplications')).toBe(true)
     })
   })
 
-  describe('BUSINESS_DETAILS', () => {
-    it('should allow submit when level is FULL_PERMISSION', () => {
-      expect(can(permissionGroups, 'submit', 'businessDetails')).toBe(true)
-    })
+  describe('missing or uknown permissions', () => {
+    it('should return false for unknown permission level', () => {
+      const permissionGroups = [
+        {
+          id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
+          level: 'INVALID'
+        }
+      ]
 
-    it('should allow amend when level is FULL_PERMISSION', () => {
-      expect(can(permissionGroups, 'amend', 'businessDetails')).toBe(true)
+      expect(can(permissionGroups, 'view', 'csApplications')).toBe(false)
     })
-
-    it('should allow view when level is FULL_PERMISSION', () => {
-      expect(can(permissionGroups, 'view', 'businessDetails')).toBe(true)
-    })
-  })
-
-  describe('NO_ACCESS permissions', () => {
-    it('should deny view when level is NO_ACCESS', () => {
-      expect(can(permissionGroups, 'view', 'elmApplications')).toBe(false)
-    })
-
-    it('should deny amend when level is NO_ACCESS', () => {
-      expect(can(permissionGroups, 'amend', 'elmApplications')).toBe(false)
-    })
-
-    it('should deny submit when level is NO_ACCESS', () => {
-      expect(can(permissionGroups, 'submit', 'elmApplications')).toBe(false)
-    })
-  })
-
-  describe('missing permissions', () => {
     it('should return false when permission group is missing', () => {
       expect(can(permissionGroups, 'view', 'csAgreements')).toBe(false)
     })

--- a/src/server/common/helpers/permissions/countryside-stewardship.permissions.js
+++ b/src/server/common/helpers/permissions/countryside-stewardship.permissions.js
@@ -1,0 +1,7 @@
+import { can } from './can.js'
+
+export const canViewCsApplication = (permissions) => can(permissions, 'view', 'csApplications')
+
+export const canAmendCsApplication = (permissions) => can(permissions, 'amend', 'csApplications')
+
+export const canSubmitCsApplication = (permissions) => can(permissions, 'submit', 'csApplications')

--- a/src/server/common/helpers/permissions/guards/require-cs-submit-permission.js
+++ b/src/server/common/helpers/permissions/guards/require-cs-submit-permission.js
@@ -5,7 +5,7 @@ import { canSubmitCsApplication } from '../countryside-stewardship.permissions.j
 export const requireCsSubmitPermission = requirePermission({
   hasPermission: canSubmitCsApplication,
 
-  onFail: (request, h, { returnUrl }) => {
+  onFail: (_request, h, { returnUrl }) => {
     const redirectUrl = returnUrl
       ? `${permissionPaths.cannotSubmit}?returnUrl=${encodeURIComponent(returnUrl)}`
       : permissionPaths.cannotSubmit

--- a/src/server/common/helpers/permissions/guards/require-cs-submit-permission.js
+++ b/src/server/common/helpers/permissions/guards/require-cs-submit-permission.js
@@ -3,8 +3,8 @@ import { permissionPaths, requirePermission } from './require-permission.js'
 import { canSubmitCsApplication } from '../countryside-stewardship.permissions.js'
 
 export const requireCsSubmitPermission = requirePermission({
-  hasPermission: canSubmitCsApplication,
-
+  permission: 'submit',
+  isAuthorised: canSubmitCsApplication,
   onFail: (_request, h, { returnUrl }) => {
     const redirectUrl = returnUrl
       ? `${permissionPaths.cannotSubmit}?returnUrl=${encodeURIComponent(returnUrl)}`

--- a/src/server/common/helpers/permissions/guards/require-cs-submit-permission.js
+++ b/src/server/common/helpers/permissions/guards/require-cs-submit-permission.js
@@ -1,0 +1,14 @@
+import { permissionPaths, requirePermission } from './require-permission.js'
+
+import { canSubmitCsApplication } from '../countryside-stewardship.permissions.js'
+
+export const requireCsSubmitPermission = requirePermission({
+  hasPermission: canSubmitCsApplication,
+
+  onFail: (request, h, { returnUrl }) => {
+    const redirectUrl = returnUrl
+      ? `${permissionPaths.cannotSubmit}?returnUrl=${encodeURIComponent(returnUrl)}`
+      : permissionPaths.cannotSubmit
+    return h.redirect(redirectUrl).takeover()
+  }
+})

--- a/src/server/common/helpers/permissions/guards/require-cs-submit-permission.test.js
+++ b/src/server/common/helpers/permissions/guards/require-cs-submit-permission.test.js
@@ -3,6 +3,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 const mockRequirePermission = vi.fn((config) => config)
 
 vi.mock('./require-permission.js', () => ({
+  permission: 'submit',
   permissionPaths: {
     cannotSubmit: '/cannot-submit'
   },
@@ -23,7 +24,8 @@ describe('requireSubmitCsApplication', () => {
     await import('./require-cs-submit-permission.js')
 
     expect(mockRequirePermission).toHaveBeenCalledWith({
-      hasPermission: expect.any(Function),
+      permission: 'submit',
+      isAuthorised: expect.any(Function),
       onFail: expect.any(Function)
     })
   })

--- a/src/server/common/helpers/permissions/guards/require-cs-submit-permission.test.js
+++ b/src/server/common/helpers/permissions/guards/require-cs-submit-permission.test.js
@@ -1,0 +1,73 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+const mockRequirePermission = vi.fn((config) => config)
+
+vi.mock('./require-permission.js', () => ({
+  permissionPaths: {
+    cannotSubmit: '/cannot-submit'
+  },
+  requirePermission: mockRequirePermission
+}))
+
+vi.mock('../countryside-stewardship.permissions.js', () => ({
+  canSubmitCsApplication: vi.fn()
+}))
+
+describe('requireSubmitCsApplication', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  test('configures requirePermission correctly', async () => {
+    await import('./require-cs-submit-permission.js')
+
+    expect(mockRequirePermission).toHaveBeenCalledWith({
+      hasPermission: expect.any(Function),
+      onFail: expect.any(Function)
+    })
+  })
+
+  test('redirects to cannot-submit without returnUrl', async () => {
+    await import('./require-cs-submit-permission.js')
+
+    const config = mockRequirePermission.mock.calls.at(-1)[0]
+
+    const takeover = vi.fn().mockReturnValue('taken-over')
+
+    const h = {
+      redirect: vi.fn().mockReturnValue({
+        takeover
+      })
+    }
+
+    const result = config.onFail({}, h, {})
+
+    expect(h.redirect).toHaveBeenCalledWith('/cannot-submit')
+    expect(takeover).toHaveBeenCalled()
+    expect(result).toBe('taken-over')
+  })
+
+  test('redirects with encoded returnUrl when provided', async () => {
+    await import('./require-cs-submit-permission.js')
+
+    const config = mockRequirePermission.mock.calls.at(-1)[0]
+
+    const takeover = vi.fn().mockReturnValue('taken-over')
+
+    const h = {
+      redirect: vi.fn().mockReturnValue({
+        takeover
+      })
+    }
+
+    const result = config.onFail({}, h, {
+      returnUrl: '/task-list?foo=bar&baz=1'
+    })
+
+    expect(h.redirect).toHaveBeenCalledWith('/cannot-submit?returnUrl=%2Ftask-list%3Ffoo%3Dbar%26baz%3D1')
+
+    expect(takeover).toHaveBeenCalled()
+    expect(result).toBe('taken-over')
+  })
+})

--- a/src/server/common/helpers/permissions/guards/require-permission.js
+++ b/src/server/common/helpers/permissions/guards/require-permission.js
@@ -1,4 +1,7 @@
 import { getTaskListPath } from '~/src/server/task-list/task-list.helper.js'
+import { isPermissionEnforced } from '../permission-config.js'
+import { getGrantCode } from '../../grant-code.js'
+import { logPermissionEvent } from '../permission-logger.js'
 
 export const permissionPaths = {
   cannotSubmit: '/cannot-submit'
@@ -21,11 +24,28 @@ export function getReturnToApplicationPath(model, basePath) {
   return `${basePath}/summary`
 }
 
-export const requirePermission = ({ hasPermission, onFail }) => {
+export const requirePermission = ({ permission, isAuthorised, onFail }) => {
   return (request, h, context = {}) => {
+    if (!isPermissionEnforced(request)) {
+      logPermissionEvent({
+        request,
+        grantCode: getGrantCode(request),
+        permission,
+        enforcementEnabled: false,
+        authorised: true
+      })
+      return h.continue
+    }
     const permissions = request.auth.credentials.permissions || []
-
-    if (hasPermission(permissions)) {
+    const authorised = isAuthorised(permissions)
+    logPermissionEvent({
+      request,
+      grantCode: getGrantCode(request),
+      permission,
+      enforcementEnabled: true,
+      authorised
+    })
+    if (authorised) {
       return h.continue
     }
 

--- a/src/server/common/helpers/permissions/guards/require-permission.js
+++ b/src/server/common/helpers/permissions/guards/require-permission.js
@@ -1,0 +1,34 @@
+import { getTaskListPath } from '~/src/server/task-list/task-list.helper.js'
+
+export const permissionPaths = {
+  cannotSubmit: '/cannot-submit'
+}
+
+/**
+ * Gets the best "return" URL for a form.
+ * Falls back to check responses if no task list exists.
+ * @param {object} model
+ * @param {string} basePath
+ * @returns {string}
+ */
+export function getReturnToApplicationPath(model, basePath) {
+  const taskListPath = getTaskListPath(model)
+
+  if (taskListPath) {
+    return `${basePath}${taskListPath}`
+  }
+
+  return `${basePath}/summary`
+}
+
+export const requirePermission = ({ hasPermission, onFail }) => {
+  return (request, h, context = {}) => {
+    const permissions = request.auth.credentials.permissions || []
+
+    if (hasPermission(permissions)) {
+      return h.continue
+    }
+
+    return onFail(request, h, context)
+  }
+}

--- a/src/server/common/helpers/permissions/guards/require-permission.test.js
+++ b/src/server/common/helpers/permissions/guards/require-permission.test.js
@@ -2,9 +2,24 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { permissionPaths, getReturnToApplicationPath, requirePermission } from './require-permission.js'
 
 import { getTaskListPath } from '~/src/server/task-list/task-list.helper.js'
+import { isPermissionEnforced } from '../permission-config.js'
+import { logPermissionEvent } from '../permission-logger.js'
+import { getGrantCode } from '../../grant-code.js'
 
 vi.mock('~/src/server/task-list/task-list.helper.js', () => ({
   getTaskListPath: vi.fn()
+}))
+
+vi.mock('../permission-config.js', () => ({
+  isPermissionEnforced: vi.fn()
+}))
+
+vi.mock('../permission-logger.js', () => ({
+  logPermissionEvent: vi.fn()
+}))
+
+vi.mock('../../grant-code.js', () => ({
+  getGrantCode: vi.fn()
 }))
 
 describe('permissionPaths', () => {
@@ -54,13 +69,15 @@ describe('getReturnToApplicationPath', () => {
 })
 
 describe('requirePermission', () => {
-  let hasPermission
+  let isAuthorised
   let onFail
   let request
   let h
 
   beforeEach(() => {
-    hasPermission = vi.fn()
+    vi.clearAllMocks()
+
+    isAuthorised = vi.fn()
     onFail = vi.fn()
 
     request = {
@@ -74,11 +91,15 @@ describe('requirePermission', () => {
     h = {
       continue: Symbol('continue')
     }
+
+    isPermissionEnforced.mockReturnValue(true)
+    getGrantCode.mockReturnValue('cs')
   })
 
   test('returns middleware function', () => {
     const middleware = requirePermission({
-      hasPermission,
+      permission: 'submit',
+      isAuthorised,
       onFail
     })
 
@@ -86,16 +107,25 @@ describe('requirePermission', () => {
   })
 
   test('returns h.continue when permission check passes', () => {
-    hasPermission.mockReturnValue(true)
+    isAuthorised.mockReturnValue(true)
 
     const middleware = requirePermission({
-      hasPermission,
+      permission: 'submit',
+      isAuthorised,
       onFail
     })
 
     const result = middleware(request, h)
 
-    expect(hasPermission).toHaveBeenCalledWith(['permission-1'])
+    expect(isAuthorised).toHaveBeenCalledWith(['permission-1'])
+
+    expect(logPermissionEvent).toHaveBeenCalledWith({
+      request,
+      grantCode: 'cs',
+      permission: 'submit',
+      enforcementEnabled: true,
+      authorised: true
+    })
 
     expect(onFail).not.toHaveBeenCalled()
 
@@ -103,12 +133,13 @@ describe('requirePermission', () => {
   })
 
   test('calls onFail when permission check fails', () => {
-    hasPermission.mockReturnValue(false)
+    isAuthorised.mockReturnValue(false)
 
     onFail.mockReturnValue('redirected')
 
     const middleware = requirePermission({
-      hasPermission,
+      permission: 'submit',
+      isAuthorised,
       onFail
     })
 
@@ -118,33 +149,69 @@ describe('requirePermission', () => {
 
     const result = middleware(request, h, context)
 
-    expect(hasPermission).toHaveBeenCalledWith(['permission-1'])
+    expect(isAuthorised).toHaveBeenCalledWith(['permission-1'])
+
+    expect(logPermissionEvent).toHaveBeenCalledWith({
+      request,
+      grantCode: 'cs',
+      permission: 'submit',
+      enforcementEnabled: true,
+      authorised: false
+    })
 
     expect(onFail).toHaveBeenCalledWith(request, h, context)
 
     expect(result).toBe('redirected')
   })
 
+  test('returns h.continue when permission enforcement is disabled', () => {
+    isPermissionEnforced.mockReturnValue(false)
+
+    const middleware = requirePermission({
+      permission: 'submit',
+      isAuthorised,
+      onFail
+    })
+
+    const result = middleware(request, h)
+
+    expect(isAuthorised).not.toHaveBeenCalled()
+
+    expect(logPermissionEvent).toHaveBeenCalledWith({
+      request,
+      grantCode: 'cs',
+      permission: 'submit',
+      enforcementEnabled: false,
+      authorised: true
+    })
+
+    expect(onFail).not.toHaveBeenCalled()
+
+    expect(result).toBe(h.continue)
+  })
+
   test('uses empty permissions array when permissions are undefined', () => {
     request.auth.credentials.permissions = undefined
 
-    hasPermission.mockReturnValue(true)
+    isAuthorised.mockReturnValue(true)
 
     const middleware = requirePermission({
-      hasPermission,
+      permission: 'submit',
+      isAuthorised,
       onFail
     })
 
     middleware(request, h)
 
-    expect(hasPermission).toHaveBeenCalledWith([])
+    expect(isAuthorised).toHaveBeenCalledWith([])
   })
 
   test('uses default empty context object', () => {
-    hasPermission.mockReturnValue(false)
+    isAuthorised.mockReturnValue(false)
 
     const middleware = requirePermission({
-      hasPermission,
+      permission: 'submit',
+      isAuthorised,
       onFail
     })
 

--- a/src/server/common/helpers/permissions/guards/require-permission.test.js
+++ b/src/server/common/helpers/permissions/guards/require-permission.test.js
@@ -1,0 +1,155 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { permissionPaths, getReturnToApplicationPath, requirePermission } from './require-permission.js'
+
+import { getTaskListPath } from '~/src/server/task-list/task-list.helper.js'
+
+vi.mock('~/src/server/task-list/task-list.helper.js', () => ({
+  getTaskListPath: vi.fn()
+}))
+
+describe('permissionPaths', () => {
+  test('exports cannotSubmit path', () => {
+    expect(permissionPaths).toEqual({
+      cannotSubmit: '/cannot-submit'
+    })
+  })
+})
+
+describe('getReturnToApplicationPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns task list path when available', () => {
+    getTaskListPath.mockReturnValue('/task-list')
+
+    const model = { id: 'model' }
+
+    const result = getReturnToApplicationPath(model, '/my-grant')
+
+    expect(getTaskListPath).toHaveBeenCalledWith(model)
+
+    expect(result).toBe('/my-grant/task-list')
+  })
+
+  test('falls back to summary path when task list path is not available', () => {
+    getTaskListPath.mockReturnValue(undefined)
+
+    const model = { id: 'model' }
+
+    const result = getReturnToApplicationPath(model, '/my-grant')
+
+    expect(getTaskListPath).toHaveBeenCalledWith(model)
+
+    expect(result).toBe('/my-grant/summary')
+  })
+
+  test.each([null, ''])('falls back to summary path when task list path is %s', (taskListPath) => {
+    getTaskListPath.mockReturnValue(taskListPath)
+
+    const result = getReturnToApplicationPath({}, '/my-grant')
+
+    expect(result).toBe('/my-grant/summary')
+  })
+})
+
+describe('requirePermission', () => {
+  let hasPermission
+  let onFail
+  let request
+  let h
+
+  beforeEach(() => {
+    hasPermission = vi.fn()
+    onFail = vi.fn()
+
+    request = {
+      auth: {
+        credentials: {
+          permissions: ['permission-1']
+        }
+      }
+    }
+
+    h = {
+      continue: Symbol('continue')
+    }
+  })
+
+  test('returns middleware function', () => {
+    const middleware = requirePermission({
+      hasPermission,
+      onFail
+    })
+
+    expect(typeof middleware).toBe('function')
+  })
+
+  test('returns h.continue when permission check passes', () => {
+    hasPermission.mockReturnValue(true)
+
+    const middleware = requirePermission({
+      hasPermission,
+      onFail
+    })
+
+    const result = middleware(request, h)
+
+    expect(hasPermission).toHaveBeenCalledWith(['permission-1'])
+
+    expect(onFail).not.toHaveBeenCalled()
+
+    expect(result).toBe(h.continue)
+  })
+
+  test('calls onFail when permission check fails', () => {
+    hasPermission.mockReturnValue(false)
+
+    onFail.mockReturnValue('redirected')
+
+    const middleware = requirePermission({
+      hasPermission,
+      onFail
+    })
+
+    const context = {
+      returnUrl: '/task-list'
+    }
+
+    const result = middleware(request, h, context)
+
+    expect(hasPermission).toHaveBeenCalledWith(['permission-1'])
+
+    expect(onFail).toHaveBeenCalledWith(request, h, context)
+
+    expect(result).toBe('redirected')
+  })
+
+  test('uses empty permissions array when permissions are undefined', () => {
+    request.auth.credentials.permissions = undefined
+
+    hasPermission.mockReturnValue(true)
+
+    const middleware = requirePermission({
+      hasPermission,
+      onFail
+    })
+
+    middleware(request, h)
+
+    expect(hasPermission).toHaveBeenCalledWith([])
+  })
+
+  test('uses default empty context object', () => {
+    hasPermission.mockReturnValue(false)
+
+    const middleware = requirePermission({
+      hasPermission,
+      onFail
+    })
+
+    middleware(request, h)
+
+    expect(onFail).toHaveBeenCalledWith(request, h, {})
+  })
+})

--- a/src/server/common/helpers/permissions/permission-config.js
+++ b/src/server/common/helpers/permissions/permission-config.js
@@ -1,0 +1,3 @@
+export function isPermissionEnforced(request) {
+  return request.app?.model?.def?.metadata?.permissions?.enforce !== false
+}

--- a/src/server/common/helpers/permissions/permission-config.test.js
+++ b/src/server/common/helpers/permissions/permission-config.test.js
@@ -1,0 +1,73 @@
+import { describe, test, expect } from 'vitest'
+
+import { isPermissionEnforced } from './permission-config.js'
+
+describe('isPermissionEnforced', () => {
+  test('returns true when permissions config is missing', () => {
+    const request = {
+      app: {
+        model: {
+          def: {
+            metadata: {}
+          }
+        }
+      }
+    }
+
+    expect(isPermissionEnforced(request)).toBe(true)
+  })
+
+  test('returns true when permissions object is missing', () => {
+    const request = {
+      app: {
+        model: {
+          def: {
+            metadata: {}
+          }
+        }
+      }
+    }
+
+    expect(isPermissionEnforced(request)).toBe(true)
+  })
+
+  test('returns true when enforce is true', () => {
+    const request = {
+      app: {
+        model: {
+          def: {
+            metadata: {
+              permissions: {
+                enforce: true
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(isPermissionEnforced(request)).toBe(true)
+  })
+
+  test('returns false when enforce is false', () => {
+    const request = {
+      app: {
+        model: {
+          def: {
+            metadata: {
+              permissions: {
+                enforce: false
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(isPermissionEnforced(request)).toBe(false)
+  })
+
+  test('returns true when request shape is incomplete', () => {
+    expect(isPermissionEnforced({})).toBe(true)
+  })
+})

--- a/src/server/common/helpers/permissions/permission-levels.js
+++ b/src/server/common/helpers/permissions/permission-levels.js
@@ -1,7 +1,7 @@
-export const permissionLevels = {
+export const permissionLevels = Object.freeze({
   NO_ACCESS: 0,
   VIEW: 1,
   AMEND: 2,
   SUBMIT: 3,
   FULL_PERMISSION: 4
-}
+})

--- a/src/server/common/helpers/permissions/permission-logger.js
+++ b/src/server/common/helpers/permissions/permission-logger.js
@@ -1,0 +1,23 @@
+export function logPermissionEvent({ request, grantCode, permission, enforcementEnabled, authorised }) {
+  const userId = request.auth.credentials?.contactId
+
+  const event = {
+    grantCode,
+    permission,
+    userId,
+    enforcementEnabled,
+    authorised
+  }
+
+  if (!enforcementEnabled) {
+    request.logger.info(event, 'Permission enforcement bypassed')
+    return
+  }
+
+  if (authorised) {
+    request.logger.info(event, 'Permission check successful')
+    return
+  }
+
+  request.logger.warn(event, 'Permission check failed')
+}

--- a/src/server/common/helpers/permissions/permission-logger.test.js
+++ b/src/server/common/helpers/permissions/permission-logger.test.js
@@ -1,0 +1,113 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+import { logPermissionEvent } from './permission-logger.js'
+
+describe('logPermissionEvent', () => {
+  let request
+
+  beforeEach(() => {
+    request = {
+      auth: {
+        credentials: {
+          contactId: 'user-123'
+        }
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn()
+      }
+    }
+  })
+
+  test('logs bypassed enforcement as info', () => {
+    logPermissionEvent({
+      request,
+      grantCode: 'cs',
+      permission: 'submit',
+      enforcementEnabled: false,
+      authorised: true
+    })
+
+    expect(request.logger.info).toHaveBeenCalledWith(
+      {
+        grantCode: 'cs',
+        permission: 'submit',
+        userId: 'user-123',
+        enforcementEnabled: false,
+        authorised: true
+      },
+      'Permission enforcement bypassed'
+    )
+
+    expect(request.logger.warn).not.toHaveBeenCalled()
+  })
+
+  test('logs successful permission check as info', () => {
+    logPermissionEvent({
+      request,
+      grantCode: 'cs',
+      permission: 'submit',
+      enforcementEnabled: true,
+      authorised: true
+    })
+
+    expect(request.logger.info).toHaveBeenCalledWith(
+      {
+        grantCode: 'cs',
+        permission: 'submit',
+        userId: 'user-123',
+        enforcementEnabled: true,
+        authorised: true
+      },
+      'Permission check successful'
+    )
+
+    expect(request.logger.warn).not.toHaveBeenCalled()
+  })
+
+  test('logs failed permission check as warn', () => {
+    logPermissionEvent({
+      request,
+      grantCode: 'cs',
+      permission: 'submit',
+      enforcementEnabled: true,
+      authorised: false
+    })
+
+    expect(request.logger.warn).toHaveBeenCalledWith(
+      {
+        grantCode: 'cs',
+        permission: 'submit',
+        userId: 'user-123',
+        enforcementEnabled: true,
+        authorised: false
+      },
+      'Permission check failed'
+    )
+
+    expect(request.logger.info).not.toHaveBeenCalled()
+  })
+
+  test('handles missing contactId', () => {
+    request.auth.credentials.contactId = undefined
+
+    logPermissionEvent({
+      request,
+      grantCode: 'cs',
+      permission: 'submit',
+      enforcementEnabled: true,
+      authorised: true
+    })
+
+    expect(request.logger.info).toHaveBeenCalledWith(
+      {
+        grantCode: 'cs',
+        permission: 'submit',
+        userId: undefined,
+        enforcementEnabled: true,
+        authorised: true
+      },
+      'Permission check successful'
+    )
+  })
+})

--- a/src/server/common/helpers/permissions/permission-rules.js
+++ b/src/server/common/helpers/permissions/permission-rules.js
@@ -7,34 +7,5 @@ export const permissionRules = {
       amend: 'AMEND',
       submit: 'SUBMIT'
     }
-  },
-
-  csAgreements: {
-    permissionGroup: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS',
-
-    permissions: {
-      view: 'VIEW',
-      amend: 'AMEND',
-      submit: 'SUBMIT'
-    }
-  },
-
-  landDetails: {
-    permissionGroup: 'LAND_DETAILS',
-
-    permissions: {
-      view: 'VIEW',
-      amend: 'AMEND'
-    }
-  },
-
-  businessDetails: {
-    permissionGroup: 'BUSINESS_DETAILS',
-
-    permissions: {
-      view: 'VIEW',
-      amend: 'AMEND',
-      submit: 'FULL_PERMISSION'
-    }
   }
 }

--- a/src/server/common/helpers/permissions/permission-rules.js
+++ b/src/server/common/helpers/permissions/permission-rules.js
@@ -2,7 +2,7 @@ export const permissionRules = {
   csApplications: {
     permissionGroup: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
 
-    actions: {
+    permissions: {
       view: 'VIEW',
       amend: 'AMEND',
       submit: 'SUBMIT'
@@ -12,7 +12,7 @@ export const permissionRules = {
   csAgreements: {
     permissionGroup: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS',
 
-    actions: {
+    permissions: {
       view: 'VIEW',
       amend: 'AMEND',
       submit: 'SUBMIT'
@@ -22,7 +22,7 @@ export const permissionRules = {
   landDetails: {
     permissionGroup: 'LAND_DETAILS',
 
-    actions: {
+    permissions: {
       view: 'VIEW',
       amend: 'AMEND'
     }
@@ -31,7 +31,7 @@ export const permissionRules = {
   businessDetails: {
     permissionGroup: 'BUSINESS_DETAILS',
 
-    actions: {
+    permissions: {
       view: 'VIEW',
       amend: 'AMEND',
       submit: 'FULL_PERMISSION'

--- a/src/server/declaration/declaration-page.controller.js
+++ b/src/server/declaration/declaration-page.controller.js
@@ -11,6 +11,8 @@ import { log, LogCodes } from '../common/helpers/logging/log.js'
 import { getTaskPageBackLink } from '~/src/server/task-list/task-list.helper.js'
 import { getGrantCode } from '../common/helpers/grant-code.js'
 import { transformWoodlandAnswers } from '~/src/server/woodland/mappers/state-to-gas-answers-mapper.js'
+import { requireCsSubmitPermission } from '~/src/server/common/helpers/permissions/guards/require-cs-submit-permission.js'
+import { getReturnToApplicationPath } from '../common/helpers/permissions/guards/require-permission.js'
 
 /** @type {Record<string, (submissionState: Record<string, unknown>, rawState: Record<string, unknown>) => object>} */
 const answerTransformers = {
@@ -190,6 +192,11 @@ export default class DeclarationPageController extends SummaryPageController {
 
   makePostRouteHandler() {
     return async (request, context, h) => {
+      const returnUrl = getReturnToApplicationPath(this.model, request.params.slug ? `/${request.params.slug}` : '')
+      const permissionResult = requireCsSubmitPermission(request, h, { returnUrl })
+      if (permissionResult !== h.continue) {
+        return permissionResult
+      }
       const { sbi, crn } = request.auth.credentials
       storeSlugInContext(request, context, 'DeclarationController')
 

--- a/src/server/declaration/declaration-page.controller.test.js
+++ b/src/server/declaration/declaration-page.controller.test.js
@@ -9,6 +9,7 @@ import { statusCodes } from '~/src/server/common/constants/status-codes.js'
 import { handleGasApiError } from '~/src/server/common/helpers/gas-error-messages.js'
 import { log, LogCodes } from '../common/helpers/logging/log.js'
 import { getTaskPageBackLink } from '~/src/server/task-list/task-list.helper.js'
+import { requireCsSubmitPermission } from '~/src/server/common/helpers/permissions/guards/require-cs-submit-permission.js'
 
 vi.mock('~/src/server/common/helpers/gas-error-messages.js')
 vi.mock('../common/helpers/logging/log.js', async () => {
@@ -47,8 +48,17 @@ vi.mock('@defra/forms-engine-plugin/controllers/SummaryPageController.js', () =>
 })
 vi.mock('~/src/server/common/services/grant-application/grant-application.service.js')
 vi.mock('~/src/server/common/helpers/grant-application-service/state-to-gas-payload-mapper.js')
-vi.mock('~/src/server/task-list/task-list.helper.js', () => ({
-  getTaskPageBackLink: vi.fn()
+vi.mock('~/src/server/task-list/task-list.helper.js', async (importOriginal) => {
+  const actual = await importOriginal()
+
+  return {
+    ...actual,
+    getTaskPageBackLink: vi.fn(),
+    getTaskListPath: vi.fn().mockReturnValue('/task-list')
+  }
+})
+vi.mock('~/src/server/common/helpers/permissions/guards/require-cs-submit-permission.js', () => ({
+  requireCsSubmitPermission: vi.fn((request, h) => h.continue)
 }))
 
 describe('DeclarationPageController', () => {
@@ -468,6 +478,24 @@ describe('DeclarationPageController', () => {
         mockRequest
       )
       expect(handleGasApiError).not.toHaveBeenCalled()
+    })
+
+    test('should redirect when user does not have submit permission', async () => {
+      const redirectResponse = { redirected: true }
+
+      requireCsSubmitPermission.mockReturnValue(redirectResponse)
+
+      const handler = controller.makePostRouteHandler()
+
+      const result = await handler(mockRequest, mockContext, mockH)
+
+      expect(result).toBe(redirectResponse)
+
+      expect(submitGrantApplication).not.toHaveBeenCalled()
+
+      expect(requireCsSubmitPermission).toHaveBeenCalledWith(mockRequest, mockH, {
+        returnUrl: '/example-grant-with-auth/task-list'
+      })
     })
   })
 

--- a/src/server/declaration/declaration-page.controller.test.js
+++ b/src/server/declaration/declaration-page.controller.test.js
@@ -497,6 +497,50 @@ describe('DeclarationPageController', () => {
         returnUrl: '/example-grant-with-auth/task-list'
       })
     })
+
+    test('should use empty base path when request.params.slug is missing', async () => {
+      const redirectResponse = { redirected: true }
+
+      requireCsSubmitPermission.mockReturnValue(redirectResponse)
+
+      const requestWithoutSlug = {
+        ...mockRequest,
+        params: {}
+      }
+
+      const handler = controller.makePostRouteHandler()
+
+      const result = await handler(requestWithoutSlug, mockContext, mockH)
+
+      expect(result).toBe(redirectResponse)
+
+      expect(requireCsSubmitPermission).toHaveBeenCalledWith(requestWithoutSlug, mockH, {
+        returnUrl: '/task-list'
+      })
+
+      expect(submitGrantApplication).not.toHaveBeenCalled()
+    })
+
+    test('should redirect when permission denied and slug missing', async () => {
+      const redirectResponse = { redirected: true }
+
+      requireCsSubmitPermission.mockReturnValue(redirectResponse)
+
+      const requestWithoutSlug = {
+        ...mockRequest,
+        params: {}
+      }
+
+      const handler = controller.makePostRouteHandler()
+
+      const result = await handler(requestWithoutSlug, mockContext, mockH)
+
+      expect(result).toBe(redirectResponse)
+
+      expect(requireCsSubmitPermission).toHaveBeenCalledWith(requestWithoutSlug, mockH, {
+        returnUrl: '/task-list'
+      })
+    })
   })
 
   describe('buildApplicationData', () => {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -51,6 +51,7 @@ import WoodlandHectaresPageController from '~/src/server/woodland/woodland-hecta
 import TerminalPageController from '~/src/server/task-list/terminal-page.controller.js'
 import CheckDetailsController from '~/src/server/details-page/check-details.controller.js'
 import CommonSelectLandParcelPageController from './land-grants/common/common-select-parcel/common-select-land-parcel-page.controller.js'
+import permissions from '../plugins/permissions.js'
 
 const SESSION_CACHE_NAME = 'session.cache.name'
 
@@ -165,6 +166,7 @@ const registerPlugins = async (server) => {
     sessionCache,
     nunjucksConfig,
     sso,
+    permissions,
     contentSecurityPolicy,
     whitelist
   ])

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -11,6 +11,7 @@ import { configConfirmation } from '~/src/server/confirmation/config-confirmatio
 import { clearApplicationState } from './dev-tools/clear-application-state.js'
 import { cookies } from '~/src/server/cookies/index.js'
 import { printSubmittedApplication } from '~/src/server/print-submitted-application/print-submitted-application.controller.js'
+import { cannotSubmit } from './cannot-submit/index.js'
 
 const cdpEnvironment = config.get('cdpEnvironment')
 
@@ -30,7 +31,7 @@ export const router = {
       await server.register([auth])
 
       // Application specific routes, add your own routes here
-      await server.register([home, agreements, configConfirmation, cookies, printSubmittedApplication])
+      await server.register([home, agreements, configConfirmation, cookies, printSubmittedApplication, cannotSubmit])
 
       // Development tools (only available in development mode)
       if (


### PR DESCRIPTION
Implements submit permission checks for Countryside Stewardship applications.

Users without the required DAL submit permission are now prevented from submitting applications from the declaration page and are redirected to a dedicated "cannot submit" page.

## Changes

- added generic `requirePermission` permission guard helper
- added `requireSubmitCsApplication` submit permission guard
- enforced submit permission checks in `DeclarationPageController`
- added `/cannot-submit` route and view
- added return navigation support back to the application/task list
- wired permission handling into CS routing

Users with submit permission:
- can successfully submit applications

Users without submit permission:
- cannot submit applications
- are redirected to the cannot-submit page
- can return to the application/task list