### PR TITLE
TGC-1459: Prepare repository for AI assistance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ node_modules
 npm-debug.log
 coverage
 .cache
-AGENTS.md
 .env
 .env.*
 !.env.example
@@ -26,3 +25,4 @@ localstack/config-broker-local
 /.grants-ui-cli-state.json
 /acceptance/schemas/
 /woodland-grant-journey-tests-schemas/
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+Application code lives in `src`. Server routes, controllers, helpers, services, and views are under `src/server`; browser JavaScript and Sass are under `src/client`; shared utilities are in `src/shared`; configuration is in `src/config`. Unit tests are colocated as `*.test.js`. Contract assets live in `src/contracts`. Acceptance tests are in `acceptance/test`, with feature files, steps, page objects, and support utilities split by folder. Operational scripts and local tooling are in `scripts/`, `tools/`, `localstack/`, and root Docker Compose files.
+
+## Build, Test, and Development Commands
+
+- `npm run dev`: runs frontend webpack watch and the Node server watcher together.
+- `npm run build`: builds production frontend assets and transpiles server files into `.server`.
+- `npm start`: builds first, then starts the production server.
+- `npm run docker:up` / `npm run docker:down`: prepare local config and start or stop the Docker stack.
+- `npm test`: runs Vitest with coverage.
+- `npm run test:unit`: runs the unit-test Vitest config.
+- `npm run test:contracts`: runs contract tests.
+- `npm run test:acceptance`: runs acceptance tests.
+- `npm run lint`: runs JavaScript, SCSS, and type checks.
+
+## Coding Style & Naming Conventions
+
+Use ES modules and 2-space indentation. Prettier uses single quotes, no semicolons, no trailing commas, and a 120-character print width. Run `npm run format` or `npm run format:check` before committing broad edits. ESLint and Stylelint enforce JavaScript and Sass style. Prefer descriptive kebab-case filenames such as `forms-status-redirect.js`; keep tests beside covered modules as `module-name.test.js`.
+
+## Domain Language
+
+Use `CONTEXT.md` as the source of truth for grant-domain terms and avoided synonyms. When adding user-facing copy, tests, docs, or AI-generated changes, prefer the glossary terms there, especially around grants, journeys, statuses, identities, and integrations.
+
+## Developer Addenda
+
+Developers can add their own `AGENTS.local.md` and should be read as an addendum to this file. Keep that file local to your machine and do not commit it.
+
+## Testing Guidelines
+
+Vitest is the primary test runner. Add or update colocated `*.test.js` files for server and shared logic, and keep acceptance coverage in `acceptance/test/features` plus matching steps when journeys change. Run the narrowest relevant test first, for example `npx vitest run src/server/common/request-pipeline/redirects/forms-status-redirect.test.js`, then run `npm run lint` and broader suites for shared behavior.
+
+## Commit & Pull Request Guidelines
+
+Git history uses short imperative messages, often prefixed with a ticket, for example `TGC-1384: Enable farm-payments allowlist` or `TGC-1374 - Fix: ...`. Keep commits focused and avoid unrelated formatting. PRs should describe the change, link the ticket or issue, list validation commands, and include screenshots only for visible UI changes. Mention config, Docker, or migration impacts explicitly.
+
+## Security & Configuration Tips
+
+Do not commit secrets. Start from `.env.example` and local setup scripts. Use Snyk and Dependabot findings as release blockers when they affect touched dependencies.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,133 @@
+# grants-ui
+
+A YAML-configured DEFRA grants application service for rendering form journeys, collecting submissions, and integrating with grant administration systems.
+
+## Language
+
+**Grant**
+A conditional payment or financial assistance programme offered by DEFRA for a specific farming, land, woodland, or rural activity.
+_Avoid_: Loan, Benefit, Entitlement, Reward
+
+**Grant application**
+The farmer or business user's in-progress or submitted request for a grant, including answers, status, reference numbers, and submission metadata.
+_Avoid_: Claim, Case, Order, Ticket
+
+**Grant journey**
+The end-to-end user flow for one grant, from start page through questions, review, declaration, submission, and post-submission pages.
+_Avoid_: Wizard, Survey, Questionnaire, Funnel
+
+**Form definition**
+A YAML or Config API supplied description of a grant journey, including pages, components, validation, task lists, redirects, and metadata.
+_Avoid_: Template, Schema, Form code, Screen config
+
+**Grant code**
+The stable identifier used to connect a Grants UI journey to external grant definitions and submission handling.
+_Avoid_: Slug, Name, Reference number, Campaign ID
+
+**Slug**
+The URL-facing identifier for a grant journey, used in paths such as `/{slug}/start`.
+_Avoid_: Grant code, Route ID, Form name
+
+**GAS**
+The Grants Application Service, the external service that stores grant definitions, accepts submitted application payloads, and returns administration statuses.
+_Avoid_: Grants UI Backend, Config API, Casework, Payment service
+
+**Grants UI Backend**
+The persistence API used by Grants UI to save and fetch form state so users can refresh, leave, and return to an application.
+_Avoid_: GAS, Redis, Config API, DAL
+
+**Config API**
+The service that can provide form definitions at startup as an alternative or supplement to local YAML files.
+_Avoid_: GAS, Grants UI Backend, Feature flags
+
+**Application status**
+The Grants UI status that represents where an application is in its lifecycle, such as `CLEARED`, `SUBMITTED`, or `REOPENED`.
+_Avoid_: GAS status, Task status, HTTP status, Page state
+
+**GAS status**
+The status returned by GAS for a submitted application, such as `APPLICATION_AMEND` or `APPLICATION_WITHDRAWN`, used to decide redirects and local status transitions.
+_Avoid_: Application status, Task status, Page status
+
+**Submitted**
+The application status after the user completes the declaration and Grants UI sends the application to GAS.
+_Avoid_: Completed, Closed, Sent, Finished
+
+**Reopened**
+The application status used when a submitted application needs amendments and the user should return to the journey to update answers.
+_Avoid_: Draft, Unsubmitted, Open, Reset
+
+**Cleared**
+The application status used when the local application state should be treated as clear for a new or withdrawn journey.
+_Avoid_: Deleted, Cancelled, Empty, Archived
+
+**Reference number**
+The user-facing identifier for an application submission, shown on confirmation and print views.
+_Avoid_: Grant code, Slug, Case ID, SBI
+
+**Client reference**
+The reference sent to GAS when querying or submitting an application; for reopened journeys it may use the previous reference number.
+_Avoid_: Reference number when discussing user display, Case ID, Session ID
+
+**CRN**
+Customer Reference Number: the Defra ID identifier for an individual user, used in authentication and access checks.
+_Avoid_: SBI, User ID, Contact ID, Account number
+
+**SBI**
+Single Business Identifier: the identifier for the farm business or organisation represented by the signed-in user.
+_Avoid_: CRN, Business name, Holding number, Parcel ID
+
+**Whitelist**
+A grant-specific access list of allowed CRNs or SBIs that determines whether a signed-in user can enter a journey.
+_Avoid_: Allowlist unless renaming the feature, Permission, Role, Feature flag
+
+**Task list**
+A structured progress page that groups a grant journey into sections and tasks, showing whether work is not started, unavailable, or completed.
+_Avoid_: Dashboard, Checklist, Menu, Summary page
+
+**Task**
+A configured unit of work in a task list, usually backed by one or more form pages whose required answers determine completion.
+_Avoid_: Page, Step, Section, Component
+
+**Section**
+A named grouping of related tasks within a task list, such as applicant details or business information.
+_Avoid_: Category, Chapter, Page group, Tab
+
+**Check answers**
+The review page where users inspect and change entered answers before declaration and submission.
+_Avoid_: Summary when referring to user-facing copy, Confirmation, Declaration
+
+**Declaration**
+The final pre-submission page where the user confirms the truth of their answers and submits the application.
+_Avoid_: Confirmation, Consent, Agreement, Check answers
+
+**Confirmation**
+The post-submission page showing that an application has been submitted, usually including reference number and next steps.
+_Avoid_: Declaration, Success screen, Receipt, Summary
+
+**Terminal page**
+An end-of-journey page shown when a user cannot or should not continue, often due to eligibility or access rules.
+_Avoid_: Error page, Confirmation, Dead end, Failure page
+
+**Landing page**
+An off-journey interstitial page reached by redirect rule or direct link to explain an application state before sending the user onward.
+_Avoid_: Start page, Terminal page, Marketing page, Summary page
+
+**State guard**
+A configured rule that prevents access to a route unless required form state exists or matches an expected value.
+_Avoid_: Permission, Validation, Redirect rule, Feature flag
+
+**Grant redirect rule**
+A configured mapping from Grants UI status and GAS status to a new Grants UI status and destination path.
+_Avoid_: Route, State guard, Permission rule, Navigation link
+
+**Land parcel**
+A registered area of land associated with a user's SBI, selected in land-grant journeys and used for action and payment calculations.
+_Avoid_: Field, Plot, Property, Holding
+
+**Payment**
+The calculated grant amount shown to a user, often derived from selected land parcels, actions, and payment strategy rules.
+_Avoid_: Invoice, Fee, Charge, Salary
+
+**Agreement**
+The downstream arrangement or service reached after certain offer statuses, distinct from the grant application journey itself.
+_Avoid_: Declaration, Contract when unspecified, Payment, Submission


### PR DESCRIPTION
## Summary

- Add repository guidance for AI coding agents in `AGENTS.md`.
- Add `CONTEXT.md` as the source of truth for domain language where needed.
- Ignore local-only `AGENTS.local.md` addenda without creating that file.
