### PR TITLE
TGC-1463 refactored out organisationId

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,6 +76,18 @@ _Avoid_: SBI, User ID, Contact ID, Account number
 Single Business Identifier: the identifier for the farm business or organisation represented by the signed-in user.
 _Avoid_: CRN, Business name, Holding number, Parcel ID
 
+**Organisation ID**
+An external Defra ID, Siti Agri, or audit-schema contract term for an organisation identifier. Inside Grants UI, use SBI for the signed-in business identifier; do not treat `organisationId` as an SBI alias. In `audit.accounts`, `organisationId` means the primary key from the customer database.
+_Avoid_: SBI when naming internal state keys or view variables, CRN, Relationship ID
+
+**Relationship ID**
+The Defra ID relationship selector value that identifies which user-to-business relationship is active for the current sign-in.
+_Avoid_: SBI, Organisation ID, CRN
+
+**SSO organisation ID**
+The `ssoOrgId` query hint passed between services so Defra ID can preselect an organisation relationship during sign-in.
+_Avoid_: SBI, Organisation ID, Relationship ID once the user is authenticated
+
 **Whitelist**
 A grant-specific access list of allowed CRNs or SBIs that determines whether a signed-in user can enter a journey.
 _Avoid_: Allowlist unless renaming the feature, Permission, Role, Feature flag

