### PR TITLE
Feature/tgc 1386 move view permission to config

### DIFF
--- a/src/server/common/forms/definitions/example-grant-with-auth.yaml
+++ b/src/server/common/forms/definitions/example-grant-with-auth.yaml
@@ -19,12 +19,12 @@ metadata:
 
       rules:
         - paths:
-            - submit-your-application
             - declaration
           permission: submit
 
         - paths:
             - print-submitted-application
+            - confirmation
           permission: view
   detailsPage:
     toleratedFailurePaths:

--- a/src/server/common/helpers/logging/log-codes.test.js
+++ b/src/server/common/helpers/logging/log-codes.test.js
@@ -704,9 +704,9 @@ describe('LogCodes', () => {
           permission: 'submit',
           userId: TEST_USER_IDS.DEFAULT,
           authorised: true,
-          slug: 'test-slug'
+          path: 'test-start'
         },
-        `Permission enforcement bypassed for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, userId=${TEST_USER_IDS.DEFAULT}, authorised=true, slug=test-slug`
+        `Permission enforcement bypassed for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, userId=${TEST_USER_IDS.DEFAULT}, authorised=true, path=test-start`
       ],
       [
         'SUCCESS',
@@ -716,9 +716,9 @@ describe('LogCodes', () => {
           permission: 'submit',
           userId: TEST_USER_IDS.DEFAULT,
           authorised: true,
-          slug: 'test-slug'
+          path: 'test-start'
         },
-        `Permission check successful for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, userId=${TEST_USER_IDS.DEFAULT}, authorised=true, slug=test-slug`
+        `Permission check successful for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, userId=${TEST_USER_IDS.DEFAULT}, authorised=true, path=test-start`
       ],
       [
         'FAILURE',
@@ -728,9 +728,9 @@ describe('LogCodes', () => {
           permission: 'submit',
           userId: TEST_USER_IDS.DEFAULT,
           authorised: false,
-          slug: 'test-slug'
+          path: 'test-start'
         },
-        `Permission check failed for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, userId=${TEST_USER_IDS.DEFAULT}, authorised=false, slug=test-slug`
+        `Permission check failed for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, userId=${TEST_USER_IDS.DEFAULT}, authorised=false, path=test-start`
       ]
     ])
   })

--- a/src/server/common/helpers/logging/log-codes/permissions.js
+++ b/src/server/common/helpers/logging/log-codes/permissions.js
@@ -5,16 +5,16 @@ export const PERMISSIONS = {
   BYPASSED: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Permission enforcement bypassed for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, userId=${messageOptions.userId}, authorised=${messageOptions.authorised}, slug=${messageOptions.slug}`
+      `Permission enforcement bypassed for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, userId=${messageOptions.userId}, authorised=${messageOptions.authorised}, path=${messageOptions.path}`
   },
   SUCCESS: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Permission check successful for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, userId=${messageOptions.userId}, authorised=${messageOptions.authorised}, slug=${messageOptions.slug}`
+      `Permission check successful for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, userId=${messageOptions.userId}, authorised=${messageOptions.authorised}, path=${messageOptions.path}`
   },
   FAILURE: {
     level: 'warn',
     messageFunc: (messageOptions) =>
-      `Permission check failed for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, userId=${messageOptions.userId}, authorised=${messageOptions.authorised}, slug=${messageOptions.slug}`
+      `Permission check failed for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, userId=${messageOptions.userId}, authorised=${messageOptions.authorised}, path=${messageOptions.path}`
   }
 }

--- a/src/server/common/helpers/permissions/permission-logger.js
+++ b/src/server/common/helpers/permissions/permission-logger.js
@@ -6,7 +6,7 @@ export function logPermissionEvent({ request, grantCode, permission, enforcement
     grantCode,
     permission,
     authorised,
-    slug: request.params?.slug
+    path: request.params?.path
   }
   if (!enforcementEnabled) {
     log(LogCodes.PERMISSIONS.BYPASSED, logData, request)

--- a/src/server/common/helpers/permissions/permission-logger.test.js
+++ b/src/server/common/helpers/permissions/permission-logger.test.js
@@ -26,7 +26,8 @@ describe('logPermissionEvent', () => {
         }
       },
       params: {
-        slug: 'woodland'
+        slug: 'woodland',
+        path: 'start'
       }
     }
   })
