### PR TITLE
TGC-1410: Enforce single active session per user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude
 .DS_Store
 .npm/
 .vscode

--- a/src/server/auth/index.js
+++ b/src/server/auth/index.js
@@ -14,6 +14,7 @@ import {
 import { releaseAllApplicationLocksForOwnerFromApi } from '../common/helpers/lock/application-lock.js'
 import { ViewError } from '~/src/server/common/utils/errors/ViewError.js'
 import { AuthError } from '~/src/server/common/utils/errors/AuthError.js'
+import { invalidatePreviousSession } from '~/src/server/auth/single-session.js'
 
 const UNKNOWN_USER = 'unknown'
 const USER_AGENT = 'user-agent'
@@ -385,6 +386,13 @@ function getPermissionsOrDefaults(profile, token) {
  */
 async function storeSessionData(request, profile, role, scope, token, refreshToken) {
   try {
+    await invalidatePreviousSession(
+      request.server.app.cache,
+      request.server.app.userSessionIndex,
+      profile.contactId,
+      profile.sessionId
+    )
+
     await request.server.app.cache.set(profile.sessionId, {
       isAuthenticated: true,
       ...profile,
@@ -542,8 +550,10 @@ async function handleOidcSignOut(request, h) {
     })
 
     if (request.auth.credentials?.sessionId) {
-      // Clear the session cache
       await request.server.app.cache.drop(request.auth.credentials.sessionId)
+    }
+    if (request.auth.credentials?.contactId) {
+      await request.server.app.userSessionIndex.drop(request.auth.credentials.contactId)
     }
     request.cookieAuth.clear()
   }

--- a/src/server/auth/single-session.js
+++ b/src/server/auth/single-session.js
@@ -1,0 +1,35 @@
+import { log, LogCodes } from '~/src/server/common/helpers/logging/log.js'
+
+/**
+ * Ensures only one active session exists per user. If an existing session is found
+ * in the index for this contactId, it is dropped from the main cache before the new
+ * session is stored. The index is then updated to point at the new sessionId.
+ *
+ * The guard `existingSessionId !== newSessionId` prevents a re-entrant sign-in from
+ * evicting the very session it is about to create.
+ *
+ * @param {SessionCache} cache - main session cache (server.app.cache)
+ * @param {UserSessionIndex} userSessionIndex - contactId→sessionId index (server.app.userSessionIndex)
+ * @param {string} contactId - stable user identifier from the JWT payload
+ * @param {string} newSessionId - UUID generated for the incoming sign-in
+ * @returns {Promise<void>}
+ */
+export async function invalidatePreviousSession(cache, userSessionIndex, contactId, newSessionId) {
+  const existingSessionId = /** @type {string | null} */ (await userSessionIndex.get(contactId))
+
+  if (existingSessionId && existingSessionId !== newSessionId) {
+    await cache.drop(existingSessionId)
+    log(LogCodes.AUTH.SESSION_INVALIDATED, {
+      userId: contactId,
+      previousSessionId: existingSessionId,
+      newSessionId
+    })
+  }
+
+  await userSessionIndex.set(contactId, newSessionId)
+}
+
+/**
+ * @typedef {{ get: (key: string) => Promise<unknown>, set: (key: string, value: unknown, ttl?: number) => Promise<void>, drop: (key: string) => Promise<void> }} SessionCache
+ * @typedef {{ get: (key: string) => Promise<string | null>, set: (key: string, value: string, ttl?: number) => Promise<void>, drop: (key: string) => Promise<void> }} UserSessionIndex
+ */

--- a/src/server/auth/single-session.test.js
+++ b/src/server/auth/single-session.test.js
@@ -1,0 +1,105 @@
+import { vi, describe, test, expect, beforeEach } from 'vitest'
+import { invalidatePreviousSession } from './single-session.js'
+import { log } from '~/src/server/common/helpers/logging/log.js'
+
+/** @import { MockedFunction } from 'vitest' */
+
+vi.mock('~/src/server/common/helpers/logging/log.js', async () => {
+  const { mockLogHelper } = await import('~/src/__mocks__')
+  return mockLogHelper()
+})
+
+/** @type {MockedFunction<typeof log>} */
+const mockLog = /** @type {any} */ (log)
+
+/**
+ * @returns {{
+ *   get: MockedFunction<(key: string) => Promise<unknown>>,
+ *   set: MockedFunction<(key: string, value: unknown, ttl?: number) => Promise<void>>,
+ *   drop: MockedFunction<(key: string) => Promise<void>>
+ * }}
+ */
+function makeCache() {
+  return {
+    get: vi.fn(),
+    set: vi.fn().mockResolvedValue(undefined),
+    drop: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+/**
+ * @returns {{
+ *   get: MockedFunction<(key: string) => Promise<string | null>>,
+ *   set: MockedFunction<(key: string, value: string, ttl?: number) => Promise<void>>,
+ *   drop: MockedFunction<(key: string) => Promise<void>>
+ * }}
+ */
+function makeIndex() {
+  return {
+    get: vi.fn(),
+    set: vi.fn().mockResolvedValue(undefined),
+    drop: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+describe('invalidatePreviousSession', () => {
+  const contactId = 'crn-abc-123'
+  const newSessionId = 'new-session-uuid'
+  const previousSessionId = 'old-session-uuid'
+
+  /** @type {ReturnType<typeof makeCache>} */
+  let cache
+  /** @type {ReturnType<typeof makeIndex>} */
+  let userSessionIndex
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cache = makeCache()
+    userSessionIndex = makeIndex()
+  })
+
+  test('no prior session: stores new index entry without dropping anything', async () => {
+    userSessionIndex.get.mockResolvedValue(null)
+
+    await invalidatePreviousSession(cache, userSessionIndex, contactId, newSessionId)
+
+    expect(cache.drop).not.toHaveBeenCalled()
+    expect(mockLog).not.toHaveBeenCalled()
+    expect(userSessionIndex.set).toHaveBeenCalledWith(contactId, newSessionId)
+  })
+
+  test('prior session exists: drops old session, logs SESSION_INVALIDATED, stores new index entry', async () => {
+    userSessionIndex.get.mockResolvedValue(previousSessionId)
+
+    await invalidatePreviousSession(cache, userSessionIndex, contactId, newSessionId)
+
+    expect(cache.drop).toHaveBeenCalledExactlyOnceWith(previousSessionId)
+    expect(mockLog).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ level: 'info' }),
+      expect.objectContaining({
+        userId: contactId,
+        previousSessionId,
+        newSessionId
+      })
+    )
+    expect(userSessionIndex.set).toHaveBeenCalledWith(contactId, newSessionId)
+  })
+
+  test('re-entrant sign-in: index already holds the new sessionId, no drop or log', async () => {
+    userSessionIndex.get.mockResolvedValue(newSessionId)
+
+    await invalidatePreviousSession(cache, userSessionIndex, contactId, newSessionId)
+
+    expect(cache.drop).not.toHaveBeenCalled()
+    expect(mockLog).not.toHaveBeenCalled()
+    expect(userSessionIndex.set).toHaveBeenCalledWith(contactId, newSessionId)
+  })
+
+  test('index entry is always updated even when no prior session existed', async () => {
+    userSessionIndex.get.mockResolvedValue(null)
+
+    await invalidatePreviousSession(cache, userSessionIndex, contactId, newSessionId)
+
+    expect(userSessionIndex.set).toHaveBeenCalledWith(contactId, newSessionId)
+  })
+})

--- a/src/server/common/helpers/logging/log-codes/auth.js
+++ b/src/server/common/helpers/logging/log-codes/auth.js
@@ -83,5 +83,10 @@ export const AUTH = {
     level: 'error',
     messageFunc: (messageOptions) =>
       `Invalid OAuth state provided | reason=${messageOptions.reason} | storedStatePresent=${messageOptions.storedStatePresent}`
+  },
+  SESSION_INVALIDATED: {
+    level: 'info',
+    messageFunc: (messageOptions) =>
+      `Previous session invalidated for user=${messageOptions.userId}, previousSessionId=${messageOptions.previousSessionId}, newSessionId=${messageOptions.newSessionId}`
   }
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -247,6 +247,12 @@ export async function createServer() {
     expiresIn: config.get('session.cookie.cache.ttl')
   })
 
+  server.app['userSessionIndex'] = server.cache({
+    cache: config.get(SESSION_CACHE_NAME),
+    segment: 'user-session-index',
+    expiresIn: config.get('session.cookie.cache.ttl')
+  })
+
   server.ext('onPreResponse', catchAll)
 
   return server

--- a/types/hapi-augmentations.d.ts
+++ b/types/hapi-augmentations.d.ts
@@ -29,6 +29,11 @@ declare module '@hapi/hapi' {
       set: (key: string, value: unknown, ttl?: number) => Promise<void>
       drop: (key: string) => Promise<void>
     }
+    userSessionIndex: {
+      get: (key: string) => Promise<string | null>
+      set: (key: string, value: string, ttl?: number) => Promise<void>
+      drop: (key: string) => Promise<void>
+    }
   }
 
   // Mirrors @defra/forms-engine-plugin's augmentation, which our tsc can't


### PR DESCRIPTION
Adds a second Catbox cache partition (user-session-index) that maps contactId → sessionId. On sign-in, any existing session for the same user is dropped from the main cache before the new session is stored, preventing concurrent sessions. The index entry is cleared on sign-out.

Works transparently across HA instances via shared Redis, and does not force re-authentication of currently signed-in users at deploy time.