### PR TITLE
TGC-1374 - Fix: backend sourced form definitions don't inherit shared redirect rules

### DIFF
--- a/src/server/common/forms/definitions/example-grant-with-map.yaml
+++ b/src/server/common/forms/definitions/example-grant-with-map.yaml
@@ -10,7 +10,9 @@ metadata:
     serviceName: Farm and land service
     cookiePolicyUrl: /cookies
     expiryDays: 365
-  grantRedirectRules: null
+  grantRedirectRules:
+    preSubmission:
+      - toPath: /summary
   permissions:
     enforce: false
   confirmationContent:

--- a/src/server/common/forms/definitions/example-grant-with-map.yaml
+++ b/src/server/common/forms/definitions/example-grant-with-map.yaml
@@ -10,9 +10,7 @@ metadata:
     serviceName: Farm and land service
     cookiePolicyUrl: /cookies
     expiryDays: 365
-  grantRedirectRules:
-    preSubmission:
-      - toPath: /summary
+  grantRedirectRules: null
   permissions:
     enforce: false
   confirmationContent:

--- a/src/server/common/forms/services/form.js
+++ b/src/server/common/forms/services/form.js
@@ -487,10 +487,16 @@ async function registerBackendForms(redis, backendSlugs) {
  * Throws clearly if there is no active request context, so a background or
  * unscoped call fails fast rather than fetching without a user.
  *
+ * Mirrors the merge `registerYamlForms` applies to YAML-sourced forms: a form's
+ * own `grantRedirectRules` (e.g. `null`, or a partial override) is layered over
+ * `sharedRules` so backend-sourced forms inherit the same defaults instead of
+ * being served whatever the backend stored verbatim.
+ *
  * @param {string} slug
+ * @param {SharedRedirectRules} sharedRules
  * @returns {Promise<FormDefinition>}
  */
-async function resolveBackendDefinition(slug) {
+async function resolveBackendDefinition(slug, sharedRules) {
   const request = currentRequest()
   if (!request) {
     throw new Error(`No request context available to resolve backend form definition for '${slug}'`)
@@ -505,14 +511,23 @@ async function resolveBackendDefinition(slug) {
   }
 
   hoistPageConfig(definition)
-  return configureFormDefinition(definition)
+  configureFormDefinition(definition)
+
+  const meta = /** @type {Record<string, unknown>} */ (definition.metadata ??= {})
+  meta.grantRedirectRules = {
+    ...sharedRules,
+    .../** @type {Record<string, unknown> | undefined} */ (meta.grantRedirectRules)
+  }
+
+  return definition
 }
 
 /**
  * @param {BaseFormsService} baseService
  * @param {FormsRedisClient} redis
+ * @param {SharedRedirectRules} sharedRules
  */
-function buildServiceInterface(baseService, redis) {
+function buildServiceInterface(baseService, redis, sharedRules) {
   return {
     /**
      * @param {string} slug
@@ -524,7 +539,7 @@ function buildServiceInterface(baseService, redis) {
       }
       // ── backend source (default going forward) ──
       if (entry.source === 'backend') {
-        const definition = await resolveBackendDefinition(slug)
+        const definition = await resolveBackendDefinition(slug, sharedRules)
 
         // The backend definition document carries its own `updatedAt` (which
         // changes when a new version is published) and a `status`
@@ -574,7 +589,7 @@ function buildServiceInterface(baseService, redis) {
       const entry = await getFormMeta(redis, slug)
       // ── backend source (default going forward) ──
       if (entry?.source === 'backend') {
-        return resolveBackendDefinition(slug)
+        return resolveBackendDefinition(slug, sharedRules)
       }
       // ── legacy YAML branch (removal-ready) ──
       try {
@@ -590,7 +605,7 @@ function buildServiceInterface(baseService, redis) {
      * @param {string} slug
      */
     getFormDefinitionBySlug: async (slug) => {
-      return resolveBackendDefinition(slug)
+      return resolveBackendDefinition(slug, sharedRules)
     }
   }
 }
@@ -613,7 +628,7 @@ export const formsService = async () => {
   // ── Slug index ────────────────────────────────────────────────────────────
   await setAllSlugs(redis, [...yamlForms.map((f) => f.slug), ...backendSlugs])
 
-  return buildServiceInterface(loader.toFormsService(), redis)
+  return buildServiceInterface(loader.toFormsService(), redis, sharedRules)
 }
 
 /**

--- a/src/server/common/forms/services/form.test.js
+++ b/src/server/common/forms/services/form.test.js
@@ -322,6 +322,24 @@ describe('form', () => {
       expect(result).toMatchObject({ name: 'Backend Form' })
     })
 
+    test('getFormDefinition merges shared redirect rules into a backend-sourced form with grantRedirectRules: null', async () => {
+      registerBackendForm()
+      _reverseStore.set('backend-form', 'backend-form')
+      mockBackendRequest()
+      mockBackendStateWithDefinition({
+        definition: {
+          definition: { name: 'Backend Form', metadata: { grantRedirectRules: null }, pages: [] }
+        }
+      })
+
+      const service = await formsService()
+      const result = await service.getFormDefinition('backend-form')
+
+      expect(result.metadata.grantRedirectRules).not.toBeNull()
+      expect(result.metadata.grantRedirectRules.preSubmission).toEqual([{ toPath: '/summary' }])
+      expect(result.metadata.grantRedirectRules.postSubmission.length).toBeGreaterThan(0)
+    })
+
     test('getFormDefinitionBySlug resolves the stashed definition for backend forms', async () => {
       mockBackendRequest()
       mockBackendStateWithDefinition({

--- a/src/server/common/forms/services/form.test.js
+++ b/src/server/common/forms/services/form.test.js
@@ -340,6 +340,72 @@ describe('form', () => {
       expect(result.metadata.grantRedirectRules.postSubmission.length).toBeGreaterThan(0)
     })
 
+    test('getFormDefinition merges shared redirect rules into a backend-sourced form with no metadata at all', async () => {
+      registerBackendForm()
+      _reverseStore.set('backend-form', 'backend-form')
+      mockBackendRequest()
+      mockBackendStateWithDefinition({
+        definition: {
+          definition: { name: 'Backend Form', pages: [] }
+        }
+      })
+
+      const service = await formsService()
+      const result = await service.getFormDefinition('backend-form')
+
+      expect(result.metadata.grantRedirectRules.preSubmission).toEqual([{ toPath: '/summary' }])
+    })
+
+    test('getFormDefinition lets a backend-sourced form override preSubmission while keeping shared postSubmission', async () => {
+      registerBackendForm()
+      _reverseStore.set('backend-form', 'backend-form')
+      mockBackendRequest()
+      mockBackendStateWithDefinition({
+        definition: {
+          definition: {
+            name: 'Backend Form',
+            metadata: { grantRedirectRules: { preSubmission: [{ toPath: '/custom' }] } },
+            pages: []
+          }
+        }
+      })
+
+      const service = await formsService()
+      const result = await service.getFormDefinition('backend-form')
+
+      expect(result.metadata.grantRedirectRules.preSubmission).toEqual([{ toPath: '/custom' }])
+      expect(result.metadata.grantRedirectRules.postSubmission.length).toBeGreaterThan(0)
+    })
+
+    test('getFormMetadata merges shared redirect rules for backend-sourced forms', async () => {
+      registerBackendForm()
+      mockBackendRequest()
+      mockBackendStateWithDefinition({
+        definition: {
+          definition: { name: 'Backend Form', metadata: { grantRedirectRules: null }, pages: [] }
+        }
+      })
+
+      const service = await formsService()
+      const result = await service.getFormMetadata('backend-form')
+
+      expect(result.metadata.grantRedirectRules.preSubmission).toEqual([{ toPath: '/summary' }])
+    })
+
+    test('getFormDefinitionBySlug merges shared redirect rules for backend-sourced forms', async () => {
+      mockBackendRequest()
+      mockBackendStateWithDefinition({
+        definition: {
+          definition: { name: 'Backend Form', metadata: { grantRedirectRules: null }, pages: [] }
+        }
+      })
+
+      const service = await formsService()
+      const result = await service.getFormDefinitionBySlug('backend-form')
+
+      expect(result.metadata.grantRedirectRules.preSubmission).toEqual([{ toPath: '/summary' }])
+    })
+
     test('getFormDefinitionBySlug resolves the stashed definition for backend forms', async () => {
       mockBackendRequest()
       mockBackendStateWithDefinition({

--- a/src/server/common/request-pipeline/redirects/forms-status-redirect.js
+++ b/src/server/common/request-pipeline/redirects/forms-status-redirect.js
@@ -181,10 +181,8 @@ function preSubmissionRedirect(request, h, context) {
     return guardRedirect
   }
 
-  const preSubmissionRedirectRule = grantRedirectRules?.preSubmission?.[0]
-  if (!preSubmissionRedirectRule) {
-    return h.continue
-  }
+  const preSubmissionRedirectRule = /** @type {{ preSubmission: RedirectRule[] }} */ (grantRedirectRules)
+    .preSubmission[0]
   const preSubmissionRedirectUrl = preSubmissionRedirectRule.toPath.startsWith('/')
     ? `/${grantId}${preSubmissionRedirectRule.toPath}`
     : `/${grantId}/${preSubmissionRedirectRule.toPath}`

--- a/src/server/common/request-pipeline/redirects/forms-status-redirect.js
+++ b/src/server/common/request-pipeline/redirects/forms-status-redirect.js
@@ -181,8 +181,10 @@ function preSubmissionRedirect(request, h, context) {
     return guardRedirect
   }
 
-  const preSubmissionRedirectRule = /** @type {{ preSubmission: RedirectRule[] }} */ (grantRedirectRules)
-    .preSubmission[0]
+  const preSubmissionRedirectRule = grantRedirectRules?.preSubmission?.[0]
+  if (!preSubmissionRedirectRule) {
+    return h.continue
+  }
   const preSubmissionRedirectUrl = preSubmissionRedirectRule.toPath.startsWith('/')
     ? `/${grantId}${preSubmissionRedirectRule.toPath}`
     : `/${grantId}/${preSubmissionRedirectRule.toPath}`

--- a/src/server/common/request-pipeline/redirects/forms-status-redirect.test.js
+++ b/src/server/common/request-pipeline/redirects/forms-status-redirect.test.js
@@ -264,6 +264,16 @@ describe('formsStatusRedirect', () => {
     expect(h.redirect).toHaveBeenCalledWith('/grant-a/check-selected-land-actions')
   })
 
+  it('continues without redirecting when there is no preSubmission rule configured', async () => {
+    request.app.model.def.metadata.grantRedirectRules.preSubmission = []
+    context.state = { question: 'answer' }
+
+    const result = await formsStatusRedirect(request, h, context)
+
+    expect(result).toBe(h.continue)
+    expect(h.redirect).not.toHaveBeenCalled()
+  })
+
   it.each([undefined, 'CLEARED'])('redirects to "check answers" page if some saved state', async (status) => {
     context.state = {
       applicationStatus: status,


### PR DESCRIPTION
**Problem**: 

`grantRedirectRules: null` on form definitions is supposed to fall back to shared-redirect-rules.yaml defaults. That merge only lived in registerYamlForms (startup, YAML forms). Backend-sourced forms (BACKEND_FORM_DEF_ENABLED_SLUGS) skip that path entirely — their definition is fetched per-request from grants-ui-backend via resolveBackendDefinition, which never merged shared rules. Result: null reached forms-status-redirect.js, crashing on .preSubmission[0].

**Fix:**

- `resolveBackendDefinition` now applies the same shared-rules merge, per request instead of once at startup.
- Restored the `grantRedirectRules?.preSubmission?.[0]` null-check in forms-status-redirect.js as a safety net.
- Added a regression test for a backend-sourced form with `grantRedirectRules: null`.