### PR TITLE
Fix LocalStack resource readiness in CI

### DIFF
--- a/compose.land-grants.yml
+++ b/compose.land-grants.yml
@@ -6,6 +6,10 @@ x-common-postgres: &common-postgres
 
 services:
   localstack:
+    environment:
+      LOCALSTACK_REQUIRED_S3_BUCKETS: configs-bucket,land-data
+      LOCALSTACK_REQUIRED_SQS_QUEUES: fcp_audit,gfr__sqs___config_input,grants_ui_backend__sqs__config_updates,grants_config_broker_update
+      LOCALSTACK_REQUIRED_SNS_TOPICS: fcp_audit_events,gfr__sns___config_update
     volumes:
       - ./localstack/start-localstack-land-grants.sh:/etc/localstack/init/ready.d/start-localstack-land-grants.sh
 

--- a/compose.yml
+++ b/compose.yml
@@ -311,15 +311,19 @@ services:
       SKIP_SSL_CERT_DOWNLOAD: 1
       DISABLE_EVENTS: 1
       DISABLE_USAGE_COLLECTION: 1
+      LOCALSTACK_REQUIRED_S3_BUCKETS: configs-bucket
+      LOCALSTACK_REQUIRED_SQS_QUEUES: fcp_audit,gfr__sqs___config_input,grants_ui_backend__sqs__config_updates
+      LOCALSTACK_REQUIRED_SNS_TOPICS: fcp_audit_events,gfr__sns___config_update
     volumes:
       - localstack-data:/var/lib/localstack
       - ./localstack/start-localstack.sh:/etc/localstack/init/ready.d/start-localstack.sh
+      - ./localstack/check-localstack-resources.sh:/usr/local/bin/check-localstack-resources.sh:ro
       - ./localstack/forms:/etc/localstack/forms:ro
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:4566/_localstack/health']
+      test: ['CMD-SHELL', '/usr/local/bin/check-localstack-resources.sh']
       interval: 2s
       start_period: 2s
-      retries: 3
+      retries: 30
     networks:
       - grants-ui-net
 

--- a/localstack/check-localstack-resources.sh
+++ b/localstack/check-localstack-resources.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -eu
+
+ENDPOINT="${LOCALSTACK_ENDPOINT:-http://localhost:4566}"
+REGION="${AWS_REGION:-eu-west-2}"
+ACCOUNT_ID="${LOCALSTACK_ACCOUNT_ID:-000000000000}"
+
+LOCALSTACK_REQUIRED_S3_BUCKETS="${LOCALSTACK_REQUIRED_S3_BUCKETS:-configs-bucket}"
+LOCALSTACK_REQUIRED_SQS_QUEUES="${LOCALSTACK_REQUIRED_SQS_QUEUES:-fcp_audit,gfr__sqs___config_input,grants_ui_backend__sqs__config_updates}"
+LOCALSTACK_REQUIRED_SNS_TOPICS="${LOCALSTACK_REQUIRED_SNS_TOPICS:-fcp_audit_events,gfr__sns___config_update}"
+
+aws_local() {
+  aws --endpoint-url="$ENDPOINT" "$@"
+}
+
+check_health_endpoint() {
+  curl -fsS "$ENDPOINT/_localstack/health" >/dev/null
+}
+
+check_buckets() {
+  old_ifs=$IFS
+  IFS=,
+  for bucket in $LOCALSTACK_REQUIRED_S3_BUCKETS; do
+    [ -n "$bucket" ] || continue
+    aws_local s3api head-bucket --bucket "$bucket" >/dev/null
+  done
+  IFS=$old_ifs
+}
+
+check_queues() {
+  old_ifs=$IFS
+  IFS=,
+  for queue in $LOCALSTACK_REQUIRED_SQS_QUEUES; do
+    [ -n "$queue" ] || continue
+    aws_local sqs get-queue-url --queue-name "$queue" >/dev/null
+  done
+  IFS=$old_ifs
+}
+
+check_topics() {
+  old_ifs=$IFS
+  IFS=,
+  for topic in $LOCALSTACK_REQUIRED_SNS_TOPICS; do
+    [ -n "$topic" ] || continue
+    aws_local sns get-topic-attributes --topic-arn "arn:aws:sns:${REGION}:${ACCOUNT_ID}:${topic}" >/dev/null
+  done
+  IFS=$old_ifs
+}
+
+check_health_endpoint
+check_buckets
+check_queues
+check_topics