@@ -47,7 +48,7 @@ describe('logPermissionEvent', () => {
         grantCode: 'cs',
         permission: 'submit',
         authorised: true,
-        slug: 'woodland'
+        path: 'start'
       },
       request
     )
@@ -69,7 +70,7 @@ describe('logPermissionEvent', () => {
         grantCode: 'cs',
         permission: 'submit',
         authorised: true,
-        slug: 'woodland'
+        path: 'start'
       },
       request
     )
@@ -91,7 +92,7 @@ describe('logPermissionEvent', () => {
         grantCode: 'cs',
         permission: 'submit',
         authorised: false,
-        slug: 'woodland'
+        path: 'start'
       },
       request
     )
@@ -115,7 +116,7 @@ describe('logPermissionEvent', () => {
         grantCode: 'cs',
         permission: 'submit',
         authorised: true,
-        slug: 'woodland'
+        path: 'start'
       },
       request
     )
@@ -139,7 +140,7 @@ describe('logPermissionEvent', () => {
         grantCode: 'cs',
         permission: 'submit',
         authorised: true,
-        slug: 'woodland'
+        path: 'start'
       },
       request
     )

--- a/src/server/common/request-pipeline/permissions/enforce-page-permission.js
+++ b/src/server/common/request-pipeline/permissions/enforce-page-permission.js
@@ -5,8 +5,6 @@ import { forbidden } from '@hapi/boom'
 import { logPermissionEvent } from '../../helpers/permissions/permission-logger.js'
 import { getGrantCode } from '../../helpers/grant-code.js'
 
-const VIEW_ONLY_ALLOWED_PATHS = new Set(['confirmation', 'print-submitted-application'])
-
 /**
  * Determines whether the current user can amend an application
  * but is not permitted to submit it.
@@ -71,16 +69,6 @@ export function getReturnToApplicationPath(model, basePath) {
 }
 
 /**
- * Checks whether a given path is allowed for view-only users.
- *
- * @param {string} path - The request path to check.
- * @returns {boolean} True if the path is allowed for view-only users.
- */
-export function isAllowedViewOnlyPath(path) {
-  return VIEW_ONLY_ALLOWED_PATHS.has(path)
-}
-
-/**
  * Enforces page-level application permissions for the current request.
  *
  * Permission enforcement is driven by the form definition metadata:
@@ -130,18 +118,10 @@ export function enforcePagePermission(request, h, context) {
   }
 
   const resource = getPermissionResource(request)
+  const requiredPermission = getRequiredPermission(request)
 
-  if (isViewOnlyUser(request, resource)) {
-    if (isSubmittedApplication(context) && isAllowedViewOnlyPath(request.params.path)) {
-      logPermissionEvent({
-        request,
-        grantCode,
-        permission: 'view',
-        enforcementEnabled: true,
-        authorised: true
-      })
-      return h.continue
-    }
+  // assuming all pages that require 'view' permission are post-submission pages
+  if (requiredPermission === 'view' && !isSubmittedApplication(context)) {
     logPermissionEvent({
       request,
       grantCode,
@@ -149,10 +129,9 @@ export function enforcePagePermission(request, h, context) {
       enforcementEnabled: true,
       authorised: false
     })
-    throw forbidden('Insufficient permissions')
-  }
 
-  const requiredPermission = getRequiredPermission(request)
+    throw forbidden('Application not submitted')
+  }
 
   if (request.can(requiredPermission, resource)) {
     logPermissionEvent({
@@ -162,6 +141,7 @@ export function enforcePagePermission(request, h, context) {
       enforcementEnabled: true,
       authorised: true
     })
+
     return h.continue
   }
 

--- a/src/server/common/request-pipeline/permissions/enforce-page-permission.test.js
+++ b/src/server/common/request-pipeline/permissions/enforce-page-permission.test.js
@@ -3,7 +3,6 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import {
   enforcePagePermission,
   getReturnToApplicationPath,
-  isAllowedViewOnlyPath,
   isCannotSubmitUser,
   isSubmittedApplication,
   isViewOnlyUser
@@ -157,20 +156,6 @@ describe('getReturnToApplicationPath', () => {
   })
 })
 
-describe('isAllowedViewOnlyPath', () => {
-  it('returns true for confirmation path', () => {
-    expect(isAllowedViewOnlyPath('confirmation')).toBe(true)
-  })
-
-  it('returns true for print submitted application path', () => {
-    expect(isAllowedViewOnlyPath('print-submitted-application')).toBe(true)
-  })
-
-  it('returns false for other paths', () => {
-    expect(isAllowedViewOnlyPath('task-list')).toBe(false)
-  })
-})
-
 describe('enforcePagePermission', () => {
   let request
   let h
@@ -271,24 +256,48 @@ describe('enforcePagePermission', () => {
     expect(result).toBe(h.continue)
   })
 
-  it('throws forbidden for view-only users on non-allowed paths', () => {
-    request.params.path = 'task-list'
+  it('allows user with required view permission', () => {
+    vi.mocked(getRequiredPermission).mockReturnValue('view')
 
-    request.can.mockImplementation((action) => {
-      return action === 'view'
-    })
+    request.can.mockImplementation((action) => action === 'view')
 
-    expect(() => enforcePagePermission(request, h, context)).toThrow()
+    const result = enforcePagePermission(request, h, context)
+
+    expect(result).toBe(h.continue)
   })
 
-  it('throws forbidden for view-only users on unsubmitted applications', () => {
+  it('throws Application not submitted when view page accessed before submission', () => {
     context.state.applicationStatus = 'IN_PROGRESS'
 
+    request.can.mockImplementation((action) => action === 'view')
+
+    expect(() => enforcePagePermission(request, h, context)).toThrow('Application not submitted')
+  })
+
+  it('does not allow view pages before submission even when user has view permission', () => {
+    context.state.applicationStatus = 'IN_PROGRESS'
+
+    request.can.mockImplementation((action) => action === 'view')
+
+    expect(() => enforcePagePermission(request, h, context)).toThrow('Application not submitted')
+  })
+
+  it('throws when model missing during cannot-submit redirect', () => {
+    vi.mocked(getRequiredPermission).mockReturnValue('submit')
+
+    request.app.model = undefined
+
     request.can.mockImplementation((action) => {
-      return action === 'view'
+      if (action === 'amend') {
+        return true
+      }
+      if (action === 'submit') {
+        return false
+      }
+      return false
     })
 
-    expect(() => enforcePagePermission(request, h, context)).toThrow()
+    expect(() => enforcePagePermission(request, h, context)).toThrow('Form model missing')
   })
 
   it('throws forbidden when user has no permissions', () => {

--- a/src/server/common/request-pipeline/types.js
+++ b/src/server/common/request-pipeline/types.js
@@ -9,5 +9,3 @@
  *   }
  * }} PipelineRequest
  */