--- a/src/config/nunjucks/context/context.js
+++ b/src/config/nunjucks/context/context.js
@@ -24,7 +24,6 @@ const usersDetails = (request, role) => {
     sbi: request?.auth?.credentials?.sbi,
     crn: request?.auth?.credentials?.crn,
     name: request?.auth?.credentials?.name,
-    organisationId: request?.auth?.credentials?.organisationId,
     organisationName: request?.auth?.credentials?.organisationName,
     relationshipId: request?.auth?.credentials?.relationshipId,
     role
@@ -194,7 +193,6 @@ const buildFallbackContext = (serviceName, cookiePolicyUrl, cookieConsentExpiryD
       sbi: null,
       crn: null,
       name: null,
-      organisationId: null,
       organisationName: null,
       relationshipId: null,
       role: null
@@ -250,7 +248,6 @@ export async function context(request) {
  * @property {unknown} sbi
  * @property {unknown} crn
  * @property {unknown} name
- * @property {unknown} organisationId
  * @property {unknown} organisationName
  * @property {unknown} relationshipId
  * @property {string | null | undefined} role

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -76,7 +76,6 @@ const getExpectedContext = () => ({
     isAuthenticated: false,
     name: undefined,
     role: undefined,
-    organisationId: undefined,
     organisationName: undefined,
     crn: undefined,
     relationshipId: undefined,
@@ -317,7 +316,6 @@ describe('context', () => {
         sbi: undefined,
         crn: undefined,
         name: undefined,
-        organisationId: undefined,
         organisationName: undefined,
         relationshipId: undefined,
         role: undefined
@@ -329,7 +327,6 @@ describe('context', () => {
         sbi: '106284736',
         crn: 'crn123',
         name: 'John Doe',
-        organisationId: 'org123',
         organisationName: ' Farm 1',
         relationshipId: 'rel456',
         sessionId: 'valid-session-id'
@@ -346,7 +343,6 @@ describe('context', () => {
         sbi: '106284736',
         crn: 'crn123',
         name: 'John Doe',
-        organisationId: 'org123',
         organisationName: ' Farm 1',
         relationshipId: 'rel456',
         role: 'admin'
@@ -364,7 +360,6 @@ describe('context', () => {
         sbi: undefined,
         crn: undefined,
         name: undefined,
-        organisationId: undefined,
         organisationName: undefined,
         relationshipId: undefined,
         role: undefined
@@ -386,7 +381,6 @@ describe('context', () => {
         sbi: undefined,
         crn: undefined,
         name: undefined,
-        organisationId: undefined,
         organisationName: undefined,
         relationshipId: undefined,
         role: undefined
@@ -434,7 +428,6 @@ describe('context', () => {
         sbi: undefined,
         crn: undefined,
         name: undefined,
-        organisationId: undefined,
         organisationName: undefined,
         relationshipId: undefined,
         role: undefined
@@ -680,7 +673,6 @@ describe('context', () => {
           sbi: null,
           crn: null,
           name: null,
-          organisationId: null,
           organisationName: null,
           relationshipId: null,
           role: null

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -327,7 +327,7 @@ describe('context', () => {
         sbi: '106284736',
         crn: 'crn123',
         name: 'John Doe',
-        organisationName: ' Farm 1',
+        organisationName: 'Farm 1',
         relationshipId: 'rel456',
         sessionId: 'valid-session-id'
       }
@@ -343,7 +343,7 @@ describe('context', () => {
         sbi: '106284736',
         crn: 'crn123',
         name: 'John Doe',
-        organisationName: ' Farm 1',
+        organisationName: 'Farm 1',
         relationshipId: 'rel456',
         role: 'admin'
       })

--- a/src/plugins/auth.js
+++ b/src/plugins/auth.js
@@ -266,7 +266,7 @@ function extractFarmDetails(relationships) {
 
   // Define indices for relationship parts
   const RELATIONSHIP_ID_INDEX = 0
-  const ORGANISATION_ID_INDEX = 1
+  const SBI_INDEX = 1
   const ORGANISATION_LOA_INDEX = parts.length - INDEX_OF_LAST_KNOWN_PARTS_IN_COLLECTION
   const RELATIONSHIP_INDEX = parts.length - 2
   const RELATIONSHIP_LOA_INDEX = parts.length - 1
@@ -293,7 +293,7 @@ function extractFarmDetails(relationships) {
 
   return [
     parts[RELATIONSHIP_ID_INDEX],
-    parts[ORGANISATION_ID_INDEX],
+    parts[SBI_INDEX],
     orgName,
     parts[ORGANISATION_LOA_INDEX],
     parts[RELATIONSHIP_INDEX],
@@ -315,17 +315,16 @@ export function mapPayloadToProfile(request, h) {
       (/** @type {string} */ relationship) => relationship.split(':')[0] === userData.currentRelationshipId
     )
     // eslint-disable-next-line no-unused-vars
-    const [relationshipId, organisationId, organisationName, _organisationLoa, _relationship, _relationshipLoa] =
+    const [relationshipId, sbi, organisationName, _organisationLoa, _relationship, _relationshipLoa] =
       extractFarmDetails(currentRelationship)
 
     const existingCreds = request.auth.credentials
 
     request.auth.credentials = {
       ...existingCreds,
-      sbi: String(organisationId),
+      sbi: String(sbi),
       crn: String(userData.contactId),
       name: `${userData.firstName} ${userData.lastName}`,
-      organisationId: String(organisationId),
       organisationName,
       relationshipId: String(relationshipId)
     }

--- a/src/plugins/auth.test.js
+++ b/src/plugins/auth.test.js
@@ -943,7 +943,6 @@ describe('Auth Plugin', () => {
         sbi: '987654',
         crn: '12345',
         name: 'John Doe',
-        organisationId: '987654',
         organisationName: 'Farm 1',
         relationshipId: '123456'
       })
@@ -970,7 +969,6 @@ describe('Auth Plugin', () => {
         sbi: '987654',
         crn: '12345',
         name: 'John Doe',
-        organisationId: '987654',
         organisationName: 'Farm 1',
         relationshipId: '123456-farm-1'
       })
@@ -1007,7 +1005,6 @@ describe('Auth Plugin', () => {
         sbi: '111222',
         crn: '12345',
         name: 'John Doe',
-        organisationId: '111222',
         organisationName: 'Test Organisation',
         relationshipId: '123456-farm1'
       })
@@ -1082,7 +1079,7 @@ describe('Auth Plugin', () => {
       const payload = JSON.parse(response.payload)
 
       expect(payload.credentials.sbi).toBe(expectedSbi)
-      expect(payload.credentials.organisationId).toBe(expectedSbi)
+      expect(payload.credentials.organisationId).toBeUndefined()
       expect(payload.credentials.organisationName).toBe(expectedOrgName)
     })
   })

--- a/src/server/common/components/account-bar/template.njk
+++ b/src/server/common/components/account-bar/template.njk
@@ -5,7 +5,7 @@
         <div class="govuk-grid-column-two-thirds-from-desktop defra-account-bar__headings govuk-!-margin-bottom-2">
             <span class="govuk-visually-hidden">Acting on behalf of </span>
             {{ params.organisationName }}
-            <div class="govuk-!-font-size-16 govuk-!-font-weight-regular govuk-!-margin-top-1">Single business identifier (SBI): {{ params.organisationId }} </div>
+            <div class="govuk-!-font-size-16 govuk-!-font-weight-regular govuk-!-margin-top-1">Single business identifier (SBI): {{ params.sbi }} </div>
         </div>
 
         <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-2 defra-account-bar__headings defra-account-bar__headings--right-aligned">
@@ -19,4 +19,3 @@
     </div>
   </div>
 {% endif %}
-

--- a/src/server/common/components/account-bar/template.test.js
+++ b/src/server/common/components/account-bar/template.test.js
@@ -1,0 +1,17 @@
+import { createComponentRenderer } from '~/src/server/common/test-helpers/component-helpers.js'
+
+const renderAccountBar = createComponentRenderer(import.meta.url, 'defraAccountBar')
+
+describe('Account Bar Component', () => {
+  test('renders the SBI from the precise sbi parameter without changing display text', () => {
+    const $accountBar = renderAccountBar({
+      organisationName: 'Test Farm',
+      sbi: '106284736',
+      name: 'John Doe'
+    })
+
+    expect($accountBar('.defra-account-bar').text()).toContain('Test Farm')
+    expect($accountBar('.defra-account-bar').text()).toContain('Single business identifier (SBI): 106284736')
+    expect($accountBar('.defra-account-bar').text()).toContain('John Doe')
+  })
+})

--- a/src/server/common/helpers/audit/audit-event.test.js
+++ b/src/server/common/helpers/audit/audit-event.test.js
@@ -90,7 +90,7 @@ describe('buildAuditEvent', () => {
     expect(/** @type {any} */ (event.audit).accounts).not.toHaveProperty('organisationId')
   })
 
-  test('does not publish organisationId from credentials as an audit account without the customer database id', () => {
+  test('does not publish an audit event including organisationId without accounts present', () => {
     const request = buildRequest({
       auth: { isAuthenticated: true, credentials: { organisationId: 'not-the-sbi' } }
     })

--- a/src/server/common/helpers/audit/audit-event.test.js
+++ b/src/server/common/helpers/audit/audit-event.test.js
@@ -87,6 +87,17 @@ describe('buildAuditEvent', () => {
     expect(typeof event.datetime).toBe('string')
     expect(event.datetime).toBe(new Date(/** @type {string} */ (event.datetime)).toISOString())
     expect(/** @type {any} */ (event.audit).accounts).toEqual({ crn: 'crn1', sbi: 'sbi1' })
+    expect(/** @type {any} */ (event.audit).accounts).not.toHaveProperty('organisationId')
+  })
+
+  test('does not publish organisationId from credentials as an audit account without the customer database id', () => {
+    const request = buildRequest({
+      auth: { isAuthenticated: true, credentials: { organisationId: 'not-the-sbi' } }
+    })
+
+    const event = buildAuditEvent(request, START)
+
+    expect(event.audit).not.toHaveProperty('accounts')
   })
 
   test('omits user, sessionid, correlationid and accounts when not known', () => {

--- a/src/server/common/helpers/auth/get-auth-identifiers.js
+++ b/src/server/common/helpers/auth/get-auth-identifiers.js
@@ -1,0 +1,82 @@
+import { BaseError } from '../../utils/errors/BaseError.js'
+
+/**
+ * Extracts the authenticated user's identity values using Grants UI's canonical
+ * internal names. SBI is the primary business identifier; `organisationId` is
+ * not used as an SBI fallback because the audit schema reserves that name for a
+ * customer database primary key.
+ *
+ * @param {import('@defra/forms-engine-plugin/engine/types.js').AnyRequest} request
+ * @returns {AuthIdentifiers}
+ */
+export function getAuthIdentifiers(request) {
+  const credentials = request.auth?.credentials
+
+  if (!credentials) {
+    throw BaseError.wrap(new Error('Missing auth credentials'))
+  }
+
+  const sbi = getCredentialString(credentials.sbi)
+  const crn = getCredentialString(credentials.crn)
+  const contactId = getCredentialString(credentials.contactId)
+  const relationshipId = getCredentialString(credentials.relationshipId)
+  const organisationName = getCredentialString(credentials.organisationName)
+
+  return {
+    sbi,
+    crn,
+    contactId,
+    relationshipId,
+    organisationName
+  }
+}
+
+/**
+ * @param {import('@defra/forms-engine-plugin/engine/types.js').AnyRequest} request
+ * @returns {string}
+ */
+export function getAuthenticatedSbi(request) {
+  const { sbi } = getAuthIdentifiers(request)
+
+  if (!sbi) {
+    throw BaseError.wrap(new Error('Missing SBI in credentials'))
+  }
+
+  return sbi
+}
+
+/**
+ * @param {import('@defra/forms-engine-plugin/engine/types.js').AnyRequest} request
+ * @returns {string}
+ */
+export function getAuthenticatedCrn(request) {
+  const { crn } = getAuthIdentifiers(request)
+
+  if (!crn) {
+    throw BaseError.wrap(new Error('Missing CRN in credentials'))
+  }
+
+  return crn
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string | undefined}
+ */
+function getCredentialString(value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined
+  }
+
+  return value
+}
+
+/**
+ * @typedef {{
+ *   sbi?: string,
+ *   crn?: string,
+ *   contactId?: string,
+ *   relationshipId?: string,
+ *   organisationName?: string
+ * }} AuthIdentifiers
+ */

--- a/src/server/common/helpers/auth/get-auth-identifiers.test.js
+++ b/src/server/common/helpers/auth/get-auth-identifiers.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { getAuthenticatedCrn, getAuthenticatedSbi, getAuthIdentifiers } from './get-auth-identifiers.js'
+
+describe('getAuthIdentifiers', () => {
+  it('returns canonical auth identifiers from credentials', () => {
+    const request = {
+      auth: {
+        credentials: {
+          sbi: 'business-123',
+          crn: 'crn-123',
+          contactId: 'contact-123',
+          relationshipId: 'relationship-123',
+          organisationName: 'Test Farm'
+        }
+      }
+    }
+
+    expect(getAuthIdentifiers(request)).toEqual({
+      sbi: 'business-123',
+      crn: 'crn-123',
+      contactId: 'contact-123',
+      relationshipId: 'relationship-123',
+      organisationName: 'Test Farm'
+    })
+  })
+
+  it('does not use organisationId as an SBI fallback', () => {
+    const request = {
+      auth: {
+        credentials: {
+          organisationId: 'customer-database-primary-key',
+          crn: 'crn-123'
+        }
+      }
+    }
+
+    expect(getAuthIdentifiers(request).sbi).toBeUndefined()
+  })
+
+  it('uses sbi when both sbi and organisationId are present', () => {
+    const request = {
+      auth: {
+        credentials: {
+          sbi: 'business-123',
+          organisationId: 'customer-database-primary-key',
+          crn: 'crn-123'
+        }
+      }
+    }
+
+    expect(getAuthIdentifiers(request).sbi).toBe('business-123')
+  })
+
+  it('throws if auth credentials are missing', () => {
+    expect(() => getAuthIdentifiers({ auth: {} })).toThrow('Missing auth credentials')
+  })
+})
+
+describe('getAuthenticatedSbi', () => {
+  it('returns the canonical SBI', () => {
+    const request = {
+      auth: {
+        credentials: {
+          sbi: 'business-123'
+        }
+      }
+    }
+
+    expect(getAuthenticatedSbi(request)).toBe('business-123')
+  })
+
+  it('throws if SBI is missing', () => {
+    const request = {
+      auth: {
+        credentials: {
+          crn: 'crn-123'
+        }
+      }
+    }
+
+    expect(() => getAuthenticatedSbi(request)).toThrow('Missing SBI in credentials')
+  })
+})
+
+describe('getAuthenticatedCrn', () => {
+  it('returns the CRN', () => {
+    const request = {
+      auth: {
+        credentials: {
+          crn: 'crn-123'
+        }
+      }
+    }
+
+    expect(getAuthenticatedCrn(request)).toBe('crn-123')
+  })
+
+  it('throws if CRN is missing', () => {
+    const request = {
+      auth: {
+        credentials: {
+          sbi: 'business-123'
+        }
+      }
+    }
+
+    expect(() => getAuthenticatedCrn(request)).toThrow('Missing CRN in credentials')
+  })
+})

--- a/src/server/common/helpers/state/get-cache-key-helper.js
+++ b/src/server/common/helpers/state/get-cache-key-helper.js
@@ -1,5 +1,6 @@
 import { getGrantCode } from '../grant-code.js'
 import { BaseError } from '../../utils/errors/BaseError.js'
+import { getAuthenticatedCrn, getAuthenticatedSbi } from '../auth/get-auth-identifiers.js'
 
 /**
  * Generates a cache key from a Hapi request by extracting user, business, and grant identifiers.
@@ -9,20 +10,8 @@ import { BaseError } from '../../utils/errors/BaseError.js'
  * @throws {Error} If authentication credentials, user ID, business relationship, or grant ID are missing or malformed.
  */
 export const getCacheKey = (request) => {
-  const credentials = request.auth?.credentials
-
-  if (!credentials) {
-    throw BaseError.wrap(new Error('Missing auth credentials'))
-  }
-  const { crn, organisationId: sbi } = /** @type {{ crn?: string, organisationId?: string }} */ (credentials)
-
-  if (!crn) {
-    throw BaseError.wrap(new Error('Missing CRN in credentials'))
-  }
-
-  if (!sbi) {
-    throw BaseError.wrap(new Error('Missing SBI (organisationId) in credentials'))
-  }
+  getAuthenticatedCrn(request)
+  const sbi = getAuthenticatedSbi(request)
 
   const grantCode = getGrantCode(request)
 

--- a/src/server/common/helpers/state/get-cache-key-helper.test.js
+++ b/src/server/common/helpers/state/get-cache-key-helper.test.js
@@ -6,7 +6,7 @@ describe('getCacheKey', () => {
       auth: {
         credentials: {
           crn: 'user123',
-          organisationId: 'business456'
+          sbi: 'business456'
         }
       },
       params: {
@@ -26,7 +26,7 @@ describe('getCacheKey', () => {
     const request = {
       auth: {
         credentials: {
-          organisationId: 'business456'
+          sbi: 'business456'
         }
       },
       params: {
@@ -37,7 +37,7 @@ describe('getCacheKey', () => {
     expect(() => getCacheKey(request)).toThrow('Missing CRN in credentials')
   })
 
-  it('throws error if organisationId is missing', () => {
+  it('throws error if SBI is missing', () => {
     const request = {
       auth: {
         credentials: {
@@ -49,7 +49,23 @@ describe('getCacheKey', () => {
       }
     }
 
-    expect(() => getCacheKey(request)).toThrow('Missing SBI (organisationId) in credentials')
+    expect(() => getCacheKey(request)).toThrow('Missing SBI in credentials')
+  })
+
+  it('does not use organisationId as an SBI fallback', () => {
+    const request = {
+      auth: {
+        credentials: {
+          crn: 'user123',
+          organisationId: 'customer-database-primary-key'
+        }
+      },
+      params: {
+        slug: 'grant789'
+      }
+    }
+
+    expect(() => getCacheKey(request)).toThrow('Missing SBI in credentials')
   })
 
   it('throws error if auth.credentials is missing', () => {
@@ -68,7 +84,7 @@ describe('getCacheKey', () => {
       auth: {
         credentials: {
           crn: 'user123',
-          organisationId: 'business456'
+          sbi: 'business456'
         }
       },
       params: {}
@@ -82,7 +98,7 @@ describe('getCacheKey', () => {
       auth: {
         credentials: {
           crn: 'user123',
-          organisationId: 'business456'
+          sbi: 'business456'
         }
       }
       // no params property

--- a/src/server/common/helpers/state/mock-request-with-identity.test-helper.js
+++ b/src/server/common/helpers/state/mock-request-with-identity.test-helper.js
@@ -11,7 +11,7 @@ export function mockRequestWithIdentity(overrides = {}) {
     auth: {
       credentials: {
         crn: 'user_test',
-        organisationId: 'biz_test',
+        sbi: 'biz_test',
         grantId: 'grant_test',
         ...overrides.credentials
       }

--- a/src/server/common/helpers/state/mock-request-with-identity.test-helper.test.js
+++ b/src/server/common/helpers/state/mock-request-with-identity.test-helper.test.js
@@ -20,16 +20,8 @@ describe('mockRequestWithIdentity', () => {
   })
 
   it.each([
-    [
-      'crn',
-      { credentials: { crn: 'custom_user' } },
-      { crn: 'custom_user', sbi: 'biz_test', grantId: 'grant_test' }
-    ],
-    [
-      'multiple credentials',
-      { credentials: { crn: 'x', sbi: 'y' } },
-      { crn: 'x', sbi: 'y', grantId: 'grant_test' }
-    ],
+    ['crn', { credentials: { crn: 'custom_user' } }, { crn: 'custom_user', sbi: 'biz_test', grantId: 'grant_test' }],
+    ['multiple credentials', { credentials: { crn: 'x', sbi: 'y' } }, { crn: 'x', sbi: 'y', grantId: 'grant_test' }],
     [
       'new credential property',
       { credentials: { extra: 'value' } },

--- a/src/server/common/helpers/state/mock-request-with-identity.test-helper.test.js
+++ b/src/server/common/helpers/state/mock-request-with-identity.test-helper.test.js
@@ -6,7 +6,7 @@ describe('mockRequestWithIdentity', () => {
 
     expect(request.auth.credentials).toEqual({
       crn: 'user_test',
-      organisationId: 'biz_test',
+      sbi: 'biz_test',
       grantId: 'grant_test'
     })
 
@@ -23,17 +23,17 @@ describe('mockRequestWithIdentity', () => {
     [
       'crn',
       { credentials: { crn: 'custom_user' } },
-      { crn: 'custom_user', organisationId: 'biz_test', grantId: 'grant_test' }
+      { crn: 'custom_user', sbi: 'biz_test', grantId: 'grant_test' }
     ],
     [
       'multiple credentials',
-      { credentials: { crn: 'x', organisationId: 'y' } },
-      { crn: 'x', organisationId: 'y', grantId: 'grant_test' }
+      { credentials: { crn: 'x', sbi: 'y' } },
+      { crn: 'x', sbi: 'y', grantId: 'grant_test' }
     ],
     [
       'new credential property',
       { credentials: { extra: 'value' } },
-      { crn: 'user_test', organisationId: 'biz_test', grantId: 'grant_test', extra: 'value' }
+      { crn: 'user_test', sbi: 'biz_test', grantId: 'grant_test', extra: 'value' }
     ]
   ])('merges %s override into credentials', (_name, overrides, expectedCredentials) => {
     const request = mockRequestWithIdentity(overrides)

--- a/src/server/common/request-pipeline/redirects/forms-status-redirect.js
+++ b/src/server/common/request-pipeline/redirects/forms-status-redirect.js
@@ -82,8 +82,6 @@ async function persistStatus(request, newStatus, previousStatus, grantId, existi
     return
   }
 
-  const organisationId = request.auth.credentials?.sbi
-
   const cacheService = getFormsCacheService(request.server)
 
   if (newStatus === ApplicationStatus.CLEARED) {
@@ -127,7 +125,7 @@ async function persistStatus(request, newStatus, previousStatus, grantId, existi
 
     await updateApplicationStatus(
       newStatus,
-      `${organisationId}:${grantId}`,
+      `${sbi}:${grantId}`,
       /** @type {{ lockToken?: string, grantVersion?: string }} */ ({ lockToken, grantVersion })
     )
   }

--- a/src/server/common/templates/layouts/dxt-form.njk
+++ b/src/server/common/templates/layouts/dxt-form.njk
@@ -27,7 +27,7 @@
 
     {{ defraAccountBar({
       organisationName: auth.organisationName,
-      organisationId: auth.organisationId | default(""),
+      sbi: auth.sbi | default(""),
       name: auth.name
     }) }}
 

--- a/src/server/common/templates/layouts/page.njk
+++ b/src/server/common/templates/layouts/page.njk
@@ -64,7 +64,7 @@
 
   {{ defraAccountBar({
     organisationName: auth.organisationName,
-    organisationId: auth.organisationId | default(""),
+    sbi: auth.sbi | default(""),
     name: auth.name
   }) }}
 {% endblock %}

--- a/src/server/confirmation/services/confirmation.service.js
+++ b/src/server/confirmation/services/confirmation.service.js
@@ -95,7 +95,7 @@ export class ConfirmationService {
         auth: {
           name: 'Dev Mode User',
           organisationName: 'Dev Mode Organisation',
-          organisationId: '999999999'
+          sbi: '999999999'
         }
       }
     }

--- a/src/server/confirmation/services/confirmation.service.test.js
+++ b/src/server/confirmation/services/confirmation.service.test.js
@@ -83,7 +83,7 @@ describe('ConfirmationService', () => {
       expect(result.formSlug).toBe('/test-form')
       expect(result.auth.name).toBe('Dev Mode User')
       expect(result.auth.organisationName).toBe('Dev Mode Organisation')
-      expect(result.auth.organisationId).toBe('999999999')
+      expect(result.auth.sbi).toBe('999999999')
     })
   })
 

--- a/src/server/dev-tools/handlers/demo-details.handler.js
+++ b/src/server/dev-tools/handlers/demo-details.handler.js
@@ -43,7 +43,7 @@ function buildBaseViewModel({ sections, form, slug }) {
     auth: {
       name: 'Dev Mode User',
       organisationName: 'Dev Mode Organisation',
-      organisationId: '999999999'
+      sbi: '999999999'
     }
   }
 }

--- a/src/server/dev-tools/handlers/demo-details.handler.test.js
+++ b/src/server/dev-tools/handlers/demo-details.handler.test.js
@@ -104,7 +104,7 @@ describe('demo-details.handler', () => {
         auth: {
           name: 'Dev Mode User',
           organisationName: 'Dev Mode Organisation',
-          organisationId: '999999999'
+          sbi: '999999999'
         }
       })
     })

--- a/src/server/home/views/home.njk
+++ b/src/server/home/views/home.njk
@@ -10,7 +10,7 @@
       You have signed in
     </h1>
 
-    <span class="govuk-caption-m">{{ auth.organisationId }}</span>
+    <span class="govuk-caption-m">{{ auth.sbi }}</span>
     <h2 class="govuk-heading-m">Your session details</h2>
 
     {% set summaryRows = [] %}

--- a/src/server/land-grants/controllers/confirm-farm-details.controller.test.js
+++ b/src/server/land-grants/controllers/confirm-farm-details.controller.test.js
@@ -48,7 +48,7 @@ describe('ConfirmFarmDetailsController', () => {
           sbi: 'SBI123456',
           crn: '1100014934',
           name: 'John Doe',
-          organisationName: ' Farm 1',
+          organisationName: 'Farm 1',
           role: 'admin',
           sessionId: 'valid-session-id'
         }

--- a/src/server/land-grants/controllers/confirm-farm-details.controller.test.js
+++ b/src/server/land-grants/controllers/confirm-farm-details.controller.test.js
@@ -48,7 +48,6 @@ describe('ConfirmFarmDetailsController', () => {
           sbi: 'SBI123456',
           crn: '1100014934',
           name: 'John Doe',
-          organisationId: 'SBI123456',
           organisationName: ' Farm 1',
           role: 'admin',
           sessionId: 'valid-session-id'

--- a/src/server/land-grants/controllers/remove-action-page.controller.test.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.test.js
@@ -55,7 +55,7 @@ describe('RemoveActionPageController', () => {
           sbi: '106284736',
           crn: '1102838829',
           name: 'John Doe',
-          organisationName: ' Farm 1',
+          organisationName: 'Farm 1',
           role: 'admin',
           sessionId: 'valid-session-id'
         }

--- a/src/server/land-grants/controllers/remove-action-page.controller.test.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.test.js
@@ -55,7 +55,6 @@ describe('RemoveActionPageController', () => {
           sbi: '106284736',
           crn: '1102838829',
           name: 'John Doe',
-          organisationId: 'org123',
           organisationName: ' Farm 1',
           role: 'admin',
           sessionId: 'valid-session-id'

--- a/src/server/land-grants/controllers/select-land-actions-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-land-actions-page.controller.test.js
@@ -129,7 +129,6 @@ describe('SelectLandActionsPageController', () => {
           sbi: '106284736',
           crn: 'CRN123',
           name: 'John Doe',
-          organisationId: 'org123',
           organisationName: 'Farm 1',
           role: 'admin',
           sessionId: 'valid-session-id'

--- a/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
@@ -85,7 +85,6 @@ describe('SelectLandParcelPageController', () => {
         sbi: '106284736',
         crn: '1102838829',
         name: 'John Doe',
-        organisationId: 'org123',
         organisationName: ' Farm 1',
         role: 'admin',
         sessionId: 'valid-session-id'

--- a/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
@@ -85,7 +85,7 @@ describe('SelectLandParcelPageController', () => {
         sbi: '106284736',
         crn: '1102838829',
         name: 'John Doe',
-        organisationName: ' Farm 1',
+        organisationName: 'Farm 1',
         role: 'admin',
         sessionId: 'valid-session-id'
       }

--- a/src/server/land-grants/views/fptt-information.html
+++ b/src/server/land-grants/views/fptt-information.html
@@ -1530,7 +1530,7 @@
       <p class="govuk-body">If you have a question about the FPTT, contact the RPA by:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          email: <a href="mailto:farmpayments@rpa.gov.uk?subject=Farm payments technical test: SBI {{auth.organisationId | default('')}}" class="govuk-link">
+          email: <a href="mailto:farmpayments@rpa.gov.uk?subject=Farm payments technical test: SBI {{auth.sbi | default('')}}" class="govuk-link">
             farmpayments@rpa.gov.uk
           </a> – use ‘Farm payments technical test’ in the subject header and include your SBI
         </li>

--- a/src/server/non-land-grants/methane/controllers/confirm-methane-details.controller.test.js
+++ b/src/server/non-land-grants/methane/controllers/confirm-methane-details.controller.test.js
@@ -74,8 +74,7 @@ describe('ConfirmMethaneDetailsController', () => {
           relationships: ['1101629797:SBI123456'],
           sbi: 'SBI123456',
           crn: '1100014934',
-          name: 'John Doe',
-          organisationId: 'SBI123456'
+          name: 'John Doe'
         }
       }
     }


### PR DESCRIPTION
  - Added a shared auth identity helper for canonical identity values.
  - Updated cache key and redirect/status logic to use SBI explicitly.
  - Removed the `organisationId: sbi` compatibility alias from normalised auth credentials.
  - Renamed view context and account bar variables from `organisationId` to `sbi`.
  - Kept the browser output unchanged, including the displayed “Single business identifier (SBI)” text.
  - Updated dev/demo view models and test fixtures to use `sbi` where the value is an SBI.
  - Added tests to make clear that `organisationId` is not used as an SBI fallback.
  - Updated CONTEXT.md to document the distinction between SBI and Organisation ID.