--- a/scripts/backend-form-definition-config.test.js
+++ b/scripts/backend-form-definition-config.test.js
@@ -3,8 +3,15 @@ import { describe, expect, it } from 'vitest'
 import { parse } from 'yaml'
 
 const composeConfig = parse(readFileSync('compose.yml', 'utf8'))
+const landGrantsComposeConfig = parse(readFileSync('compose.land-grants.yml', 'utf8'))
 const releaseAllConfig = parse(readFileSync('localstack/config-broker/release.all.yml', 'utf8'))
 const backendFormDefEnv = composeConfig.services['grants-ui'].environment.BACKEND_FORM_DEF_ENABLED_SLUGS
+
+const csv = (value = '') =>
+  value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
 
 const getDefaultSlugs = (environmentValue) =>
   environmentValue
@@ -31,5 +38,43 @@ describe('backend-sourced form deployment config', () => {
     expect(composeConfig.services['grants-ui-backend'].depends_on['grants-config-broker']).toEqual({
       condition: 'service_healthy'
     })
+  })
+
+  it('waits for LocalStack base resources before dependent services start', () => {
+    const localstack = composeConfig.services.localstack
+
+    expect(localstack.volumes).toContain(
+      './localstack/check-localstack-resources.sh:/usr/local/bin/check-localstack-resources.sh:ro'
+    )
+    expect(localstack.healthcheck.test).toEqual(['CMD-SHELL', '/usr/local/bin/check-localstack-resources.sh'])
+    expect(csv(localstack.environment.LOCALSTACK_REQUIRED_S3_BUCKETS)).toEqual(
+      expect.arrayContaining(['configs-bucket'])
+    )
+    expect(csv(localstack.environment.LOCALSTACK_REQUIRED_SQS_QUEUES)).toEqual(
+      expect.arrayContaining(['fcp_audit', 'gfr__sqs___config_input', 'grants_ui_backend__sqs__config_updates'])
+    )
+    expect(csv(localstack.environment.LOCALSTACK_REQUIRED_SNS_TOPICS)).toEqual(
+      expect.arrayContaining(['fcp_audit_events', 'gfr__sns___config_update'])
+    )
+  })
+
+  it('extends LocalStack readiness for land-grants resources', () => {
+    const localstack = landGrantsComposeConfig.services.localstack
+    const environment = localstack.environment ?? {}
+
+    expect(csv(environment.LOCALSTACK_REQUIRED_S3_BUCKETS)).toEqual(
+      expect.arrayContaining(['configs-bucket', 'land-data'])
+    )
+    expect(csv(environment.LOCALSTACK_REQUIRED_SQS_QUEUES)).toEqual(
+      expect.arrayContaining([
+        'fcp_audit',
+        'gfr__sqs___config_input',
+        'grants_ui_backend__sqs__config_updates',
+        'grants_config_broker_update'
+      ])
+    )
+    expect(csv(environment.LOCALSTACK_REQUIRED_SNS_TOPICS)).toEqual(
+      expect.arrayContaining(['fcp_audit_events', 'gfr__sns___config_update'])
+    )
   })
 })

--- a/tools/docker-compose-smoke-test.sh
+++ b/tools/docker-compose-smoke-test.sh
@@ -78,11 +78,17 @@ dump_diagnostics() {
   eval "${COMPOSE_COMMAND} ps" || true
   docker compose -f compose.tests.yml ps || true
 
-  for service in grants-ui grants-ui-backend grants-config-broker fcp-defra-id-stub; do
+  for service in grants-ui grants-ui-backend grants-config-broker localstack fcp-defra-id-stub; do
     echo ""
     echo "--- ${service} Service Logs ---"
     eval "${COMPOSE_COMMAND} logs --no-color --tail=300 ${service}" || true
   done
+
+  echo ""
+  echo "--- LocalStack Resources ---"
+  eval "${COMPOSE_COMMAND} exec -T localstack aws --endpoint-url=http://localhost:4566 s3 ls" || true
+  eval "${COMPOSE_COMMAND} exec -T localstack aws --endpoint-url=http://localhost:4566 sqs list-queues" || true
+  eval "${COMPOSE_COMMAND} exec -T localstack aws --endpoint-url=http://localhost:4566 sns list-topics" || true
 }
 
 # Guarantee teardown of both the main stack and the ephemeral test stack on


### PR DESCRIPTION
- Added a LocalStack healthcheck script that waits for the required S3 buckets, SQS queues, and SNS topics.
- Put the readiness check into the base compose stack and extended the required resources for land-grants tests.
- Added regression tests for compose readiness.
- Included LocalStack logs and resource listings in smoke-tests.