-
-export {}

--- a/src/server/confirmation/config-confirmation.js
+++ b/src/server/confirmation/config-confirmation.js
@@ -4,6 +4,8 @@ import { log, LogCodes } from '~/src/server/common/helpers/logging/log.js'
 import { ApplicationStatus } from '~/src/server/common/constants/application-status.js'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
 import { validateRequestAndFindForm } from '~/src/server/common/helpers/form-verify-and-request-load.js'
+import { enforcePagePermission } from '../common/request-pipeline/permissions/enforce-page-permission.js'
+import { isBoom } from '@hapi/boom'
 
 /**
  * Loads and validates confirmation content for the form
@@ -76,6 +78,9 @@ function buildConfirmationResponse(confirmationContent, sessionData, form, slug,
  * @returns {object} Error response
  */
 function handleError(error, request, h) {
+  if (isBoom(error)) {
+    throw error
+  }
   log(
     LogCodes.CONFIRMATION.CONFIRMATION_ERROR,
     {
@@ -130,6 +135,21 @@ export const configConfirmation = {
             }
 
             const sessionData = await getSessionDataAndState(request)
+            const path = request.path.split('/').pop()
+
+            if (!path) {
+              throw new Error('Unable to determine page path')
+            }
+
+            request.params.path = path
+            const pipelineRequest = /** @type {import('../common/request-pipeline/types.js').PipelineRequest} */ (
+              /** @type {unknown} */ (request)
+            )
+            const result = enforcePagePermission(pipelineRequest, h, sessionData)
+            if (result !== h.continue) {
+              return result
+            }
+
             const confirmationContent = await loadConfirmationContent(form, slug, sessionData.state)
 
             log(

--- a/src/server/confirmation/config-confirmation.test.js
+++ b/src/server/confirmation/config-confirmation.test.js
@@ -1,12 +1,13 @@
 import { vi } from 'vitest'
 import { configConfirmation } from './config-confirmation.js'
-import { findFormBySlug } from '~/src/server/common/forms/services/find-form-by-slug.js'
 import { ConfirmationService } from './services/confirmation.service.js'
 import { mockHapiRequest, mockHapiResponseToolkit } from '~/src/__mocks__/hapi-mocks.js'
 import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
 import { MOCK_CONFIRMATION_CONTENT, MOCK_FORMS } from './__test-fixtures__/confirmation-test-fixtures.js'
 import { log } from '~/src/server/common/helpers/logging/log.js'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+import { enforcePagePermission } from '../common/request-pipeline/permissions/enforce-page-permission.js'
+import { forbidden } from '@hapi/boom'
 
 const mockFormsCacheService = {
   getState: vi.fn()
@@ -16,10 +17,12 @@ const mockYarSession = {
   get: vi.fn()
 }
 
-vi.mock('~/src/server/common/forms/services/find-form-by-slug.js')
 vi.mock('./services/confirmation.service.js')
 vi.mock('~/src/server/common/helpers/forms-cache/forms-cache.js', () => ({
   getFormsCacheService: () => mockFormsCacheService
+}))
+vi.mock('../common/request-pipeline/permissions/enforce-page-permission.js', () => ({
+  enforcePagePermission: vi.fn()
 }))
 describe('config-confirmation', () => {
   let mockRequest
@@ -35,6 +38,7 @@ describe('config-confirmation', () => {
 
     mockLogger = mockRequestLogger()
     mockRequest = mockHapiRequest({
+      path: '/test-slug/confirmation',
       params: { slug: 'test-slug' },
       pre: { validatedSlugAndForm: { slug: 'test-slug', form: mockForm } },
       logger: mockLogger,
@@ -56,6 +60,7 @@ describe('config-confirmation', () => {
     })
 
     vi.mocked(log).mockClear()
+    vi.mocked(enforcePagePermission).mockReturnValue(mockH.continue)
   })
 
   describe('confirmation flow', () => {
@@ -65,7 +70,6 @@ describe('config-confirmation', () => {
         .mockReturnValueOnce('Test Business')
         .mockReturnValueOnce('123456789')
         .mockReturnValueOnce('Test Contact')
-      findFormBySlug.mockResolvedValue(mockForm)
       ConfirmationService.loadConfirmationContent.mockResolvedValue({
         confirmationContent,
         formDefinition
@@ -99,6 +103,13 @@ describe('config-confirmation', () => {
         slug: 'test-slug'
       })
       expect(mockH.view).toHaveBeenCalledWith('config-confirmation-page', { test: 'viewModel' })
+      expect(enforcePagePermission).toHaveBeenCalledWith(
+        mockRequest,
+        mockH,
+        expect.objectContaining({
+          referenceNumber: 'REF123'
+        })
+      )
     })
 
     test('should return validation error from handler when pre-handler returns an error', async () => {
@@ -132,6 +143,13 @@ describe('config-confirmation', () => {
         slug: 'test-slug'
       })
       expect(mockH.view).toHaveBeenCalledWith('config-confirmation-page', { test: 'viewModel' })
+      expect(enforcePagePermission).toHaveBeenCalledWith(
+        mockRequest,
+        mockH,
+        expect.objectContaining({
+          referenceNumber: 'REF123'
+        })
+      )
     })
 
     test('should handle missing reference number', async () => {
@@ -141,7 +159,6 @@ describe('config-confirmation', () => {
       mockFormsCacheService.getState.mockResolvedValue({})
       mockYarSession.get.mockReturnValue(undefined)
 
-      findFormBySlug.mockResolvedValue(mockForm)
       ConfirmationService.loadConfirmationContent.mockResolvedValue({
         confirmationContent: mockConfirmationContent,
         formDefinition: mockFormDefinition
@@ -167,7 +184,6 @@ describe('config-confirmation', () => {
         applicationStatus: 'SUBMITTED'
       })
 
-      findFormBySlug.mockResolvedValue(mockForm)
       ConfirmationService.loadConfirmationContent.mockResolvedValue({
         confirmationContent: null,
         formDefinition: { metadata: {} }
@@ -184,12 +200,65 @@ describe('config-confirmation', () => {
     })
 
     test('should handle errors gracefully', async () => {
-      findFormBySlug.mockRejectedValue(new Error('Service error'))
+      ConfirmationService.loadConfirmationContent.mockRejectedValue(new Error('Service error'))
 
       await handler(mockRequest, mockH)
 
-      expect(vi.mocked(log)).toHaveBeenCalled()
+      expect(vi.mocked(log)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          errorMessage: expect.stringContaining('Service error')
+        }),
+        mockRequest
+      )
       expect(mockH.code).toHaveBeenCalledWith(500)
+    })
+
+    test('sets request.params.path before enforcing permissions', async () => {
+      setupHappyPathMocks()
+
+      mockRequest.path = '/test-slug/confirmation'
+
+      await handler(mockRequest, mockH)
+
+      expect(mockRequest.params.path).toBe('confirmation')
+      expect(enforcePagePermission).toHaveBeenCalled()
+    })
+
+    test('returns permission redirect when permission check does not continue', async () => {
+      const redirectResponse = { takeover: true }
+
+      vi.mocked(enforcePagePermission).mockReturnValue(redirectResponse)
+
+      const result = await handler(mockRequest, mockH)
+
+      expect(result).toBe(redirectResponse)
+
+      expect(ConfirmationService.loadConfirmationContent).not.toHaveBeenCalled()
+    })
+
+    test('rethrows boom errors from permission enforcement', async () => {
+      const boomError = forbidden('Insufficient permissions')
+
+      vi.mocked(enforcePagePermission).mockImplementation(() => {
+        throw boomError
+      })
+
+      await expect(handler(mockRequest, mockH)).rejects.toThrow('Insufficient permissions')
+    })
+
+    test('does not continue processing when permission check returns redirect response', async () => {
+      const redirectResponse = { takeover: true }
+
+      vi.mocked(enforcePagePermission).mockReturnValue(redirectResponse)
+
+      const result = await handler(mockRequest, mockH)
+
+      expect(result).toBe(redirectResponse)
+
+      expect(ConfirmationService.loadConfirmationContent).not.toHaveBeenCalled()
+      expect(ConfirmationService.processConfirmationContent).not.toHaveBeenCalled()
+      expect(ConfirmationService.buildViewModel).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/server/print-submitted-application/print-submitted-application.controller.js
+++ b/src/server/print-submitted-application/print-submitted-application.controller.js
@@ -10,6 +10,8 @@ import {
 } from '../common/helpers/print-application-service/print-application-service.js'
 import { createBusinessRows, createContactRows, createPersonRows } from '~/src/server/common/helpers/create-rows.js'
 import { validateRequestAndFindForm } from '~/src/server/common/helpers/form-verify-and-request-load.js'
+import { enforcePagePermission } from '../common/request-pipeline/permissions/enforce-page-permission.js'
+import { isBoom } from '@hapi/boom'
 
 /**
  * Loads the application state from the session cache and returns it only if submitted.
@@ -103,6 +105,9 @@ async function buildPrintResponse({ form, state, slug }, request, h) {
  * @param {ResponseToolkit} h
  */
 function handleError(error, request, h) {
+  if (isBoom(error)) {
+    throw error
+  }
   log(
     LogCodes.PRINT_APPLICATION.ERROR,
     {
@@ -140,6 +145,25 @@ export const printSubmittedApplication = {
             const state = await loadSubmittedApplication(request)
             if (!state) {
               return h.response('Application not submitted').code(statusCodes.forbidden)
+            }
+
+            const context = /** @type {import('@defra/forms-engine-plugin/engine/types.js').FormContext} */ (
+              /** @type {unknown} */ ({ state })
+            )
+            const path = request.path.split('/').pop()
+
+            if (!path) {
+              throw new Error('Unable to determine page path')
+            }
+
+            request.params.path = path
+            const pipelineRequest = /** @type {import('../common/request-pipeline/types.js').PipelineRequest} */ (
+              /** @type {unknown} */ (request)
+            )
+
+            const result = enforcePagePermission(pipelineRequest, h, context)
+            if (result !== h.continue) {
+              return result
             }
 
             log(

--- a/src/server/print-submitted-application/print-submitted-application.controller.test.js
+++ b/src/server/print-submitted-application/print-submitted-application.controller.test.js
@@ -12,6 +12,8 @@ import { mockHapiRequest, mockHapiResponseToolkit, mockHapiServer } from '~/src/
 import { MOCK_FORM_WITH_PATH, MOCK_SINGLE_PAGE_DEFINITION } from '~/src/__test-fixtures__/mock-forms-cache.js'
 import { createPersonRows, createBusinessRows, createContactRows } from '~/src/server/common/helpers/create-rows.js'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+import { enforcePagePermission } from '../common/request-pipeline/permissions/enforce-page-permission.js'
+import { forbidden } from '@hapi/boom'
 
 vi.mock('../common/forms/services/find-form-by-slug.js')
 vi.mock('../common/helpers/print-application-service/print-application-service.js')
@@ -21,6 +23,9 @@ vi.mock('../common/helpers/logging/log.js', async () => {
   const { mockLogHelper } = await import('~/src/__mocks__')
   return mockLogHelper()
 })
+vi.mock('../common/request-pipeline/permissions/enforce-page-permission.js', () => ({
+  enforcePagePermission: vi.fn()
+}))
 
 const mockForm = MOCK_FORM_WITH_PATH
 const mockDefinition = MOCK_SINGLE_PAGE_DEFINITION
@@ -59,6 +64,7 @@ describe('print-submitted-application.controller', () => {
     getFormsCacheService.mockReturnValue({ getState: mockGetState })
 
     mockRequest = mockHapiRequest({
+      path: '/test-form/print-submitted-application',
       params: { slug: 'test-form' },
       auth: { credentials: { sbi: '123456789' } },
       pre: { validatedSlugAndForm: { slug: 'test-form', form: mockForm } },
@@ -69,6 +75,8 @@ describe('print-submitted-application.controller', () => {
     findFormBySlug.mockResolvedValue(mockForm)
     loadFormDefinition.mockResolvedValue(mockDefinition)
     buildPrintViewModel.mockReturnValue({ test: 'viewModel' })
+
+    vi.mocked(enforcePagePermission).mockReturnValue(mockH.continue)
   })
 
   test('should register GET /{slug}/print-submitted-application route', () => {
@@ -131,6 +139,34 @@ describe('print-submitted-application.controller', () => {
     })
     expect(processConfigurablePrintContent).toHaveBeenCalledWith(undefined, 'test-form')
     expect(mockH.view).toHaveBeenCalledWith('print-submitted-application', { test: 'viewModel' })
+    expect(enforcePagePermission).toHaveBeenCalledWith(mockRequest, mockH, {
+      state: mockState
+    })
+
+    expect(mockRequest.params.path).toBe('print-submitted-application')
+  })
+
+  test('returns permission redirect when permission check does not continue', async () => {
+    const redirectResponse = { takeover: true }
+
+    vi.mocked(enforcePagePermission).mockReturnValue(redirectResponse)
+
+    const result = await handler(mockRequest, mockH)
+
+    expect(result).toBe(redirectResponse)
+
+    expect(loadFormDefinition).not.toHaveBeenCalled()
+    expect(buildPrintViewModel).not.toHaveBeenCalled()
+  })
+
+  test('rethrows boom errors from permission enforcement', async () => {
+    const boomError = forbidden('Insufficient permissions')
+
+    vi.mocked(enforcePagePermission).mockImplementation(() => {
+      throw boomError
+    })
+
+    await expect(handler(mockRequest, mockH)).rejects.toThrow('Insufficient permissions')
   })
 
   test.each([


### PR DESCRIPTION
Refactor page permission enforcement to use configured page-level permissions consistently, removing hard-coded exceptions for post-submission pages.

Changes
- Removed VIEW_ONLY_ALLOWED_PATHS and isAllowedViewOnlyPath()
- Removed special-case handling for view-only users based on route names
- Updated enforcePagePermission() to rely entirely on the configured page access rules from form metadata
- Added explicit handling for view-permission pages:
    - users must have view permission
    - application must be in a submitted/reopened state
    - otherwise a 403 is returned
    
Benefits

- Removes hard-coded route exceptions from permission enforcement
- Makes page access rules configuration-driven
- Ensures confirmation and print pages use the same permission model as the rest of the application
- Improves auditability through richer permission logs
- Reduces future maintenance when adding additional post-submission pages