### PR TITLE
chore(deps): unblock joi (SMOKE TEST — do not merge)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,6 @@ updates:
       # (Verified the rules DO run under eslint 10 — this is purely a packaging block.)
       - dependency-name: "eslint"
         versions: [">=10.0.0"]
-      # joi 18 is blocked by @defra/forms-engine-plugin, which deps joi ^17.13.3 (all versions,
-      # incl. the 8.x major). Remove when forms-engine-plugin supports joi 18.
-      - dependency-name: "joi"
-        versions: [">=18.0.0"]
       # govuk-frontend 6 is blocked by @defra/forms-engine-plugin, which deps govuk-frontend ^5.x.
       # The repo's Sass-module migration for v6 is already done; remove when forms-engine-plugin
       # supports govuk-frontend 6.


### PR DESCRIPTION
Throwaway PR to verify the check-blocked-deps workflow opens a PR by removing a dependabot `ignore` rule. Safe to close.