### PR TITLE
TGC-1418 - accessibility + os maps / streetmaps comparison

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -69,7 +69,7 @@ services:
       LAND_GRANTS_ENABLED_ACTIONS: ${LAND_GRANTS_ENABLED_ACTIONS:-CMOR1,UPL1,UPL2,UPL3,UPL8,UPL10,CLIG3}
       MAP_MOCK_DATA_ENABLED: ${MAP_MOCK_DATA_ENABLED:-true}
       OS_MAPS_API_KEY: ${OS_MAPS_API_KEY:-}
-      BACKEND_FORM_DEF_ENABLED_SLUGS: ${BACKEND_FORM_DEF_ENABLED_SLUGS:-grasslands,woodland,farm-payments,example-grant-with-auth,example-grant-with-map,example-grant-with-task-list,example-grant-with-task-list-hide-questions,example-whitelist,pigs-might-fly}
+      BACKEND_FORM_DEF_ENABLED_SLUGS: ${BACKEND_FORM_DEF_ENABLED_SLUGS:-grasslands,woodland,farm-payments,example-grant-with-auth,example-grant-with-task-list,example-grant-with-task-list-hide-questions,example-whitelist,pigs-might-fly}
       NOTIFICATION_BANNER_EXCLUDED_PATH_SUFFIXES: ${NOTIFICATION_BANNER_EXCLUDED_PATH_SUFFIXES:-/confirmation,/print-submitted-application}
       SFD_UPDATE_URL: '${SFD_UPDATE_URL:-http://localhost:3000/sfd/mock}'
       SFD_UPDATE_ENABLED: ${SFD_UPDATE_ENABLED:-false}

--- a/compose.yml
+++ b/compose.yml
@@ -69,7 +69,7 @@ services:
       LAND_GRANTS_ENABLED_ACTIONS: ${LAND_GRANTS_ENABLED_ACTIONS:-CMOR1,UPL1,UPL2,UPL3,UPL8,UPL10,CLIG3}
       MAP_MOCK_DATA_ENABLED: ${MAP_MOCK_DATA_ENABLED:-true}
       OS_MAPS_API_KEY: ${OS_MAPS_API_KEY:-}
-      BACKEND_FORM_DEF_ENABLED_SLUGS: ${BACKEND_FORM_DEF_ENABLED_SLUGS:-grasslands,woodland,farm-payments,example-grant-with-auth,example-grant-with-task-list,example-grant-with-task-list-hide-questions,example-whitelist,pigs-might-fly}
+      BACKEND_FORM_DEF_ENABLED_SLUGS: ${BACKEND_FORM_DEF_ENABLED_SLUGS:-grasslands,woodland,farm-payments,example-grant-with-auth,example-grant-with-map,example-grant-with-task-list,example-grant-with-task-list-hide-questions,example-whitelist,pigs-might-fly}
       NOTIFICATION_BANNER_EXCLUDED_PATH_SUFFIXES: ${NOTIFICATION_BANNER_EXCLUDED_PATH_SUFFIXES:-/confirmation,/print-submitted-application}
       SFD_UPDATE_URL: '${SFD_UPDATE_URL:-http://localhost:3000/sfd/mock}'
       SFD_UPDATE_ENABLED: ${SFD_UPDATE_ENABLED:-false}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18984,9 +18984,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -20120,34 +20120,6 @@
       "engines": {
         "node": ">=6.0"
       }
-    },
-    "node_modules/gray-matter/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/gray-matter/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -22218,9 +22190,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@hapi/jwt": "3.2.4",
         "@hapi/vision": "7.0.3",
         "@hapi/yar": "11.0.3",
+        "@mapbox/vector-tile": "3.0.0",
         "accessible-autocomplete": "3.0.1",
         "ajv": "8.20.0",
         "ajv-formats": "3.0.1",
@@ -45,10 +46,12 @@
         "jsonwebtoken": "9.0.3",
         "lodash": "4.18.1",
         "nunjucks": "3.2.4",
+        "pbf": "5.1.0",
         "pino": "9.14.0",
         "pino-pretty": "13.1.3",
         "semver": "7.8.5",
         "undici": "8.5.0",
+        "vt-pbf": "3.1.3",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -9355,14 +9358,14 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
-      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
         "@types/geojson": "^7946.0.16",
-        "pbf": "^4.0.1"
+        "pbf": "^5.0.0"
       }
     },
     "node_modules/@mapbox/whoots-js": {
@@ -9426,11 +9429,34 @@
         "supercluster": "^8.0.1"
       }
     },
+    "node_modules/@maplibre/vt-pbf/node_modules/@mapbox/vector-tile": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.2"
+      }
+    },
     "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
       "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
       "license": "ISC"
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.1",
@@ -21025,6 +21051,26 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -23198,6 +23244,29 @@
       },
       "funding": {
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/maplibre-gl/node_modules/@mapbox/vector-tile": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.2"
+      }
+    },
+    "node_modules/maplibre-gl/node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/mark.js": {
@@ -27261,9 +27330,9 @@
       "license": "MIT"
     },
     "node_modules/pbf": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
-      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.0.tgz",
+      "integrity": "sha512-Wv0yo0+uZepnoNEKsquhar1F18LogB8oeEikIhUXG16udbiXG7JecHGySwoo6kuMgjmbQYzdrTZlO+/K9t8eZg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"
@@ -35283,6 +35352,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/vt-pbf/node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "license": "ISC"
+    },
+    "node_modules/vt-pbf/node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/vt-pbf/node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20103,6 +20103,34 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/gray-matter/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
     "qs": "6.15.2",
     "underscore": "1.13.8",
     "uuid": "14.0.0",
+    "fast-uri": "3.1.3",
+    "js-yaml": "4.3.0",
     "cheerio": {
       "undici": "7.28.0"
     },

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@hapi/jwt": "3.2.4",
     "@hapi/vision": "7.0.3",
     "@hapi/yar": "11.0.3",
+    "@mapbox/vector-tile": "3.0.0",
     "accessible-autocomplete": "3.0.1",
     "ajv": "8.20.0",
     "ajv-formats": "3.0.1",
@@ -126,10 +127,12 @@
     "jsonwebtoken": "9.0.3",
     "lodash": "4.18.1",
     "nunjucks": "3.2.4",
+    "pbf": "5.1.0",
     "pino": "9.14.0",
     "pino-pretty": "13.1.3",
     "semver": "7.8.5",
     "undici": "8.5.0",
+    "vt-pbf": "3.1.3",
     "yaml": "2.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -87,8 +87,6 @@
     "qs": "6.15.2",
     "underscore": "1.13.8",
     "uuid": "14.0.0",
-    "fast-uri": "3.1.3",
-    "js-yaml": "4.3.0",
     "cheerio": {
       "undici": "7.28.0"
     },

--- a/src/client/javascripts/parcel-map/basemap-metrics.js
+++ b/src/client/javascripts/parcel-map/basemap-metrics.js
@@ -1,0 +1,100 @@
+// TEMPORARY (TGC-1418 follow-up): OS Maps vs OpenStreetMap performance
+// comparison. Delete this whole file, its one import, and the four call
+// sites marked "metrics:" in index.js once the comparison is complete.
+
+const EVENT_METRICS_UPDATE = 'parcel-map:basemap-metrics'
+
+// URL fragments identifying a network request as part of the basemap load,
+// so PerformanceObserver only counts what's relevant to the comparison —
+// not unrelated page assets (fonts, GOV.UK styles, analytics, etc).
+const BASEMAP_URL_PATTERNS = ['/api/map/os-tiles', '/api/map/os-basemap', 'basemaps.cartocdn.com']
+
+/**
+ * Times a basemap load (via MapLibre's `idle` event) and tracks tile
+ * requests/errors, first-tile time, and bytes transferred, dispatching a
+ * `parcel-map:basemap-metrics` event on `target` on each change.
+ *
+ * bytesTransferred reads 0 for cross-origin responses without
+ * Timing-Allow-Origin (e.g. CartoCDN) — a disclosed limitation, not a bug.
+ * @param {import('maplibre-gl').Map} ml
+ * @param {string} basemapProvider
+ * @param {EventTarget} target  element to dispatch EVENT_METRICS_UPDATE on
+ */
+export function trackBasemapMetrics(ml, basemapProvider, target) {
+  const startedAt = performance.now()
+  /** @type {{ provider: string, tileRequests: number, tileErrors: number, loadMs: number | null, firstTileMs: number | null, bytesTransferred: number }} */
+  const metrics = {
+    provider: basemapProvider,
+    tileRequests: 0,
+    tileErrors: 0,
+    loadMs: null,
+    firstTileMs: null,
+    bytesTransferred: 0
+  }
+
+  const emit = () => {
+    target.dispatchEvent(new CustomEvent(EVENT_METRICS_UPDATE, { bubbles: true, detail: { ...metrics } }))
+  }
+
+  const onSourceData = (/** @type {{ tile?: unknown }} */ e) => {
+    if (e.tile) {
+      metrics.tileRequests += 1
+      if (metrics.firstTileMs === null) {
+        metrics.firstTileMs = Math.round(performance.now() - startedAt)
+      }
+      emit()
+    }
+  }
+  const onError = () => {
+    metrics.tileErrors += 1
+    emit()
+  }
+  const onIdle = () => {
+    if (metrics.loadMs === null) {
+      metrics.loadMs = Math.round(performance.now() - startedAt)
+      emit()
+    }
+  }
+
+  ml.on('sourcedata', onSourceData)
+  ml.on('error', onError)
+  ml.on('idle', onIdle)
+
+  /** @type {PerformanceObserver | undefined} */
+  let perfObserver
+  // Tracks entries already counted, since `buffered: true` replays every
+  // resource-timing entry since navigation start on every observer — without
+  // this, switching basemap providers mid-session would re-sum bytes from
+  // the *previous* provider's tiles into the new provider's total.
+  const seenEntries = new WeakSet()
+  if (typeof PerformanceObserver !== 'undefined') {
+    perfObserver = new PerformanceObserver((list) => {
+      let added = false
+      for (const entry of list.getEntries()) {
+        if (entry.startTime < startedAt || seenEntries.has(entry)) {
+          continue
+        }
+        if (BASEMAP_URL_PATTERNS.some((pattern) => entry.name.includes(pattern))) {
+          seenEntries.add(entry)
+          metrics.bytesTransferred += /** @type {PerformanceResourceTiming} */ (entry).transferSize ?? 0
+          added = true
+        }
+      }
+      if (added) {
+        emit()
+      }
+    })
+    perfObserver.observe({ type: 'resource', buffered: true })
+  }
+
+  emit()
+
+  return () => {
+    ml.off('sourcedata', onSourceData)
+    ml.off('error', onError)
+    ml.off('idle', onIdle)
+    perfObserver?.disconnect()
+  }
+}
+
+export { EVENT_METRICS_UPDATE }

--- a/src/client/javascripts/parcel-map/basemap-metrics.js
+++ b/src/client/javascripts/parcel-map/basemap-metrics.js
@@ -36,8 +36,22 @@ export function trackBasemapMetrics(ml, basemapProvider, target) {
     target.dispatchEvent(new CustomEvent(EVENT_METRICS_UPDATE, { bubbles: true, detail: { ...metrics } }))
   }
 
-  const onSourceData = (/** @type {{ tile?: unknown }} */ e) => {
-    if (e.tile) {
+  // TEMPORARY (TGC-1418 follow-up): dedup by tile ID. `sourcedata` can fire
+  // more than once for the same tile (re-renders, style changes), so without
+  // this tileRequests over-counts — delete this Set + the `if` guard below
+  // (keep the `metrics.tileRequests += 1` line) when the comparison ends.
+  const seenTileIds = new Set()
+  const onSourceData = (/** @type {{ tile?: { tileID?: { key?: string } }, sourceId?: string }} */ e) => {
+    // The map also has a 'parcels' source (vector tiles/geojson) — exclude it
+    // so its tile events don't get counted as basemap activity.
+    if (e.tile && e.sourceId !== 'parcels') {
+      const tileId = e.tile.tileID?.key
+      if (tileId !== undefined) {
+        if (seenTileIds.has(tileId)) {
+          return
+        }
+        seenTileIds.add(tileId)
+      }
       metrics.tileRequests += 1
       if (metrics.firstTileMs === null) {
         metrics.firstTileMs = Math.round(performance.now() - startedAt)

--- a/src/client/javascripts/parcel-map/basemap-metrics.js
+++ b/src/client/javascripts/parcel-map/basemap-metrics.js
@@ -76,7 +76,8 @@ export function trackBasemapMetrics(ml, basemapProvider, target) {
         }
         if (BASEMAP_URL_PATTERNS.some((pattern) => entry.name.includes(pattern))) {
           seenEntries.add(entry)
-          metrics.bytesTransferred += /** @type {PerformanceResourceTiming} */ (entry).transferSize ?? 0
+          const resourceEntry = /** @type {PerformanceResourceTiming} */ (entry)
+          metrics.bytesTransferred += resourceEntry.transferSize ?? 0
           added = true
         }
       }

--- a/src/client/javascripts/parcel-map/basemap-metrics.test.js
+++ b/src/client/javascripts/parcel-map/basemap-metrics.test.js
@@ -43,7 +43,7 @@ describe('trackBasemapMetrics', () => {
       tileErrors: 0,
       loadMs: null,
       firstTileMs: null,
-      bytesTransferred: 0
+      bytesTransferred: 0,
     })
   })
 

--- a/src/client/javascripts/parcel-map/basemap-metrics.test.js
+++ b/src/client/javascripts/parcel-map/basemap-metrics.test.js
@@ -57,6 +57,63 @@ describe('trackBasemapMetrics', () => {
     expect(events.at(-1).tileRequests).toBe(1)
   })
 
+  it('does not double-count sourcedata firing twice for the same tile', () => {
+    const ml = makeMl()
+    const { target, events } = makeTarget()
+    trackBasemapMetrics(ml, 'ordnance-survey', target)
+
+    ml._emit('sourcedata', { tile: { tileID: { key: '0/0/0' } } })
+    ml._emit('sourcedata', { tile: { tileID: { key: '0/0/0' } } })
+
+    expect(events.at(-1).tileRequests).toBe(1)
+  })
+
+  it('counts distinct tile IDs separately', () => {
+    const ml = makeMl()
+    const { target, events } = makeTarget()
+    trackBasemapMetrics(ml, 'ordnance-survey', target)
+
+    ml._emit('sourcedata', { tile: { tileID: { key: '0/0/0' } } })
+    ml._emit('sourcedata', { tile: { tileID: { key: '0/0/1' } } })
+
+    expect(events.at(-1).tileRequests).toBe(2)
+  })
+
+  it('falls back to counting every event when tiles carry no tileID (e.g. mocked/geojson tiles)', () => {
+    const ml = makeMl()
+    const { target, events } = makeTarget()
+    trackBasemapMetrics(ml, 'ordnance-survey', target)
+
+    ml._emit('sourcedata', { tile: {} })
+    ml._emit('sourcedata', { tile: {} })
+
+    expect(events.at(-1).tileRequests).toBe(2)
+  })
+
+  it('ignores tile events from the parcels source', () => {
+    const ml = makeMl()
+    const { target, events } = makeTarget()
+    trackBasemapMetrics(ml, 'ordnance-survey', target)
+
+    ml._emit('sourcedata', { tile: { tileID: { key: '0/0/0' } }, sourceId: 'parcels' })
+
+    expect(events.at(-1).tileRequests).toBe(0)
+  })
+
+  it('does not let a parcels tile set firstTileMs ahead of the real basemap tile', () => {
+    const ml = makeMl()
+    const { target, events } = makeTarget()
+    trackBasemapMetrics(ml, 'ordnance-survey', target)
+
+    performance.now.mockReturnValue(50)
+    ml._emit('sourcedata', { tile: { tileID: { key: 'p/0/0' } }, sourceId: 'parcels' })
+
+    performance.now.mockReturnValue(200)
+    ml._emit('sourcedata', { tile: { tileID: { key: 'b/0/0' } }, sourceId: 'os-raster' })
+
+    expect(events.at(-1).firstTileMs).toBe(200)
+  })
+
   it('records firstTileMs on the first tile only', () => {
     const ml = makeMl()
     const { target, events } = makeTarget()

--- a/src/client/javascripts/parcel-map/basemap-metrics.test.js
+++ b/src/client/javascripts/parcel-map/basemap-metrics.test.js
@@ -1,0 +1,239 @@
+// @ts-nocheck
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { trackBasemapMetrics, EVENT_METRICS_UPDATE } from './basemap-metrics.js'
+
+function makeMl() {
+  const listeners = {}
+  return {
+    on: vi.fn((event, cb) => {
+      listeners[event] = listeners[event] ?? []
+      listeners[event].push(cb)
+    }),
+    off: vi.fn((event, cb) => {
+      listeners[event] = (listeners[event] ?? []).filter((fn) => fn !== cb)
+    }),
+    _emit(event, payload) {
+      ;(listeners[event] ?? []).forEach((fn) => fn(payload))
+    }
+  }
+}
+
+function makeTarget() {
+  const events = []
+  const target = new EventTarget()
+  target.addEventListener(EVENT_METRICS_UPDATE, (e) => events.push(e.detail))
+  return { target, events }
+}
+
+describe('trackBasemapMetrics', () => {
+  beforeEach(() => {
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+  })
+
+  it('emits an initial metrics snapshot synchronously', () => {
+    const ml = makeMl()
+    const { target, events } = makeTarget()
+
+    trackBasemapMetrics(ml, 'ordnance-survey', target)
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({
+      provider: 'ordnance-survey',
+      tileRequests: 0,
+      tileErrors: 0,
+      loadMs: null,
+      firstTileMs: null,
+      bytesTransferred: 0
+    })
+  })
+
+  it('counts a tile request on sourcedata events that carry a tile', () => {
+    const ml = makeMl()
+    const { target, events } = makeTarget()
+    trackBasemapMetrics(ml, 'ordnance-survey', target)
+
+    ml._emit('sourcedata', { tile: {} })
+
+    expect(events.at(-1).tileRequests).toBe(1)
+  })
+
+  it('records firstTileMs on the first tile only', () => {
+    const ml = makeMl()
+    const { target, events } = makeTarget()
+    trackBasemapMetrics(ml, 'ordnance-survey', target)
+
+    performance.now.mockReturnValue(120)
+    ml._emit('sourcedata', { tile: {} })
+    expect(events.at(-1).firstTileMs).toBe(120)
+
+    performance.now.mockReturnValue(500)
+    ml._emit('sourcedata', { tile: {} })
+    expect(events.at(-1).firstTileMs).toBe(120)
+  })
+
+  it('ignores sourcedata events with no tile', () => {
+    const ml = makeMl()
+    const { target, events } = makeTarget()
+    trackBasemapMetrics(ml, 'ordnance-survey', target)
+
+    ml._emit('sourcedata', {})
+
+    expect(events).toHaveLength(1) // only the initial snapshot
+  })
+
+  it('counts errors', () => {
+    const ml = makeMl()
+    const { target, events } = makeTarget()
+    trackBasemapMetrics(ml, 'ordnance-survey', target)
+
+    ml._emit('error', { error: new Error('tile fetch failed') })
+
+    expect(events.at(-1).tileErrors).toBe(1)
+  })
+
+  it('records loadMs once, on the first idle event', () => {
+    const ml = makeMl()
+    const { target, events } = makeTarget()
+    trackBasemapMetrics(ml, 'openstreetmap', target)
+
+    performance.now.mockReturnValue(342)
+    ml._emit('idle')
+
+    expect(events.at(-1).loadMs).toBe(342)
+
+    // A second idle (e.g. after panning) should not overwrite the first timing
+    performance.now.mockReturnValue(9000)
+    ml._emit('idle')
+
+    expect(events.at(-1).loadMs).toBe(342)
+  })
+
+  it('returns an unsubscribe function that detaches all listeners', () => {
+    const ml = makeMl()
+    const { target } = makeTarget()
+    const disconnect = vi.fn()
+    vi.spyOn(globalThis, 'PerformanceObserver').mockImplementation(function () {
+      this.observe = vi.fn()
+      this.disconnect = disconnect
+    })
+
+    const unsubscribe = trackBasemapMetrics(ml, 'ordnance-survey', target)
+    unsubscribe()
+
+    expect(ml.off).toHaveBeenCalledWith('sourcedata', expect.any(Function))
+    expect(ml.off).toHaveBeenCalledWith('error', expect.any(Function))
+    expect(ml.off).toHaveBeenCalledWith('idle', expect.any(Function))
+    expect(disconnect).toHaveBeenCalled()
+  })
+
+  describe('bytesTransferred (PerformanceObserver)', () => {
+    it('sums transferSize for resource entries matching basemap URL patterns', () => {
+      const ml = makeMl()
+      const { target, events } = makeTarget()
+      let observerCallback
+      vi.spyOn(globalThis, 'PerformanceObserver').mockImplementation(function (cb) {
+        observerCallback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+
+      trackBasemapMetrics(ml, 'ordnance-survey', target)
+      observerCallback({
+        getEntries: () => [
+          { name: 'http://localhost/api/map/os-tiles/1/2/3', transferSize: 1500, startTime: 10 },
+          { name: 'http://localhost/api/map/os-basemap', transferSize: 800, startTime: 20 },
+          { name: 'http://localhost/unrelated-asset.js', transferSize: 99999, startTime: 30 }
+        ]
+      })
+
+      expect(events.at(-1).bytesTransferred).toBe(2300)
+    })
+
+    it('counts CartoCDN OSM requests too', () => {
+      const ml = makeMl()
+      const { target, events } = makeTarget()
+      let observerCallback
+      vi.spyOn(globalThis, 'PerformanceObserver').mockImplementation(function (cb) {
+        observerCallback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+
+      trackBasemapMetrics(ml, 'openstreetmap', target)
+      observerCallback({
+        getEntries: () => [
+          { name: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json', transferSize: 4200, startTime: 10 }
+        ]
+      })
+
+      expect(events.at(-1).bytesTransferred).toBe(4200)
+    })
+
+    it('does not emit when no matching entries are observed', () => {
+      const ml = makeMl()
+      const { target, events } = makeTarget()
+      let observerCallback
+      vi.spyOn(globalThis, 'PerformanceObserver').mockImplementation(function (cb) {
+        observerCallback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+
+      trackBasemapMetrics(ml, 'ordnance-survey', target)
+      const countBefore = events.length
+      observerCallback({
+        getEntries: () => [{ name: 'http://localhost/unrelated.js', transferSize: 100, startTime: 10 }]
+      })
+
+      expect(events.length).toBe(countBefore)
+    })
+
+    it('ignores entries that started before this tracker began (previous provider load)', () => {
+      // Regression test: PerformanceObserver's `buffered: true` replays every
+      // resource-timing entry since navigation start, so switching provider
+      // mid-session must not re-sum the previous provider's tile bytes.
+      const ml = makeMl()
+      const { target, events } = makeTarget()
+      let observerCallback
+      vi.spyOn(globalThis, 'PerformanceObserver').mockImplementation(function (cb) {
+        observerCallback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+
+      performance.now.mockReturnValue(1000)
+      trackBasemapMetrics(ml, 'openstreetmap', target)
+
+      observerCallback({
+        getEntries: () => [
+          // Recorded before this tracker started (e.g. OS Maps' own tiles from
+          // before the provider switch) — must be excluded.
+          { name: 'http://localhost/api/map/os-tiles/1/2/3', transferSize: 1500, startTime: 200 },
+          // Recorded after this tracker started — the real OSM request.
+          { name: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json', transferSize: 4200, startTime: 1100 }
+        ]
+      })
+
+      expect(events.at(-1).bytesTransferred).toBe(4200)
+    })
+
+    it('does not double-count an entry replayed across multiple observer callbacks', () => {
+      const ml = makeMl()
+      const { target, events } = makeTarget()
+      let observerCallback
+      vi.spyOn(globalThis, 'PerformanceObserver').mockImplementation(function (cb) {
+        observerCallback = cb
+        this.observe = vi.fn()
+        this.disconnect = vi.fn()
+      })
+
+      trackBasemapMetrics(ml, 'ordnance-survey', target)
+      const entry = { name: 'http://localhost/api/map/os-tiles/1/2/3', transferSize: 1500, startTime: 10 }
+
+      observerCallback({ getEntries: () => [entry] })
+      observerCallback({ getEntries: () => [entry] })
+
+      expect(events.at(-1).bytesTransferred).toBe(1500)
+    })
+  })
+})

--- a/src/client/javascripts/parcel-map/basemap-metrics.test.js
+++ b/src/client/javascripts/parcel-map/basemap-metrics.test.js
@@ -189,9 +189,6 @@ describe('trackBasemapMetrics', () => {
     })
 
     it('ignores entries that started before this tracker began (previous provider load)', () => {
-      // Regression test: PerformanceObserver's `buffered: true` replays every
-      // resource-timing entry since navigation start, so switching provider
-      // mid-session must not re-sum the previous provider's tile bytes.
       const ml = makeMl()
       const { target, events } = makeTarget()
       let observerCallback
@@ -206,10 +203,7 @@ describe('trackBasemapMetrics', () => {
 
       observerCallback({
         getEntries: () => [
-          // Recorded before this tracker started (e.g. OS Maps' own tiles from
-          // before the provider switch) — must be excluded.
           { name: 'http://localhost/api/map/os-tiles/1/2/3', transferSize: 1500, startTime: 200 },
-          // Recorded after this tracker started — the real OSM request.
           { name: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json', transferSize: 4200, startTime: 1100 }
         ]
       })

--- a/src/client/javascripts/parcel-map/basemap-metrics.test.js
+++ b/src/client/javascripts/parcel-map/basemap-metrics.test.js
@@ -185,7 +185,7 @@ describe('trackBasemapMetrics', () => {
         getEntries: () => [{ name: 'http://localhost/unrelated.js', transferSize: 100, startTime: 10 }]
       })
 
-      expect(events.length).toHaveLength(countBefore)
+      expect(events).toHaveLength(countBefore)
     })
 
     it('ignores entries that started before this tracker began (previous provider load)', () => {

--- a/src/client/javascripts/parcel-map/basemap-metrics.test.js
+++ b/src/client/javascripts/parcel-map/basemap-metrics.test.js
@@ -185,7 +185,7 @@ describe('trackBasemapMetrics', () => {
         getEntries: () => [{ name: 'http://localhost/unrelated.js', transferSize: 100, startTime: 10 }]
       })
 
-      expect(events.length).toBe(countBefore)
+      expect(events.length).toHaveLength(countBefore)
     })
 
     it('ignores entries that started before this tracker began (previous provider load)', () => {

--- a/src/client/javascripts/parcel-map/basemap-metrics.test.js
+++ b/src/client/javascripts/parcel-map/basemap-metrics.test.js
@@ -43,7 +43,7 @@ describe('trackBasemapMetrics', () => {
       tileErrors: 0,
       loadMs: null,
       firstTileMs: null,
-      bytesTransferred: 0,
+      bytesTransferred: 0
     })
   })
 

--- a/src/client/javascripts/parcel-map/config.js
+++ b/src/client/javascripts/parcel-map/config.js
@@ -11,12 +11,15 @@ export function getMapStyleAttribution() {
   return `© Crown copyright and database rights ${new Date().getFullYear()} OS`
 }
 
+export const MULTI_SELECT_ATTRIBUTE = 'multi-select'
+
 // --- TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up) ---
 // Delete this block, BASEMAP_PROVIDER_OPENSTREETMAP's usages in index.js, and
 // the toggle in map-select-parcel.html once the comparison is complete.
 export const BASEMAP_PROVIDER_OPENSTREETMAP = 'openstreetmap'
 export const OSM_STYLE_URL = 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json'
 export const OSM_STYLE_ATTRIBUTION = '© OpenStreetMap contributors © CARTO'
+export const BASEMAP_PROVIDER_ATTRIBUTE = 'basemap-provider'
 // --- END TEMPORARY ---
 
 export const PARCEL_COLORS = [

--- a/src/client/javascripts/parcel-map/config.js
+++ b/src/client/javascripts/parcel-map/config.js
@@ -1,10 +1,23 @@
 export const PARCELS_API_URL = '/api/map/parcels'
 export const PARCEL_TILES_URL = '/api/map/parcel-tiles/{z}/{x}/{y}'
 export const PARCELS_GEOJSON_URL = '/api/map/parcels/geojson'
+
+export const BASEMAP_PROVIDER_ORDNANCE_SURVEY = 'ordnance-survey'
+export const DEFAULT_BASEMAP_PROVIDER = BASEMAP_PROVIDER_ORDNANCE_SURVEY
+
 export const MAP_STYLE_URL = '/api/map/os-basemap'
+
 export function getMapStyleAttribution() {
   return `© Crown copyright and database rights ${new Date().getFullYear()} OS`
 }
+
+// --- TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up) ---
+// Delete this block, BASEMAP_PROVIDER_OPENSTREETMAP's usages in index.js, and
+// the toggle in map-select-parcel.html once the comparison is complete.
+export const BASEMAP_PROVIDER_OPENSTREETMAP = 'openstreetmap'
+export const OSM_STYLE_URL = 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json'
+export const OSM_STYLE_ATTRIBUTION = '© OpenStreetMap contributors © CARTO'
+// --- END TEMPORARY ---
 
 export const PARCEL_COLORS = [
   '#1d70b8', // govuk-blue

--- a/src/client/javascripts/parcel-map/config.js
+++ b/src/client/javascripts/parcel-map/config.js
@@ -48,6 +48,9 @@ export const LABEL_HALO_COLOR = '#ffffff'
 
 export const SELECTION_NONE_SENTINEL = '__none__'
 
+// Accessible name for the map viewport (role="application"), announced by screen readers on focus
+export const MAP_LABEL = 'Map of your land parcels. Select a parcel to apply for actions on it.'
+
 export const MSG_LOADING = 'Loading map…'
 export const MSG_ERROR_UNAVAILABLE = 'There was a problem loading the map.'
 export const MSG_UNKNOWN_PARCEL = 'Unknown parcel'

--- a/src/client/javascripts/parcel-map/config.js
+++ b/src/client/javascripts/parcel-map/config.js
@@ -22,6 +22,18 @@ export const LAYER_LINE_WIDTH = 1.5
 export const FIT_BOUNDS_PADDING = 40
 export const AREA_DECIMAL_PLACES = 2
 
+// Feature property carrying the compound "SHEET-PARCEL" ID. Present in both the
+// vector tiles (stamped on by the grants-ui tile proxy) and the mock GeoJSON.
+// The interact plugin uses it to identify features and label them in the
+// keyboard-accessible listbox.
+export const PARCEL_ID_PROPERTY = 'id'
+
+// Pixel radius for parcel hit-testing. The interact plugin only matches
+// polygons on exact geometric containment, so the provider falls back to a
+// rendered-pixel query within this radius — otherwise small (zoomed-out)
+// parcels are practically unclickable.
+export const PARCEL_CLICK_TOLERANCE_PX = 10
+
 export const LAYER_ID_FILL = 'parcels-fill'
 export const LAYER_ID_OUTLINE = 'parcels-outline'
 export const LAYER_ID_LABEL = 'parcels-label'

--- a/src/client/javascripts/parcel-map/index.js
+++ b/src/client/javascripts/parcel-map/index.js
@@ -5,6 +5,9 @@ import InteractiveMap from '@defra/interactive-map'
 import maplibreProvider from '@defra/interactive-map/providers/maplibre'
 // @ts-ignore — no type declarations shipped with this package
 import createInteractPlugin from '@defra/interactive-map/plugins/interact'
+// TEMPORARY (TGC-1418 follow-up): delete this import and its one call site
+// (marked "metrics:" below) along with basemap-metrics.js.
+import { trackBasemapMetrics } from './basemap-metrics.js'
 import {
   PARCELS_API_URL,
   PARCEL_TILES_URL,
@@ -133,8 +136,9 @@ function buildParcelLayers(colorExpr, sourceLayer, basemapProvider) {
   }
 }
 
-// <parcel-map multi-select="true|false" basemap-provider="ordnance-survey|openstreetmap">
-// basemap-provider's "openstreetmap" value is TEMPORARY (TGC-1418 follow-up).
+// <parcel-map multi-select="true|false" basemap-provider="ordnance-survey|openstreetmap" basemap-metrics="true|false">
+// basemap-provider's "openstreetmap" value and basemap-metrics are both
+// TEMPORARY (TGC-1418 follow-up).
 // Height via CSS on the element. Dispatches:
 //   parcel-map:ready, parcel-map:error, parcel-map:selection → { selectedIds: string[] }
 class ParcelMap extends HTMLElement {
@@ -342,6 +346,12 @@ class ParcelMap extends HTMLElement {
           globalThis.clearTimeout(timeout)
           resolve(null)
         })
+        // metrics: TEMPORARY (TGC-1418 follow-up) — see basemap-metrics.js.
+        // Only runs when the page opts in via basemap-metrics="true", so
+        // journeys that don't show the comparison toggle pay no extra cost.
+        if (this.getAttribute('basemap-metrics') === 'true') {
+          this.#mlCleanup.push(trackBasemapMetrics(m, basemapProvider, this))
+        }
       })
       map.on('map:stylechange', () => {
         if (mlInstance && this.#state === STATE_LOADING) {

--- a/src/client/javascripts/parcel-map/index.js
+++ b/src/client/javascripts/parcel-map/index.js
@@ -629,7 +629,7 @@ function buildColorExpr(ids) {
  * @returns {string}
  */
 function resolveFeatureId(feature) {
-  const id = /** @type {ParcelProperties} */ (feature.properties ?? {})[PARCEL_ID_PROPERTY]
+  const id = /** @type {ParcelProperties | undefined} */ (feature.properties)?.[PARCEL_ID_PROPERTY]
   return typeof id === 'string' || typeof id === 'number' ? String(id) : ''
 }
 

--- a/src/client/javascripts/parcel-map/index.js
+++ b/src/client/javascripts/parcel-map/index.js
@@ -75,11 +75,8 @@ import {
  * @typedef {{ minLng: number, minLat: number, maxLng: number, maxLat: number }} BBox
  */
 
-// MapLibre expression reading the compound "SHEET-PARCEL" ID. This is the
-// same `id` property the interact plugin matches selections against
-// (PARCEL_ID_PROPERTY) — reading it here too means the component's label,
-// colour, and highlight logic can never disagree with what the plugin
-// selected.
+// Same PARCEL_ID_PROPERTY the interact plugin matches on, so label/colour/
+// highlight logic can't disagree with what's selected.
 const COMPOUND_ID_EXPR = ['get', PARCEL_ID_PROPERTY]
 
 /**
@@ -545,11 +542,9 @@ class ParcelMap extends HTMLElement {
 }
 
 /**
- * Resolves the MapLibre style URL/attribution for the chosen basemap
- * provider.
- * TEMPORARY (TGC-1418 follow-up): once the OpenStreetMap comparison is
- * removed, this collapses to always returning the OS Maps style — delete
- * the ternary and this function's `provider` param.
+ * Resolves the MapLibre style URL/attribution for the chosen basemap provider.
+ * TEMPORARY (TGC-1418 follow-up): delete the ternary + provider param once
+ * the OpenStreetMap comparison ends.
  * @param {string} provider  BASEMAP_PROVIDER_ORDNANCE_SURVEY | BASEMAP_PROVIDER_OPENSTREETMAP
  * @returns {{ url: string, attribution: string }}
  */
@@ -562,21 +557,13 @@ function getMapStyle(provider) {
 }
 
 /**
- * Makes parcels easier to click when they're small on screen.
+ * Falls back to the nearest rendered parcel within PARCEL_CLICK_TOLERANCE_PX
+ * when the interact plugin's strict inside-the-shape hit test finds nothing —
+ * which is common for small parcels at low zoom.
  *
- * The interact plugin already searches a PARCEL_CLICK_TOLERANCE_PX box around
- * the click, but for polygons it only counts a hit if the click lands exactly
- * inside the shape — near-misses are dropped. That's nearly guaranteed for a
- * parcel that's only a few pixels wide when zoomed out. When the strict check
- * finds nothing, this falls back to whatever parcel is *drawn* closest to the
- * click within that same box. Adjacent (not overlapping) small parcels can
- * both land in that box at low zoom, so this picks whichever one is nearest
- * to the click rather than an arbitrary one. Covers both mouse clicks and the
- * keyboard crosshair, at any zoom.
- *
- * The odd wrapping is because the map library hands us a *descriptor*, not
- * the provider itself — its `load()` creates the provider later — so we
- * intercept `load()` to subclass the provider once it exists.
+ * Wrapped via `load()` because the map library hands us a provider
+ * *descriptor*, not the provider itself — the real class only exists once
+ * `load()` resolves.
  * @param {{ load: () => Promise<{ MapProvider: new (...args: never[]) => { map?: import('maplibre-gl').Map } }> }} descriptor
  */
 function withParcelHitTolerance(descriptor) {
@@ -689,9 +676,7 @@ function buildColorExpr(ids) {
 }
 
 /**
- * Read the compound parcel ID (e.g. "SD7148-9160") off a MapLibre feature's
- * `id` property — the same property the interact plugin matches selections
- * against (PARCEL_ID_PROPERTY).
+ * Compound parcel ID (e.g. "SD7148-9160") from a feature's PARCEL_ID_PROPERTY.
  * @param {MapGeoJSONFeature} feature
  * @returns {string}
  */

--- a/src/client/javascripts/parcel-map/index.js
+++ b/src/client/javascripts/parcel-map/index.js
@@ -9,9 +9,14 @@ import {
   PARCELS_API_URL,
   PARCEL_TILES_URL,
   PARCELS_GEOJSON_URL,
-  MAP_STYLE_URL,
   MAP_LABEL,
+  MAP_STYLE_URL,
   getMapStyleAttribution,
+  DEFAULT_BASEMAP_PROVIDER,
+  // TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up) — see config.js
+  OSM_STYLE_URL,
+  OSM_STYLE_ATTRIBUTION,
+  BASEMAP_PROVIDER_OPENSTREETMAP,
   PARCEL_COLORS,
   LAYER_TEXT_SIZE,
   LAYER_TEXT_HALO_WIDTH,
@@ -77,9 +82,16 @@ const COMPOUND_ID_EXPR = ['get', PARCEL_ID_PROPERTY]
 /**
  * @param {unknown[]} colorExpr  MapLibre `match` expression
  * @param {string}   [sourceLayer]
+ * @param {string}   [basemapProvider]  BASEMAP_PROVIDER_ORDNANCE_SURVEY | BASEMAP_PROVIDER_OPENSTREETMAP
  */
-function buildParcelLayers(colorExpr, sourceLayer) {
+function buildParcelLayers(colorExpr, sourceLayer, basemapProvider) {
   const src = sourceLayer ? { 'source-layer': sourceLayer } : {}
+  // OS Maps sets no `glyphs` URL, so any font renders locally via MapLibre's
+  // TinySDF fallback. TEMPORARY (TGC-1418 follow-up): CartoCDN's OpenStreetMap
+  // style DOES set a glyphs URL, and only serves the fonts it declares in its
+  // own layers ('Open Sans Regular' etc) — 'Arial Regular' 404s against it.
+  // Delete this branch (keep 'Arial Regular') once OSM support is removed.
+  const labelFont = basemapProvider === BASEMAP_PROVIDER_OPENSTREETMAP ? 'Open Sans Regular' : 'Arial Regular'
   return {
     fill: {
       id: LAYER_ID_FILL,
@@ -108,7 +120,7 @@ function buildParcelLayers(colorExpr, sourceLayer) {
       ...src,
       layout: {
         'text-field': COMPOUND_ID_EXPR,
-        'text-font': ['Arial Regular'],
+        'text-font': [labelFont],
         'text-size': LAYER_TEXT_SIZE,
         'text-anchor': 'center'
       },
@@ -121,7 +133,8 @@ function buildParcelLayers(colorExpr, sourceLayer) {
   }
 }
 
-// <parcel-map multi-select="true|false">
+// <parcel-map multi-select="true|false" basemap-provider="ordnance-survey|openstreetmap">
+// basemap-provider's "openstreetmap" value is TEMPORARY (TGC-1418 follow-up).
 // Height via CSS on the element. Dispatches:
 //   parcel-map:ready, parcel-map:error, parcel-map:selection → { selectedIds: string[] }
 class ParcelMap extends HTMLElement {
@@ -146,13 +159,33 @@ class ParcelMap extends HTMLElement {
   /** @type {Array<() => void>} */
   #mlCleanup = []
 
+  #connected = false
+
+  static get observedAttributes() {
+    return ['basemap-provider']
+  }
+
   connectedCallback() {
+    this.#connected = true
     this.#state = STATE_IDLE
     this.#init()
   }
 
   disconnectedCallback() {
+    this.#connected = false
     this.#teardown()
+  }
+
+  attributeChangedCallback(name) {
+    // Ignore the attribute's own initial set before the element is connected,
+    // and any change while a load is already in flight (that in-flight load
+    // will pick up the new value once it settles into an idle/error state).
+    if (name !== 'basemap-provider' || !this.#connected || this.#state === STATE_LOADING) {
+      return
+    }
+    this.#teardown()
+    this.#state = STATE_IDLE
+    this.#init()
   }
 
   #teardown() {
@@ -179,13 +212,15 @@ class ParcelMap extends HTMLElement {
   async #init() {
     this.#state = STATE_LOADING
 
-    // Read once at connect, runtime changes to the attribute are not supported.
+    // Read once per init — basemap-provider changes trigger a fresh #init via
+    // attributeChangedCallback, so this always reflects the current value.
     const multiSelect = this.getAttribute('multi-select') === 'true'
+    const basemapProvider = this.getAttribute('basemap-provider') || DEFAULT_BASEMAP_PROVIDER
 
     this.#skeleton = buildSkeleton()
     this.appendChild(this.#skeleton)
 
-    const [ml, data] = await Promise.all([this.#initMap(multiSelect), this.#fetchData()])
+    const [ml, data] = await Promise.all([this.#initMap(multiSelect, basemapProvider), this.#fetchData()])
 
     // Torn down (disconnected) while we were loading, nothing to wire up.
     if (this.#state !== STATE_LOADING) {
@@ -203,7 +238,7 @@ class ParcelMap extends HTMLElement {
       this.dispatchEvent(new CustomEvent(EVENT_ERROR, { bubbles: true, detail: { reason: 'no-parcels' } }))
     } else {
       const colorExpr = buildColorExpr(data.parcelIds)
-      this.#addParcelsToMap(ml, data, colorExpr)
+      this.#addParcelsToMap(ml, data, colorExpr, basemapProvider)
       const tooltip = this.#attachTooltip(ml, data.metaIndex)
       this.#attachSelectionRelay(ml, tooltip)
       this.#interactPlugin?.enable()
@@ -231,9 +266,10 @@ class ParcelMap extends HTMLElement {
 
   /**
    * @param {boolean} multiSelect
+   * @param {string} basemapProvider  BASEMAP_PROVIDER_OS | BASEMAP_PROVIDER_OSM
    * @returns {Promise<MLMap | null>}
    */
-  #initMap(multiSelect) {
+  #initMap(multiSelect, basemapProvider) {
     return new Promise((resolve) => {
       const wrapper = document.createElement('div')
       wrapper.style.cssText = 'position:relative;width:100%;height:100%'
@@ -271,13 +307,16 @@ class ParcelMap extends HTMLElement {
         mapLabel: MAP_LABEL,
         containerHeight: this.style.height || MAP_DEFAULT_HEIGHT,
         mapProvider: withParcelHitTolerance(maplibreProvider()),
-        mapStyle: { url: MAP_STYLE_URL, attribution: getMapStyleAttribution() },
+        mapStyle: getMapStyle(basemapProvider),
         plugins: [interactPlugin],
         center: MAP_DEFAULT_CENTER,
         zoom: MAP_DEFAULT_ZOOM,
-        // The OS basemap has no tiles below z7 — stop users zooming out into
-        // blank void. Passed through to the MapLibre Map constructor.
-        minZoom: MAP_MIN_ZOOM,
+        // The OS raster basemap has no tiles below z7 — stop users zooming
+        // out into blank void.
+        // TEMPORARY (TGC-1418 follow-up): the OSM/CartoCDN vector style
+        // covers the full zoom range, so it's exempted from the cap below.
+        // When OSM is removed, replace this with a plain `MAP_MIN_ZOOM`.
+        minZoom: basemapProvider === BASEMAP_PROVIDER_OPENSTREETMAP ? undefined : MAP_MIN_ZOOM,
         // Don't persist the viewport in URL params.
         urlPosition: 'none'
       })
@@ -370,8 +409,9 @@ class ParcelMap extends HTMLElement {
    * @param {MLMap} ml
    * @param {ParcelData} data
    * @param {unknown[]} colorExpr
+   * @param {string} basemapProvider  BASEMAP_PROVIDER_ORDNANCE_SURVEY | BASEMAP_PROVIDER_OPENSTREETMAP
    */
-  #addParcelsToMap(ml, { geojsonUrl, bbox }, colorExpr) {
+  #addParcelsToMap(ml, { geojsonUrl, bbox }, colorExpr, basemapProvider) {
     if (bbox) {
       const { minLng, minLat, maxLng, maxLat } = bbox
       ml.fitBounds(
@@ -398,7 +438,7 @@ class ParcelMap extends HTMLElement {
           tiles: [`${origin}${PARCEL_TILES_URL}`]
         })
     ml.addSource('parcels', source)
-    const layers = buildParcelLayers(colorExpr, geojsonUrl ? undefined : 'parcels')
+    const layers = buildParcelLayers(colorExpr, geojsonUrl ? undefined : 'parcels', basemapProvider)
     ml.addLayer(/** @type {import('maplibre-gl').LayerSpecification} */ (layers.fill))
     ml.addLayer(/** @type {import('maplibre-gl').LayerSpecification} */ (layers.outline))
     ml.addLayer(/** @type {import('maplibre-gl').LayerSpecification} */ (layers.label))
@@ -492,6 +532,23 @@ class ParcelMap extends HTMLElement {
       }
     )
   }
+}
+
+/**
+ * Resolves the MapLibre style URL/attribution for the chosen basemap
+ * provider.
+ * TEMPORARY (TGC-1418 follow-up): once the OpenStreetMap comparison is
+ * removed, this collapses to always returning the OS Maps style — delete
+ * the ternary and this function's `provider` param.
+ * @param {string} provider  BASEMAP_PROVIDER_ORDNANCE_SURVEY | BASEMAP_PROVIDER_OPENSTREETMAP
+ * @returns {{ url: string, attribution: string }}
+ */
+function getMapStyle(provider) {
+  // OSM's style/tiles are public (no key to protect), so its URL points
+  // straight at CartoCDN; OS Maps stays server-proxied.
+  return provider === BASEMAP_PROVIDER_OPENSTREETMAP
+    ? { url: OSM_STYLE_URL, attribution: OSM_STYLE_ATTRIBUTION }
+    : { url: MAP_STYLE_URL, attribution: getMapStyleAttribution() }
 }
 
 /**

--- a/src/client/javascripts/parcel-map/index.js
+++ b/src/client/javascripts/parcel-map/index.js
@@ -8,6 +8,7 @@ import {
   PARCEL_TILES_URL,
   PARCELS_GEOJSON_URL,
   MAP_STYLE_URL,
+  MAP_LABEL,
   getMapStyleAttribution,
   PARCEL_COLORS,
   LAYER_TEXT_SIZE,
@@ -232,6 +233,7 @@ class ParcelMap extends HTMLElement {
 
       const map = new InteractiveMap(mapEl.id, {
         behaviour: 'inline',
+        mapLabel: MAP_LABEL,
         containerHeight: this.style.height || MAP_DEFAULT_HEIGHT,
         mapProvider: maplibreProvider(),
         mapStyle: { url: MAP_STYLE_URL, attribution: getMapStyleAttribution() },

--- a/src/client/javascripts/parcel-map/index.js
+++ b/src/client/javascripts/parcel-map/index.js
@@ -3,6 +3,8 @@
 import InteractiveMap from '@defra/interactive-map'
 // @ts-ignore — no type declarations shipped with this package
 import maplibreProvider from '@defra/interactive-map/providers/maplibre'
+// @ts-ignore — no type declarations shipped with this package
+import createInteractPlugin from '@defra/interactive-map/plugins/interact'
 import {
   PARCELS_API_URL,
   PARCEL_TILES_URL,
@@ -17,6 +19,8 @@ import {
   FIT_BOUNDS_PADDING,
   AREA_DECIMAL_PLACES,
   TOOLTIP_STYLES,
+  PARCEL_ID_PROPERTY,
+  PARCEL_CLICK_TOLERANCE_PX,
   LAYER_ID_FILL,
   LAYER_ID_OUTLINE,
   LAYER_ID_LABEL,
@@ -120,6 +124,9 @@ class ParcelMap extends HTMLElement {
   /** @type {InstanceType<typeof InteractiveMap> | null} */
   #mapInstance = null
 
+  /** @type {ReturnType<typeof createInteractPlugin> | null} */
+  #interactPlugin = null
+
   /** @type {HTMLDivElement | null} */
   #mapEl = null
 
@@ -153,6 +160,7 @@ class ParcelMap extends HTMLElement {
       /* ignore */
     }
     this.#mapInstance = null
+    this.#interactPlugin = null
     this.#mapEl?.parentElement?.remove()
     this.#mapEl = null
     this.#skeleton?.remove()
@@ -170,7 +178,7 @@ class ParcelMap extends HTMLElement {
     this.#skeleton = buildSkeleton()
     this.appendChild(this.#skeleton)
 
-    const [ml, data] = await Promise.all([this.#initMap(), this.#fetchData()])
+    const [ml, data] = await Promise.all([this.#initMap(multiSelect), this.#fetchData()])
 
     // Torn down (disconnected) while we were loading, nothing to wire up.
     if (this.#state !== STATE_LOADING) {
@@ -190,7 +198,8 @@ class ParcelMap extends HTMLElement {
       const colorExpr = buildColorExpr(data.parcelIds)
       this.#addParcelsToMap(ml, data, colorExpr)
       const tooltip = this.#attachTooltip(ml, data.metaIndex)
-      this.#attachSelectionHandler(ml, multiSelect, tooltip)
+      this.#attachSelectionBridge(ml, tooltip)
+      this.#interactPlugin?.enable()
 
       this.#state = STATE_READY
       this.#skeleton?.remove()
@@ -213,8 +222,11 @@ class ParcelMap extends HTMLElement {
     this.#errorOverlay = el
   }
 
-  /** @returns {Promise<MLMap | null>} */
-  #initMap() {
+  /**
+   * @param {boolean} multiSelect
+   * @returns {Promise<MLMap | null>}
+   */
+  #initMap(multiSelect) {
     return new Promise((resolve) => {
       const wrapper = document.createElement('div')
       wrapper.style.cssText = 'position:relative;width:100%;height:100%'
@@ -231,12 +243,29 @@ class ParcelMap extends HTMLElement {
         this.appendChild(wrapper)
       }
 
+      // Handles feature selection accessibly: pointer clicks, a touch
+      // crosshair + Select button, and a keyboard-navigable feature listbox.
+      const interactPlugin = createInteractPlugin({
+        interactionModes: ['selectFeature'],
+        multiSelect,
+        deselectOnClickOutside: true,
+        layers: [
+          {
+            layerId: LAYER_ID_FILL,
+            idProperty: PARCEL_ID_PROPERTY,
+            labelProperty: PARCEL_ID_PROPERTY
+          }
+        ]
+      })
+      this.#interactPlugin = interactPlugin
+
       const map = new InteractiveMap(mapEl.id, {
         behaviour: 'inline',
         mapLabel: MAP_LABEL,
         containerHeight: this.style.height || MAP_DEFAULT_HEIGHT,
-        mapProvider: maplibreProvider(),
+        mapProvider: withParcelHitTolerance(maplibreProvider()),
         mapStyle: { url: MAP_STYLE_URL, attribution: getMapStyleAttribution() },
+        plugins: [interactPlugin],
         center: MAP_DEFAULT_CENTER,
         zoom: MAP_DEFAULT_ZOOM,
         // The OS basemap has no tiles below z7 — stop users zooming out into
@@ -424,17 +453,19 @@ class ParcelMap extends HTMLElement {
   }
 
   /**
+   * Bridges the interact plugin's selection state to this component's public
+   * API: re-applies the fill-opacity highlight and re-dispatches selection
+   * changes as `parcel-map:selection` events. Selection input handling
+   * (click, touch crosshair, keyboard listbox) lives in the plugin.
    * @param {MLMap} ml
-   * @param {boolean} multiSelect
    * @param {HTMLElement | undefined} tooltip
    */
-  #attachSelectionHandler(ml, multiSelect, tooltip) {
-    /** @type {Set<string>} */
-    const selected = new Set()
+  #attachSelectionBridge(ml, tooltip) {
     const idExpr = ['concat', ['get', 'sheet_id'], '-', ['get', 'parcel_id']]
 
-    const applySelection = () => {
-      const matchList = selected.size > 0 ? [...selected] : [SELECTION_NONE_SENTINEL]
+    /** @param {string[]} selectedIds */
+    const applyHighlight = (selectedIds) => {
+      const matchList = selectedIds.length > 0 ? selectedIds : [SELECTION_NONE_SENTINEL]
       ml.setPaintProperty(LAYER_ID_FILL, 'fill-opacity', [
         'match',
         idExpr,
@@ -444,56 +475,69 @@ class ParcelMap extends HTMLElement {
       ])
     }
 
-    const onParcelClick = (
-      /** @type {import('maplibre-gl').MapMouseEvent & { features?: import('maplibre-gl').MapGeoJSONFeature[] }} */ e
-    ) => {
-      const feature = e.features?.[0]
-      if (!feature) {
-        return
-      }
-      const id = resolveFeatureId(feature)
-      if (!id) {
-        return
-      }
-
-      if (multiSelect) {
-        const wasSelected = selected.has(id)
-        wasSelected ? selected.delete(id) : selected.add(id)
-        if (wasSelected && tooltip) {
+    this.#mapInstance?.on(
+      'interact:selectionchange',
+      (/** @type {{ selectedFeatures: Array<{ featureId: string | number }> }} */ { selectedFeatures }) => {
+        const selectedIds = selectedFeatures.map((f) => String(f.featureId))
+        applyHighlight(selectedIds)
+        if (selectedIds.length === 0 && tooltip) {
           hideTooltip(tooltip)
         }
-      } else {
-        const alreadySelected = selected.has(id)
-        selected.clear()
-        if (!alreadySelected) {
-          selected.add(id)
-        } else if (tooltip) {
-          hideTooltip(tooltip)
-        } else {
-          // parcel deselected and no tooltip to hide
-        }
+        this.dispatchEvent(new CustomEvent(EVENT_SELECTION, { bubbles: true, detail: { selectedIds } }))
       }
-
-      applySelection()
-      this.dispatchEvent(new CustomEvent(EVENT_SELECTION, { bubbles: true, detail: { selectedIds: [...selected] } }))
-    }
-
-    const onDeselect = (/** @type {import('maplibre-gl').MapMouseEvent} */ e) => {
-      if (ml.getLayer(LAYER_ID_FILL) && ml.queryRenderedFeatures(e.point, { layers: [LAYER_ID_FILL] }).length === 0) {
-        selected.clear()
-        applySelection()
-        this.dispatchEvent(new CustomEvent(EVENT_SELECTION, { bubbles: true, detail: { selectedIds: [] } }))
-      }
-    }
-
-    ml.on('click', LAYER_ID_FILL, onParcelClick)
-    ml.on('click', onDeselect)
-
-    this.#mlCleanup.push(
-      () => ml.off('click', LAYER_ID_FILL, onParcelClick),
-      () => ml.off('click', onDeselect)
     )
   }
+}
+
+/**
+ * Makes parcels easier to click when they're small on screen.
+ *
+ * The problem: when the interact plugin decides "did this click land on a
+ * parcel?", it checks whether the clicked point is mathematically inside the
+ * parcel's polygon. That's fine zoomed in, when a parcel fills half the
+ * screen. But zoomed out, a parcel might be 4-5 pixels wide — you'd have to
+ * click exactly inside those few pixels, so selection feels broken.
+ *
+ * The fix: if the plugin's strict check finds nothing, we ask MapLibre a more
+ * forgiving question instead — "is there a parcel *drawn on screen* within
+ * 10px of where the user clicked?" (PARCEL_CLICK_TOLERANCE_PX). If yes, we
+ * return that parcel, and the click selects it. This applies to mouse clicks
+ * and to the keyboard crosshair alike, at every zoom level.
+ *
+ * The wrapping is awkward because of how the map library is built: we don't
+ * get the provider object directly — we get a *descriptor* whose `load()` the
+ * library calls later to create the provider. So we intercept `load()` and
+ * hand back a subclass whose `getFeaturesAtPoint` adds our fallback.
+ * @param {{ load: () => Promise<{ MapProvider: new (...args: never[]) => { map?: import('maplibre-gl').Map } }> }} descriptor
+ */
+function withParcelHitTolerance(descriptor) {
+  const originalLoad = descriptor.load
+  descriptor.load = async () => {
+    const result = await originalLoad()
+    class ParcelHitToleranceProvider extends result.MapProvider {
+      /**
+       * @param {{ x: number, y: number }} point
+       * @param {{ radius?: number }} [options]
+       */
+      getFeaturesAtPoint(point, options) {
+        // @ts-ignore — base method exists on the runtime provider
+        const hits = super.getFeaturesAtPoint(point, options)
+        if (hits.length > 0 || !this.map?.getLayer(LAYER_ID_FILL)) {
+          return hits
+        }
+        const r = PARCEL_CLICK_TOLERANCE_PX
+        return this.map.queryRenderedFeatures(
+          [
+            [point.x - r, point.y - r],
+            [point.x + r, point.y + r]
+          ],
+          { layers: [LAYER_ID_FILL] }
+        )
+      }
+    }
+    return { ...result, MapProvider: ParcelHitToleranceProvider }
+  }
+  return descriptor
 }
 
 /** @returns {HTMLDivElement} */

--- a/src/client/javascripts/parcel-map/index.js
+++ b/src/client/javascripts/parcel-map/index.js
@@ -9,32 +9,29 @@ import createInteractPlugin from '@defra/interactive-map/plugins/interact'
 // (marked "metrics:" below) along with basemap-metrics.js.
 import { trackBasemapMetrics } from './basemap-metrics.js'
 import {
+  COMPOUND_ID_EXPR,
+  buildParcelLayers,
+  getMapStyle,
+  withParcelHitTolerance,
+  buildSkeleton,
+  buildColorExpr,
+  resolveFeatureId,
+  showTooltip,
+  hideTooltip
+} from './map-helpers.js'
+import {
   PARCELS_API_URL,
   PARCEL_TILES_URL,
   PARCELS_GEOJSON_URL,
   MAP_LABEL,
-  MAP_STYLE_URL,
-  getMapStyleAttribution,
   BASEMAP_PROVIDER_ATTRIBUTE,
   DEFAULT_BASEMAP_PROVIDER,
   // TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up) — see config.js
-  OSM_STYLE_URL,
-  OSM_STYLE_ATTRIBUTION,
   BASEMAP_PROVIDER_OPENSTREETMAP,
-  PARCEL_COLORS,
-  LAYER_TEXT_SIZE,
-  LAYER_TEXT_HALO_WIDTH,
-  LAYER_LINE_WIDTH,
-  FIT_BOUNDS_PADDING,
-  AREA_DECIMAL_PLACES,
-  TOOLTIP_STYLES,
   PARCEL_ID_PROPERTY,
-  PARCEL_CLICK_TOLERANCE_PX,
   LAYER_ID_FILL,
-  LAYER_ID_OUTLINE,
-  LAYER_ID_LABEL,
-  FILL_OPACITY_DEFAULT,
-  FILL_OPACITY_SELECTED,
+  FIT_BOUNDS_PADDING,
+  TOOLTIP_STYLES,
   MAP_DEFAULT_HEIGHT,
   MAP_DEFAULT_CENTER,
   MAP_DEFAULT_ZOOM,
@@ -42,9 +39,6 @@ import {
   MAP_LOAD_TIMEOUT_MS,
   FETCH_MAX_ATTEMPTS,
   FETCH_RETRY_DELAY_MS,
-  TOOLTIP_OFFSET_X,
-  TOOLTIP_MAX_WIDTH,
-  TOOLTIP_FALLBACK_MAP_WIDTH,
   EVENT_READY,
   EVENT_ERROR,
   EVENT_SELECTION,
@@ -55,91 +49,23 @@ import {
   MULTI_SELECT_ATTRIBUTE,
   ERROR_OVERLAY_STYLES,
   ERROR_LABEL_STYLES,
-  LABEL_TEXT_COLOR,
-  LABEL_HALO_COLOR,
+  FILL_OPACITY_DEFAULT,
+  FILL_OPACITY_SELECTED,
   SELECTION_NONE_SENTINEL,
-  MSG_LOADING,
-  MSG_ERROR_UNAVAILABLE,
-  MSG_UNKNOWN_PARCEL,
-  MSG_UNKNOWN_AREA,
-  TOOLTIP_VERTICAL_OFFSET
+  MSG_ERROR_UNAVAILABLE
 } from './config.js'
 
 /**
- * @import { Map as MLMap, MapGeoJSONFeature } from 'maplibre-gl'
+ * @import { Map as MLMap } from 'maplibre-gl'
+ * @import { ParcelProperties, MetaIndex } from './map-helpers.js'
  */
 
 /**
- * @typedef {{ sheet_id?: unknown, parcel_id?: unknown, areaHa?: unknown, [key: string]: unknown }} ParcelProperties
- * @typedef {{ id: string } & ParcelProperties} ParcelMeta
- * @typedef {Record<string, ParcelMeta>} MetaIndex
  * @typedef {{ parcelIds: string[], metaIndex: MetaIndex, geojsonUrl: string | null, bbox: BBox | null }} ParcelData
  * @typedef {{ minLng: number, minLat: number, maxLng: number, maxLat: number }} BBox
  */
 
-// Same PARCEL_ID_PROPERTY the interact plugin matches on, so label/colour/
-// highlight logic can't disagree with what's selected.
-const COMPOUND_ID_EXPR = ['get', PARCEL_ID_PROPERTY]
-
-/**
- * @param {unknown[]} colorExpr  MapLibre `match` expression
- * @param {string}   [sourceLayer]
- * @param {string}   [basemapProvider]  BASEMAP_PROVIDER_ORDNANCE_SURVEY | BASEMAP_PROVIDER_OPENSTREETMAP
- */
-function buildParcelLayers(colorExpr, sourceLayer, basemapProvider) {
-  const src = sourceLayer ? { 'source-layer': sourceLayer } : {}
-  // OS Maps sets no `glyphs` URL, so any font renders locally via MapLibre's
-  // TinySDF fallback. TEMPORARY (TGC-1418 follow-up): CartoCDN's OpenStreetMap
-  // style DOES set a glyphs URL, and only serves the fonts it declares in its
-  // own layers ('Open Sans Regular' etc) — 'Arial Regular' 404s against it.
-  // Delete this branch (keep 'Arial Regular') once OSM support is removed.
-  const labelFont = basemapProvider === BASEMAP_PROVIDER_OPENSTREETMAP ? 'Open Sans Regular' : 'Arial Regular'
-  return {
-    fill: {
-      id: LAYER_ID_FILL,
-      type: 'fill',
-      source: 'parcels',
-      ...src,
-      paint: {
-        'fill-color': colorExpr,
-        'fill-opacity': FILL_OPACITY_DEFAULT
-      }
-    },
-    outline: {
-      id: LAYER_ID_OUTLINE,
-      type: 'line',
-      source: 'parcels',
-      ...src,
-      paint: {
-        'line-color': colorExpr,
-        'line-width': LAYER_LINE_WIDTH
-      }
-    },
-    label: {
-      id: LAYER_ID_LABEL,
-      type: 'symbol',
-      source: 'parcels',
-      ...src,
-      layout: {
-        'text-field': COMPOUND_ID_EXPR,
-        'text-font': [labelFont],
-        'text-size': LAYER_TEXT_SIZE,
-        'text-anchor': 'center'
-      },
-      paint: {
-        'text-color': LABEL_TEXT_COLOR,
-        'text-halo-color': LABEL_HALO_COLOR,
-        'text-halo-width': LAYER_TEXT_HALO_WIDTH
-      }
-    }
-  }
-}
-
 // <parcel-map multi-select="true|false" basemap-provider="ordnance-survey|openstreetmap" basemap-metrics="true|false">
-// basemap-provider's "openstreetmap" value and basemap-metrics are both
-// TEMPORARY (TGC-1418 follow-up).
-// Height via CSS on the element. Dispatches:
-//   parcel-map:ready, parcel-map:error, parcel-map:selection → { selectedIds: string[] }
 class ParcelMap extends HTMLElement {
   /** @type {typeof STATE_IDLE | typeof STATE_LOADING | typeof STATE_READY | typeof STATE_ERROR} */
   #state = STATE_IDLE
@@ -314,13 +240,7 @@ class ParcelMap extends HTMLElement {
         plugins: [interactPlugin],
         center: MAP_DEFAULT_CENTER,
         zoom: MAP_DEFAULT_ZOOM,
-        // The OS raster basemap has no tiles below z7 — stop users zooming
-        // out into blank void.
-        // TEMPORARY (TGC-1418 follow-up): the OSM/CartoCDN vector style
-        // covers the full zoom range, so it's exempted from the cap below.
-        // When OSM is removed, replace this with a plain `MAP_MIN_ZOOM`.
         minZoom: basemapProvider === BASEMAP_PROVIDER_OPENSTREETMAP ? undefined : MAP_MIN_ZOOM,
-        // Don't persist the viewport in URL params.
         urlPosition: 'none'
       })
       this.#mapInstance = map
@@ -345,9 +265,7 @@ class ParcelMap extends HTMLElement {
           globalThis.clearTimeout(timeout)
           resolve(null)
         })
-        // metrics: TEMPORARY (TGC-1418 follow-up) — see basemap-metrics.js.
-        // Only runs when the page opts in via basemap-metrics="true", so
-        // journeys that don't show the comparison toggle pay no extra cost.
+
         if (this.getAttribute('basemap-metrics') === 'true') {
           this.#mlCleanup.push(trackBasemapMetrics(m, basemapProvider, this))
         }
@@ -541,184 +459,6 @@ class ParcelMap extends HTMLElement {
       }
     )
   }
-}
-
-/**
- * Resolves the MapLibre style URL/attribution for the chosen basemap provider.
- * TEMPORARY (TGC-1418 follow-up): delete the ternary + provider param once
- * the OpenStreetMap comparison ends.
- * @param {string} provider  BASEMAP_PROVIDER_ORDNANCE_SURVEY | BASEMAP_PROVIDER_OPENSTREETMAP
- * @returns {{ url: string, attribution: string }}
- */
-function getMapStyle(provider) {
-  // OSM's style/tiles are public (no key to protect), so its URL points
-  // straight at CartoCDN; OS Maps stays server-proxied.
-  return provider === BASEMAP_PROVIDER_OPENSTREETMAP
-    ? { url: OSM_STYLE_URL, attribution: OSM_STYLE_ATTRIBUTION }
-    : { url: MAP_STYLE_URL, attribution: getMapStyleAttribution() }
-}
-
-/**
- * Falls back to the nearest rendered parcel within PARCEL_CLICK_TOLERANCE_PX
- * when the interact plugin's strict inside-the-shape hit test finds nothing —
- * which is common for small parcels at low zoom.
- *
- * Wrapped via `load()` because the map library hands us a provider
- * *descriptor*, not the provider itself — the real class only exists once
- * `load()` resolves.
- * @param {{ load: () => Promise<{ MapProvider: new (...args: never[]) => { map?: import('maplibre-gl').Map } }> }} descriptor
- */
-function withParcelHitTolerance(descriptor) {
-  const originalLoad = descriptor.load
-  descriptor.load = async () => {
-    const result = await originalLoad()
-    class ParcelHitToleranceProvider extends result.MapProvider {
-      /**
-       * @param {{ x: number, y: number }} point
-       * @param {{ radius?: number }} [options]
-       */
-      getFeaturesAtPoint(point, options) {
-        // @ts-ignore — base method exists on the runtime provider
-        const hits = super.getFeaturesAtPoint(point, options)
-        if (hits.length > 0 || !this.map?.getLayer(LAYER_ID_FILL)) {
-          return hits
-        }
-        const r = PARCEL_CLICK_TOLERANCE_PX
-        const rendered = this.map.queryRenderedFeatures(
-          [
-            [point.x - r, point.y - r],
-            [point.x + r, point.y + r]
-          ],
-          { layers: [LAYER_ID_FILL] }
-        )
-        return nearestFeatureToPoint(this.map, point, rendered)
-      }
-    }
-    return { ...result, MapProvider: ParcelHitToleranceProvider }
-  }
-  return descriptor
-}
-
-/**
- * Picks the rendered feature whose on-screen bounding-box centre is closest
- * to the click point. Used when two or more adjacent parcels both land in
- * the tolerance box — without this, `queryRenderedFeatures` order (not
- * proximity) would decide which one gets selected.
- * @param {import('maplibre-gl').Map} map
- * @param {{ x: number, y: number }} point
- * @param {import('maplibre-gl').MapGeoJSONFeature[]} features
- * @returns {import('maplibre-gl').MapGeoJSONFeature[]}
- */
-function nearestFeatureToPoint(map, point, features) {
-  if (features.length <= 1) {
-    return features
-  }
-  const distSq = (/** @type {import('maplibre-gl').MapGeoJSONFeature} */ f) => {
-    const box = f.geometry.type.includes('Polygon') ? getScreenBounds(map, f) : null
-    if (!box) {
-      return Infinity
-    }
-    const cx = (box.minX + box.maxX) / 2
-    const cy = (box.minY + box.maxY) / 2
-    return (point.x - cx) ** 2 + (point.y - cy) ** 2
-  }
-  return [[...features].sort((a, b) => distSq(a) - distSq(b))[0]]
-}
-
-/**
- * On-screen pixel bounding box of a polygon/multipolygon feature.
- * @param {import('maplibre-gl').Map} map
- * @param {import('maplibre-gl').MapGeoJSONFeature} feature
- */
-function getScreenBounds(map, feature) {
-  const geometry = /** @type {import('geojson').Polygon | import('geojson').MultiPolygon} */ (feature.geometry)
-  const { type, coordinates } = geometry
-  const rings = type === 'Polygon' ? coordinates : coordinates.flat()
-  let minX = Infinity
-  let minY = Infinity
-  let maxX = -Infinity
-  let maxY = -Infinity
-  for (const ring of rings) {
-    for (const [lng, lat] of ring) {
-      const { x, y } = map.project([lng, lat])
-      minX = Math.min(minX, x)
-      minY = Math.min(minY, y)
-      maxX = Math.max(maxX, x)
-      maxY = Math.max(maxY, y)
-    }
-  }
-  return minX === Infinity ? null : { minX, minY, maxX, maxY }
-}
-
-/** @returns {HTMLDivElement} */
-function buildSkeleton() {
-  const el = /** @type {HTMLDivElement} */ (document.createElement('div'))
-  el.setAttribute('aria-label', MSG_LOADING)
-  el.setAttribute('role', 'status')
-  el.style.cssText = ERROR_OVERLAY_STYLES
-  const label = document.createElement('span')
-  label.style.cssText = ERROR_LABEL_STYLES
-  label.textContent = MSG_LOADING
-  el.appendChild(label)
-  return el
-}
-
-/**
- * MapLibre `match` expression mapping compound parcel ID → colour.
- * @param {string[]} ids
- * @returns {unknown[]}
- */
-function buildColorExpr(ids) {
-  const expr = /** @type {unknown[]} */ (['match', COMPOUND_ID_EXPR])
-  ;[...new Set(ids)].forEach((id, i) => {
-    expr.push(id, PARCEL_COLORS[i % PARCEL_COLORS.length])
-  })
-  expr.push(PARCEL_COLORS[0])
-  return expr
-}
-
-/**
- * Compound parcel ID (e.g. "SD7148-9160") from a feature's PARCEL_ID_PROPERTY.
- * @param {MapGeoJSONFeature} feature
- * @returns {string}
- */
-function resolveFeatureId(feature) {
-  const id = /** @type {ParcelProperties | undefined} */ (feature.properties)?.[PARCEL_ID_PROPERTY]
-  return typeof id === 'string' || typeof id === 'number' ? String(id) : ''
-}
-
-/**
- * @param {HTMLElement} tooltip
- * @param {string} id
- * @param {ParcelProperties} props
- * @param {number} x
- * @param {number} y
- * @param {HTMLDivElement | null} mapEl
- */
-function showTooltip(tooltip, id, props, x, y, mapEl) {
-  const areaHa = props.areaHa == null ? null : Number(props.areaHa)
-  tooltip.innerHTML = `
-    <strong style="display:block;margin-bottom:8px;font-size:15px">${htmlEncode(id || MSG_UNKNOWN_PARCEL)}</strong>
-    <table style="border-collapse:collapse;width:100%">
-      <tr><td style="color:#505a5f;padding:2px 12px 2px 0;white-space:nowrap">Total area</td>
-          <td>${areaHa == null ? MSG_UNKNOWN_AREA : htmlEncode(areaHa.toFixed(AREA_DECIMAL_PLACES) + ' ha')}</td></tr>
-    </table>`
-  tooltip.style.left = `${Math.min(x + TOOLTIP_OFFSET_X, (mapEl?.offsetWidth ?? TOOLTIP_FALLBACK_MAP_WIDTH) - TOOLTIP_MAX_WIDTH)}px`
-  tooltip.style.top = `${y - TOOLTIP_VERTICAL_OFFSET}px`
-  tooltip.style.display = 'block'
-}
-
-/** @param {HTMLElement} tooltip */
-function hideTooltip(tooltip) {
-  tooltip.style.display = 'none'
-}
-
-/** @param {string} value @returns {string} */
-function htmlEncode(value) {
-  const text = document.createTextNode(value)
-  const div = document.createElement('div')
-  div.appendChild(text)
-  return div.innerHTML
 }
 
 if (!customElements.get('parcel-map')) {

--- a/src/client/javascripts/parcel-map/index.js
+++ b/src/client/javascripts/parcel-map/index.js
@@ -90,6 +90,12 @@ class ParcelMap extends HTMLElement {
 
   #connected = false
 
+  // Set when basemap-provider changes while a load is already in flight —
+  // the in-flight #init() already captured the old value in a local const,
+  // so it can't pick up the new one itself. #init() checks this once it
+  // settles and restarts itself if needed.
+  #pendingReinit = false
+
   static get observedAttributes() {
     return [BASEMAP_PROVIDER_ATTRIBUTE]
   }
@@ -106,10 +112,12 @@ class ParcelMap extends HTMLElement {
   }
 
   attributeChangedCallback(name) {
-    // Ignore the attribute's own initial set before the element is connected,
-    // and any change while a load is already in flight (that in-flight load
-    // will pick up the new value once it settles into an idle/error state).
-    if (name !== BASEMAP_PROVIDER_ATTRIBUTE || !this.#connected || this.#state === STATE_LOADING) {
+    // Ignore the attribute's own initial set before the element is connected.
+    if (name !== BASEMAP_PROVIDER_ATTRIBUTE || !this.#connected) {
+      return
+    }
+    if (this.#state === STATE_LOADING) {
+      this.#pendingReinit = true
       return
     }
     this.#teardown()
@@ -177,6 +185,16 @@ class ParcelMap extends HTMLElement {
       this.#skeleton = null
 
       this.dispatchEvent(new CustomEvent(EVENT_READY, { bubbles: true }))
+    }
+
+    // basemap-provider changed while the load above was in flight — restart
+    // now that we've settled, so the map ends up on the current attribute
+    // value instead of the one captured at the top of this #init() call.
+    if (this.#pendingReinit) {
+      this.#pendingReinit = false
+      this.#teardown()
+      this.#state = STATE_IDLE
+      this.#init()
     }
   }
 

--- a/src/client/javascripts/parcel-map/index.js
+++ b/src/client/javascripts/parcel-map/index.js
@@ -67,6 +67,13 @@ import {
  * @typedef {{ minLng: number, minLat: number, maxLng: number, maxLat: number }} BBox
  */
 
+// MapLibre expression reading the compound "SHEET-PARCEL" ID. This is the
+// same `id` property the interact plugin matches selections against
+// (PARCEL_ID_PROPERTY) — reading it here too means the component's label,
+// colour, and highlight logic can never disagree with what the plugin
+// selected.
+const COMPOUND_ID_EXPR = ['get', PARCEL_ID_PROPERTY]
+
 /**
  * @param {unknown[]} colorExpr  MapLibre `match` expression
  * @param {string}   [sourceLayer]
@@ -100,7 +107,7 @@ function buildParcelLayers(colorExpr, sourceLayer) {
       source: 'parcels',
       ...src,
       layout: {
-        'text-field': ['concat', ['get', 'sheet_id'], '-', ['get', 'parcel_id']],
+        'text-field': COMPOUND_ID_EXPR,
         'text-font': ['Arial Regular'],
         'text-size': LAYER_TEXT_SIZE,
         'text-anchor': 'center'
@@ -198,7 +205,7 @@ class ParcelMap extends HTMLElement {
       const colorExpr = buildColorExpr(data.parcelIds)
       this.#addParcelsToMap(ml, data, colorExpr)
       const tooltip = this.#attachTooltip(ml, data.metaIndex)
-      this.#attachSelectionBridge(ml, tooltip)
+      this.#attachSelectionRelay(ml, tooltip)
       this.#interactPlugin?.enable()
 
       this.#state = STATE_READY
@@ -460,15 +467,13 @@ class ParcelMap extends HTMLElement {
    * @param {MLMap} ml
    * @param {HTMLElement | undefined} tooltip
    */
-  #attachSelectionBridge(ml, tooltip) {
-    const idExpr = ['concat', ['get', 'sheet_id'], '-', ['get', 'parcel_id']]
-
+  #attachSelectionRelay(ml, tooltip) {
     /** @param {string[]} selectedIds */
     const applyHighlight = (selectedIds) => {
       const matchList = selectedIds.length > 0 ? selectedIds : [SELECTION_NONE_SENTINEL]
       ml.setPaintProperty(LAYER_ID_FILL, 'fill-opacity', [
         'match',
-        idExpr,
+        COMPOUND_ID_EXPR,
         matchList,
         FILL_OPACITY_SELECTED,
         FILL_OPACITY_DEFAULT
@@ -492,22 +497,19 @@ class ParcelMap extends HTMLElement {
 /**
  * Makes parcels easier to click when they're small on screen.
  *
- * The problem: when the interact plugin decides "did this click land on a
- * parcel?", it checks whether the clicked point is mathematically inside the
- * parcel's polygon. That's fine zoomed in, when a parcel fills half the
- * screen. But zoomed out, a parcel might be 4-5 pixels wide — you'd have to
- * click exactly inside those few pixels, so selection feels broken.
+ * The interact plugin already searches a PARCEL_CLICK_TOLERANCE_PX box around
+ * the click, but for polygons it only counts a hit if the click lands exactly
+ * inside the shape — near-misses are dropped. That's nearly guaranteed for a
+ * parcel that's only a few pixels wide when zoomed out. When the strict check
+ * finds nothing, this falls back to whatever parcel is *drawn* closest to the
+ * click within that same box. Adjacent (not overlapping) small parcels can
+ * both land in that box at low zoom, so this picks whichever one is nearest
+ * to the click rather than an arbitrary one. Covers both mouse clicks and the
+ * keyboard crosshair, at any zoom.
  *
- * The fix: if the plugin's strict check finds nothing, we ask MapLibre a more
- * forgiving question instead — "is there a parcel *drawn on screen* within
- * 10px of where the user clicked?" (PARCEL_CLICK_TOLERANCE_PX). If yes, we
- * return that parcel, and the click selects it. This applies to mouse clicks
- * and to the keyboard crosshair alike, at every zoom level.
- *
- * The wrapping is awkward because of how the map library is built: we don't
- * get the provider object directly — we get a *descriptor* whose `load()` the
- * library calls later to create the provider. So we intercept `load()` and
- * hand back a subclass whose `getFeaturesAtPoint` adds our fallback.
+ * The odd wrapping is because the map library hands us a *descriptor*, not
+ * the provider itself — its `load()` creates the provider later — so we
+ * intercept `load()` to subclass the provider once it exists.
  * @param {{ load: () => Promise<{ MapProvider: new (...args: never[]) => { map?: import('maplibre-gl').Map } }> }} descriptor
  */
 function withParcelHitTolerance(descriptor) {
@@ -526,18 +528,70 @@ function withParcelHitTolerance(descriptor) {
           return hits
         }
         const r = PARCEL_CLICK_TOLERANCE_PX
-        return this.map.queryRenderedFeatures(
+        const rendered = this.map.queryRenderedFeatures(
           [
             [point.x - r, point.y - r],
             [point.x + r, point.y + r]
           ],
           { layers: [LAYER_ID_FILL] }
         )
+        return nearestFeatureToPoint(this.map, point, rendered)
       }
     }
     return { ...result, MapProvider: ParcelHitToleranceProvider }
   }
   return descriptor
+}
+
+/**
+ * Picks the rendered feature whose on-screen bounding-box centre is closest
+ * to the click point. Used when two or more adjacent parcels both land in
+ * the tolerance box — without this, `queryRenderedFeatures` order (not
+ * proximity) would decide which one gets selected.
+ * @param {import('maplibre-gl').Map} map
+ * @param {{ x: number, y: number }} point
+ * @param {import('maplibre-gl').MapGeoJSONFeature[]} features
+ * @returns {import('maplibre-gl').MapGeoJSONFeature[]}
+ */
+function nearestFeatureToPoint(map, point, features) {
+  if (features.length <= 1) {
+    return features
+  }
+  const distSq = (/** @type {import('maplibre-gl').MapGeoJSONFeature} */ f) => {
+    const box = f.geometry.type.includes('Polygon') ? getScreenBounds(map, f) : null
+    if (!box) {
+      return Infinity
+    }
+    const cx = (box.minX + box.maxX) / 2
+    const cy = (box.minY + box.maxY) / 2
+    return (point.x - cx) ** 2 + (point.y - cy) ** 2
+  }
+  return [[...features].sort((a, b) => distSq(a) - distSq(b))[0]]
+}
+
+/**
+ * On-screen pixel bounding box of a polygon/multipolygon feature.
+ * @param {import('maplibre-gl').Map} map
+ * @param {import('maplibre-gl').MapGeoJSONFeature} feature
+ */
+function getScreenBounds(map, feature) {
+  const geometry = /** @type {import('geojson').Polygon | import('geojson').MultiPolygon} */ (feature.geometry)
+  const { type, coordinates } = geometry
+  const rings = type === 'Polygon' ? coordinates : coordinates.flat()
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const ring of rings) {
+    for (const [lng, lat] of ring) {
+      const { x, y } = map.project([lng, lat])
+      minX = Math.min(minX, x)
+      minY = Math.min(minY, y)
+      maxX = Math.max(maxX, x)
+      maxY = Math.max(maxY, y)
+    }
+  }
+  return minX === Infinity ? null : { minX, minY, maxX, maxY }
 }
 
 /** @returns {HTMLDivElement} */
@@ -559,7 +613,7 @@ function buildSkeleton() {
  * @returns {unknown[]}
  */
 function buildColorExpr(ids) {
-  const expr = /** @type {unknown[]} */ (['match', ['concat', ['get', 'sheet_id'], '-', ['get', 'parcel_id']]])
+  const expr = /** @type {unknown[]} */ (['match', COMPOUND_ID_EXPR])
   ;[...new Set(ids)].forEach((id, i) => {
     expr.push(id, PARCEL_COLORS[i % PARCEL_COLORS.length])
   })
@@ -568,15 +622,15 @@ function buildColorExpr(ids) {
 }
 
 /**
- * Derive the compound parcel ID (e.g. "SD7148-9160") from a MapLibre vector tile feature.
+ * Read the compound parcel ID (e.g. "SD7148-9160") off a MapLibre feature's
+ * `id` property — the same property the interact plugin matches selections
+ * against (PARCEL_ID_PROPERTY).
  * @param {MapGeoJSONFeature} feature
  * @returns {string}
  */
 function resolveFeatureId(feature) {
-  const p = /** @type {ParcelProperties} */ (feature.properties ?? {})
-  const sheet = typeof p.sheet_id === 'string' || typeof p.sheet_id === 'number' ? String(p.sheet_id) : ''
-  const parcel = typeof p.parcel_id === 'string' || typeof p.parcel_id === 'number' ? String(p.parcel_id) : ''
-  return sheet && parcel ? `${sheet}-${parcel}` : ''
+  const id = /** @type {ParcelProperties} */ (feature.properties ?? {})[PARCEL_ID_PROPERTY]
+  return typeof id === 'string' || typeof id === 'number' ? String(id) : ''
 }
 
 /**

--- a/src/client/javascripts/parcel-map/index.js
+++ b/src/client/javascripts/parcel-map/index.js
@@ -15,6 +15,7 @@ import {
   MAP_LABEL,
   MAP_STYLE_URL,
   getMapStyleAttribution,
+  BASEMAP_PROVIDER_ATTRIBUTE,
   DEFAULT_BASEMAP_PROVIDER,
   // TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up) — see config.js
   OSM_STYLE_URL,
@@ -51,6 +52,7 @@ import {
   STATE_LOADING,
   STATE_READY,
   STATE_ERROR,
+  MULTI_SELECT_ATTRIBUTE,
   ERROR_OVERLAY_STYLES,
   ERROR_LABEL_STYLES,
   LABEL_TEXT_COLOR,
@@ -163,7 +165,7 @@ class ParcelMap extends HTMLElement {
   #connected = false
 
   static get observedAttributes() {
-    return ['basemap-provider']
+    return [BASEMAP_PROVIDER_ATTRIBUTE]
   }
 
   connectedCallback() {
@@ -181,7 +183,7 @@ class ParcelMap extends HTMLElement {
     // Ignore the attribute's own initial set before the element is connected,
     // and any change while a load is already in flight (that in-flight load
     // will pick up the new value once it settles into an idle/error state).
-    if (name !== 'basemap-provider' || !this.#connected || this.#state === STATE_LOADING) {
+    if (name !== BASEMAP_PROVIDER_ATTRIBUTE || !this.#connected || this.#state === STATE_LOADING) {
       return
     }
     this.#teardown()
@@ -215,8 +217,8 @@ class ParcelMap extends HTMLElement {
 
     // Read once per init — basemap-provider changes trigger a fresh #init via
     // attributeChangedCallback, so this always reflects the current value.
-    const multiSelect = this.getAttribute('multi-select') === 'true'
-    const basemapProvider = this.getAttribute('basemap-provider') || DEFAULT_BASEMAP_PROVIDER
+    const multiSelect = this.getAttribute(MULTI_SELECT_ATTRIBUTE) === 'true'
+    const basemapProvider = this.getAttribute(BASEMAP_PROVIDER_ATTRIBUTE) || DEFAULT_BASEMAP_PROVIDER
 
     this.#skeleton = buildSkeleton()
     this.appendChild(this.#skeleton)

--- a/src/client/javascripts/parcel-map/index.test.js
+++ b/src/client/javascripts/parcel-map/index.test.js
@@ -285,6 +285,15 @@ describe('parcel-map web component', () => {
         // No mountElement/appendChild here — attributeChangedCallback should no-op
         expect(InteractiveMap.mock.calls.length).toBe(callsBefore)
       })
+
+      it('uses a label font the CartoCDN style actually serves glyphs for', async () => {
+        global.fetch = fetchOk(PARCELS_RESPONSE)
+        const el = await mountElement({ 'basemap-provider': 'openstreetmap' })
+        await waitForEvent(el, EVENT_READY)
+
+        const labelLayer = ml.addLayer.mock.calls.map((c) => c[0]).find((l) => l.id === LAYER_ID_LABEL)
+        expect(labelLayer.layout['text-font']).not.toEqual(['Arial Regular'])
+      })
     })
   })
 

--- a/src/client/javascripts/parcel-map/index.test.js
+++ b/src/client/javascripts/parcel-map/index.test.js
@@ -294,6 +294,33 @@ describe('parcel-map web component', () => {
         const labelLayer = ml.addLayer.mock.calls.map((c) => c[0]).find((l) => l.id === LAYER_ID_LABEL)
         expect(labelLayer.layout['text-font']).not.toEqual(['Arial Regular'])
       })
+
+      it('dispatches parcel-map:basemap-metrics when basemap-metrics="true"', async () => {
+        global.fetch = fetchOk(PARCELS_RESPONSE)
+        const el = await mountElement({ 'basemap-metrics': 'true' })
+        await waitForEvent(el, EVENT_READY)
+
+        const metricsEvent = new Promise((resolve) =>
+          el.addEventListener('parcel-map:basemap-metrics', resolve, { once: true })
+        )
+        ml._emit('idle')
+        const e = await metricsEvent
+        expect(e.detail.loadMs).toEqual(expect.any(Number))
+      })
+
+      it('does not track metrics when basemap-metrics is absent', async () => {
+        global.fetch = fetchOk(PARCELS_RESPONSE)
+        const el = await mountElement()
+        await waitForEvent(el, EVENT_READY)
+
+        let fired = false
+        el.addEventListener('parcel-map:basemap-metrics', () => {
+          fired = true
+        })
+        ml._emit('idle')
+        await Promise.resolve()
+        expect(fired).toBe(false)
+      })
     })
   })
 

--- a/src/client/javascripts/parcel-map/index.test.js
+++ b/src/client/javascripts/parcel-map/index.test.js
@@ -182,6 +182,15 @@ describe('parcel-map web component', () => {
       const [, options] = InteractiveMap.mock.calls[0]
       expect(options.minZoom).toBe(7)
     })
+
+    it('sets an accessible mapLabel for screen readers', async () => {
+      global.fetch = fetchOk(PARCELS_RESPONSE)
+      const el = await mountElement()
+      await waitForEvent(el, EVENT_READY)
+
+      const [, options] = InteractiveMap.mock.calls[0]
+      expect(options.mapLabel).toEqual(expect.stringContaining('land parcels'))
+    })
   })
 
   describe('data fetching', () => {

--- a/src/client/javascripts/parcel-map/index.test.js
+++ b/src/client/javascripts/parcel-map/index.test.js
@@ -66,7 +66,7 @@ function makeMlMap(overrides = {}) {
 function makeFeature(sheetId, parcelId, numericId) {
   return {
     id: numericId ?? 1,
-    properties: { sheet_id: sheetId, parcel_id: parcelId },
+    properties: { sheet_id: sheetId, parcel_id: parcelId, id: `${sheetId}-${parcelId}` },
     geometry: { type: 'Point', coordinates: [0, 0] }
   }
 }
@@ -324,6 +324,39 @@ describe('parcel-map web component', () => {
         { layers: [LAYER_ID_FILL] }
       )
       expect(hits).toBe(fallbackFeatures)
+    })
+
+    it('picks the closest feature when the fallback finds several overlapping the tolerance box', async () => {
+      global.fetch = fetchOk(PARCELS_RESPONSE)
+      const el = await mountElement()
+      await waitForEvent(el, EVENT_READY)
+
+      const [, options] = InteractiveMap.mock.calls.at(-1)
+      const { MapProvider } = await options.mapProvider.load()
+      const provider = new MapProvider()
+
+      // Both are single-point "polygons" (only the corner matters for the
+      // bounding-box centre this test exercises) — `near` projects to a
+      // screen point right at the click, `far` projects well outside it.
+      const near = {
+        layer: { id: LAYER_ID_FILL },
+        properties: { id: 'SD7148-9160' },
+        geometry: { type: 'Polygon', coordinates: [[[0, 0]]] }
+      }
+      const far = {
+        layer: { id: LAYER_ID_FILL },
+        properties: { id: 'SD7148-9161' },
+        geometry: { type: 'Polygon', coordinates: [[[1, 1]]] }
+      }
+      provider.map = {
+        getLayer: vi.fn().mockReturnValue(true),
+        queryRenderedFeatures: vi.fn().mockReturnValue([far, near]),
+        project: vi.fn(([lng]) => (lng === 0 ? { x: 50, y: 60 } : { x: 500, y: 500 }))
+      }
+
+      const hits = provider.getFeaturesAtPoint({ x: 50, y: 60 }, { radius: 10 })
+
+      expect(hits).toEqual([near])
     })
 
     it('does not run the fallback when the strict query already has hits', async () => {

--- a/src/client/javascripts/parcel-map/index.test.js
+++ b/src/client/javascripts/parcel-map/index.test.js
@@ -172,7 +172,7 @@ describe('parcel-map web component', () => {
       await waitForEvent(el, EVENT_ERROR)
 
       expect(el.querySelector('[role="status"]')).toBeNull()
-      expect(el.querySelectorAll('div').length).toBeLessThanOrEqual(1) 
+      expect(el.querySelectorAll('div').length).toBeLessThanOrEqual(1)
     })
 
     it('removes skeleton once ready', async () => {

--- a/src/client/javascripts/parcel-map/index.test.js
+++ b/src/client/javascripts/parcel-map/index.test.js
@@ -2,8 +2,22 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 
 vi.mock('@defra/interactive-map', () => ({ default: vi.fn() }))
-vi.mock('@defra/interactive-map/providers/maplibre', () => ({ default: vi.fn(() => ({})) }))
+vi.mock('@defra/interactive-map/providers/maplibre', () => ({
+  default: vi.fn(() => ({
+    load: async () => ({
+      MapProvider: class {
+        getFeaturesAtPoint() {
+          return []
+        }
+      }
+    })
+  }))
+}))
+vi.mock('@defra/interactive-map/plugins/interact', () => ({
+  default: vi.fn(() => ({ enable: vi.fn(), disable: vi.fn(), clear: vi.fn() }))
+}))
 import InteractiveMap from '@defra/interactive-map'
+import createInteractPlugin from '@defra/interactive-map/plugins/interact'
 import { LAYER_ID_FILL, LAYER_ID_OUTLINE, LAYER_ID_LABEL, EVENT_READY, EVENT_ERROR, EVENT_SELECTION } from './config.js'
 
 const PARCELS_RESPONSE = {
@@ -81,6 +95,20 @@ function fetchOk(body) {
 
 function waitForEvent(el, eventName) {
   return new Promise((resolve) => el.addEventListener(eventName, resolve, { once: true }))
+}
+
+// Latest InteractiveMap mock instance — used to emit plugin events (e.g.
+// interact:selectionchange) the way the real event bus would.
+function lastMapInstance() {
+  return InteractiveMap.mock.instances.at(-1)
+}
+
+function emitSelectionChange(selectedFeatures) {
+  lastMapInstance()._emit('interact:selectionchange', {
+    selectedFeatures,
+    selectedMarkers: [],
+    contiguous: false
+  })
 }
 
 async function mountElement(attrs = {}) {
@@ -256,124 +284,170 @@ describe('parcel-map web component', () => {
     })
   })
 
-  describe('selection — single-select (default)', () => {
-    it('dispatches parcel-map:selection with clicked parcel ID', async () => {
+  describe('interact plugin configuration', () => {
+    it('creates the plugin for feature selection on the fill layer with compound id property', async () => {
+      global.fetch = fetchOk(PARCELS_RESPONSE)
+      const el = await mountElement()
+      await waitForEvent(el, EVENT_READY)
+
+      expect(createInteractPlugin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          interactionModes: ['selectFeature'],
+          multiSelect: false,
+          deselectOnClickOutside: true,
+          layers: [expect.objectContaining({ layerId: LAYER_ID_FILL, idProperty: 'id', labelProperty: 'id' })]
+        })
+      )
+    })
+
+    it('falls back to a rendered-pixel radius query when the strict provider query misses', async () => {
+      global.fetch = fetchOk(PARCELS_RESPONSE)
+      const el = await mountElement()
+      await waitForEvent(el, EVENT_READY)
+
+      const [, options] = InteractiveMap.mock.calls.at(-1)
+      const { MapProvider } = await options.mapProvider.load()
+      const provider = new MapProvider()
+      const fallbackFeatures = [{ layer: { id: LAYER_ID_FILL }, properties: { id: 'SD7148-9160' } }]
+      provider.map = {
+        getLayer: vi.fn().mockReturnValue(true),
+        queryRenderedFeatures: vi.fn().mockReturnValue(fallbackFeatures)
+      }
+
+      const hits = provider.getFeaturesAtPoint({ x: 50, y: 60 }, { radius: 10 })
+
+      expect(provider.map.queryRenderedFeatures).toHaveBeenCalledWith(
+        [
+          [40, 50],
+          [60, 70]
+        ],
+        { layers: [LAYER_ID_FILL] }
+      )
+      expect(hits).toBe(fallbackFeatures)
+    })
+
+    it('does not run the fallback when the strict query already has hits', async () => {
+      global.fetch = fetchOk(PARCELS_RESPONSE)
+      const el = await mountElement()
+      await waitForEvent(el, EVENT_READY)
+
+      const [, options] = InteractiveMap.mock.calls.at(-1)
+      const loaded = await options.mapProvider.load()
+      const strictHits = [{ layer: { id: LAYER_ID_FILL } }]
+      // Re-wrap a base that returns hits to prove the fallback is skipped
+      const provider = new loaded.MapProvider()
+      provider.map = { getLayer: vi.fn(), queryRenderedFeatures: vi.fn() }
+      Object.getPrototypeOf(Object.getPrototypeOf(provider)).getFeaturesAtPoint = () => strictHits
+
+      const hits = provider.getFeaturesAtPoint({ x: 0, y: 0 })
+
+      expect(hits).toBe(strictHits)
+      expect(provider.map.queryRenderedFeatures).not.toHaveBeenCalled()
+    })
+
+    it('passes the plugin to the InteractiveMap constructor', async () => {
+      global.fetch = fetchOk(PARCELS_RESPONSE)
+      const el = await mountElement()
+      await waitForEvent(el, EVENT_READY)
+
+      const pluginInstance = createInteractPlugin.mock.results.at(-1).value
+      const [, options] = InteractiveMap.mock.calls.at(-1)
+      expect(options.plugins).toContain(pluginInstance)
+    })
+
+    it('enables the plugin once parcels are on the map', async () => {
+      global.fetch = fetchOk(PARCELS_RESPONSE)
+      const el = await mountElement()
+      await waitForEvent(el, EVENT_READY)
+
+      const pluginInstance = createInteractPlugin.mock.results.at(-1).value
+      expect(pluginInstance.enable).toHaveBeenCalled()
+    })
+
+    it('does not enable the plugin when the user has no parcels', async () => {
+      global.fetch = fetchOk({ features: [], bbox: null })
+      const el = await mountElement()
+      await waitForEvent(el, EVENT_ERROR)
+
+      const pluginInstance = createInteractPlugin.mock.results.at(-1).value
+      expect(pluginInstance.enable).not.toHaveBeenCalled()
+    })
+
+    it('creates the plugin with multiSelect when the attribute is set', async () => {
+      global.fetch = fetchOk(PARCELS_RESPONSE)
+      const el = await mountElement({ 'multi-select': 'true' })
+      await waitForEvent(el, EVENT_READY)
+
+      expect(createInteractPlugin).toHaveBeenCalledWith(expect.objectContaining({ multiSelect: true }))
+    })
+  })
+
+  describe('selection bridge', () => {
+    it('dispatches parcel-map:selection with the plugin-selected parcel IDs', async () => {
       global.fetch = fetchOk(PARCELS_RESPONSE)
       const el = await mountElement()
       await waitForEvent(el, EVENT_READY)
 
       const selectionEvent = waitForEvent(el, EVENT_SELECTION)
-      ml._emitLayer('click', LAYER_ID_FILL, { features: [makeFeature('SD7148', '9160')], lngLat: { lng: 0, lat: 0 } })
+      emitSelectionChange([{ featureId: 'SD7148-9160' }])
       const e = await selectionEvent
       expect(e.detail.selectedIds).toEqual(['SD7148-9160'])
     })
 
-    it('deselects when the same parcel is clicked twice', async () => {
-      global.fetch = fetchOk(PARCELS_RESPONSE)
-      const el = await mountElement()
-      await waitForEvent(el, EVENT_READY)
-
-      const clickPayload = { features: [makeFeature('SD7148', '9160')], lngLat: { lng: 0, lat: 0 } }
-
-      const first = waitForEvent(el, EVENT_SELECTION)
-      ml._emitLayer('click', LAYER_ID_FILL, clickPayload)
-      await first
-
-      const second = waitForEvent(el, EVENT_SELECTION)
-      ml._emitLayer('click', LAYER_ID_FILL, clickPayload)
-      const e = await second
-      expect(e.detail.selectedIds).toEqual([])
-    })
-
-    it('replaces selection when a different parcel is clicked', async () => {
+    it('dispatches an empty selection when the plugin clears it', async () => {
       global.fetch = fetchOk(PARCELS_RESPONSE)
       const el = await mountElement()
       await waitForEvent(el, EVENT_READY)
 
       const first = waitForEvent(el, EVENT_SELECTION)
-      ml._emitLayer('click', LAYER_ID_FILL, { features: [makeFeature('SD7148', '9160')], lngLat: { lng: 0, lat: 0 } })
+      emitSelectionChange([{ featureId: 'SD7148-9160' }])
       await first
 
-      const second = waitForEvent(el, EVENT_SELECTION)
-      ml._emitLayer('click', LAYER_ID_FILL, { features: [makeFeature('SD7148', '9161')], lngLat: { lng: 0, lat: 0 } })
-      const e = await second
-      expect(e.detail.selectedIds).toEqual(['SD7148-9161'])
-    })
-
-    it('clears selection when clicking empty map area', async () => {
-      global.fetch = fetchOk(PARCELS_RESPONSE)
-      const el = await mountElement()
-      await waitForEvent(el, EVENT_READY)
-
-      const first = waitForEvent(el, EVENT_SELECTION)
-      ml._emitLayer('click', LAYER_ID_FILL, { features: [makeFeature('SD7148', '9160')], lngLat: { lng: 0, lat: 0 } })
-      await first
-
-      ml.queryRenderedFeatures.mockReturnValue([])
       const cleared = waitForEvent(el, EVENT_SELECTION)
-      ml._emit('click', { point: { x: 0, y: 0 } })
+      emitSelectionChange([])
       const e = await cleared
       expect(e.detail.selectedIds).toEqual([])
     })
 
-    it('calls setPaintProperty to highlight selected parcel', async () => {
+    it('dispatches all selected IDs in multi-select', async () => {
+      global.fetch = fetchOk(PARCELS_RESPONSE)
+      const el = await mountElement({ 'multi-select': 'true' })
+      await waitForEvent(el, EVENT_READY)
+
+      const selectionEvent = waitForEvent(el, EVENT_SELECTION)
+      emitSelectionChange([{ featureId: 'SD7148-9160' }, { featureId: 'SD7148-9161' }])
+      const e = await selectionEvent
+      expect(e.detail.selectedIds).toEqual(['SD7148-9160', 'SD7148-9161'])
+    })
+
+    it('calls setPaintProperty to highlight selected parcels', async () => {
       global.fetch = fetchOk(PARCELS_RESPONSE)
       const el = await mountElement()
       await waitForEvent(el, EVENT_READY)
 
       const first = waitForEvent(el, EVENT_SELECTION)
-      ml._emitLayer('click', LAYER_ID_FILL, { features: [makeFeature('SD7148', '9160')], lngLat: { lng: 0, lat: 0 } })
+      emitSelectionChange([{ featureId: 'SD7148-9160' }])
       await first
 
       expect(ml.setPaintProperty).toHaveBeenCalledWith(LAYER_ID_FILL, 'fill-opacity', expect.arrayContaining(['match']))
     })
 
-    it('ignores clicks with no feature', async () => {
+    it('hides the tooltip when the selection is cleared', async () => {
       global.fetch = fetchOk(PARCELS_RESPONSE)
       const el = await mountElement()
       await waitForEvent(el, EVENT_READY)
 
-      let fired = false
-      el.addEventListener(EVENT_SELECTION, () => {
-        fired = true
-      })
-      ml._emitLayer('click', LAYER_ID_FILL, { features: [], lngLat: { lng: 0, lat: 0 } })
-      await Promise.resolve()
-      expect(fired).toBe(false)
-    })
-  })
-
-  describe('selection — multi-select', () => {
-    it('accumulates multiple selections', async () => {
-      global.fetch = fetchOk(PARCELS_RESPONSE)
-      const el = await mountElement({ 'multi-select': 'true' })
-      await waitForEvent(el, EVENT_READY)
-
-      const first = waitForEvent(el, EVENT_SELECTION)
+      // Show the tooltip via a parcel click first
       ml._emitLayer('click', LAYER_ID_FILL, { features: [makeFeature('SD7148', '9160')], lngLat: { lng: 0, lat: 0 } })
-      await first
+      const tooltip = el.querySelector('[role="tooltip"]')
+      expect(tooltip.style.display).toBe('block')
 
-      const second = waitForEvent(el, EVENT_SELECTION)
-      ml._emitLayer('click', LAYER_ID_FILL, { features: [makeFeature('SD7148', '9161')], lngLat: { lng: 0, lat: 0 } })
-      const e = await second
-      expect(e.detail.selectedIds).toEqual(['SD7148-9160', 'SD7148-9161'])
-    })
+      const cleared = waitForEvent(el, EVENT_SELECTION)
+      emitSelectionChange([{ featureId: 'SD7148-9160' }])
+      emitSelectionChange([])
+      await cleared
 
-    it('removes a parcel when clicked again in multi-select', async () => {
-      global.fetch = fetchOk(PARCELS_RESPONSE)
-      const el = await mountElement({ 'multi-select': 'true' })
-      await waitForEvent(el, EVENT_READY)
-
-      const clickPayload = { features: [makeFeature('SD7148', '9160')], lngLat: { lng: 0, lat: 0 } }
-
-      const first = waitForEvent(el, EVENT_SELECTION)
-      ml._emitLayer('click', LAYER_ID_FILL, clickPayload)
-      await first
-
-      const second = waitForEvent(el, EVENT_SELECTION)
-      ml._emitLayer('click', LAYER_ID_FILL, clickPayload)
-      const e = await second
-      expect(e.detail.selectedIds).toEqual([])
+      expect(tooltip.style.display).toBe('none')
     })
   })
 
@@ -383,12 +457,10 @@ describe('parcel-map web component', () => {
       const el = await mountElement()
       await waitForEvent(el, EVENT_READY)
 
-      const sel = waitForEvent(el, EVENT_SELECTION)
       ml._emitLayer('click', LAYER_ID_FILL, {
         features: [makeFeature('SD7148', '9160')],
         lngLat: { lng: 0, lat: 0 }
       })
-      await sel
 
       const tooltip = el.querySelector('[role="tooltip"]')
       expect(tooltip).not.toBeNull()
@@ -401,12 +473,10 @@ describe('parcel-map web component', () => {
       const el = await mountElement()
       await waitForEvent(el, EVENT_READY)
 
-      const sel = waitForEvent(el, EVENT_SELECTION)
       ml._emitLayer('click', LAYER_ID_FILL, {
         features: [makeFeature('SD7148', '9161')],
         lngLat: { lng: 0, lat: 0 }
       })
-      await sel
 
       const tooltip = el.querySelector('[role="tooltip"]')
       expect(tooltip.innerHTML).toContain('Unknown')

--- a/src/client/javascripts/parcel-map/index.test.js
+++ b/src/client/javascripts/parcel-map/index.test.js
@@ -273,7 +273,7 @@ describe('parcel-map web component', () => {
         el.setAttribute('basemap-provider', 'openstreetmap')
         await readyAgain
 
-        expect(InteractiveMap.mock.calls.length).toBe(callsBeforeToggle + 1)
+        expect(InteractiveMap.mock.calls).toHaveLength(callsBeforeToggle + 1)
         const [, options] = InteractiveMap.mock.calls.at(-1)
         expect(options.mapStyle.url).toBe('https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json')
       })
@@ -282,8 +282,8 @@ describe('parcel-map web component', () => {
         const el = document.createElement('parcel-map')
         const callsBefore = InteractiveMap.mock.calls.length
         el.setAttribute('basemap-provider', 'openstreetmap')
-        // No mountElement/appendChild here — attributeChangedCallback should no-op
-        expect(InteractiveMap.mock.calls.length).toBe(callsBefore)
+
+        expect(InteractiveMap.mock.calls).toHaveLength(callsBefore)
       })
 
       it('uses a label font the CartoCDN style actually serves glyphs for', async () => {

--- a/src/client/javascripts/parcel-map/index.test.js
+++ b/src/client/javascripts/parcel-map/index.test.js
@@ -202,7 +202,7 @@ describe('parcel-map web component', () => {
       expect(options.urlPosition).toBe('none')
     })
 
-    it('constrains zoom-out to the OS basemap coverage (min zoom 7)', async () => {
+    it('constrains zoom-out to the OS basemap coverage (min zoom 7) by default', async () => {
       global.fetch = fetchOk(PARCELS_RESPONSE)
       const el = await mountElement()
       await waitForEvent(el, EVENT_READY)
@@ -218,6 +218,73 @@ describe('parcel-map web component', () => {
 
       const [, options] = InteractiveMap.mock.calls[0]
       expect(options.mapLabel).toEqual(expect.stringContaining('land parcels'))
+    })
+  })
+
+  describe('basemap provider', () => {
+    it('defaults to the OS Maps style when no attribute is set', async () => {
+      global.fetch = fetchOk(PARCELS_RESPONSE)
+      const el = await mountElement()
+      await waitForEvent(el, EVENT_READY)
+
+      const [, options] = InteractiveMap.mock.calls.at(-1)
+      expect(options.mapStyle.url).toBe('/api/map/os-basemap')
+      expect(options.minZoom).toBe(7)
+    })
+
+    it('defaults to OS Maps even when the attribute is explicitly "ordnance-survey"', async () => {
+      global.fetch = fetchOk(PARCELS_RESPONSE)
+      const el = await mountElement({ 'basemap-provider': 'ordnance-survey' })
+      await waitForEvent(el, EVENT_READY)
+
+      const [, options] = InteractiveMap.mock.calls.at(-1)
+      expect(options.mapStyle.url).toBe('/api/map/os-basemap')
+    })
+
+    // TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up) —
+    // delete this describe block once the comparison is complete.
+    describe('OpenStreetMap comparison (temporary)', () => {
+      it('switches to the OpenStreetMap style when basemap-provider="openstreetmap"', async () => {
+        global.fetch = fetchOk(PARCELS_RESPONSE)
+        const el = await mountElement({ 'basemap-provider': 'openstreetmap' })
+        await waitForEvent(el, EVENT_READY)
+
+        const [, options] = InteractiveMap.mock.calls.at(-1)
+        expect(options.mapStyle.url).toBe('https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json')
+        expect(options.mapStyle.attribution).toContain('OpenStreetMap')
+      })
+
+      it('does not constrain minZoom for the OpenStreetMap style', async () => {
+        global.fetch = fetchOk(PARCELS_RESPONSE)
+        const el = await mountElement({ 'basemap-provider': 'openstreetmap' })
+        await waitForEvent(el, EVENT_READY)
+
+        const [, options] = InteractiveMap.mock.calls.at(-1)
+        expect(options.minZoom).toBeUndefined()
+      })
+
+      it('re-initialises the map when basemap-provider changes at runtime', async () => {
+        global.fetch = fetchOk(PARCELS_RESPONSE)
+        const el = await mountElement()
+        await waitForEvent(el, EVENT_READY)
+        const callsBeforeToggle = InteractiveMap.mock.calls.length
+
+        const readyAgain = waitForEvent(el, EVENT_READY)
+        el.setAttribute('basemap-provider', 'openstreetmap')
+        await readyAgain
+
+        expect(InteractiveMap.mock.calls.length).toBe(callsBeforeToggle + 1)
+        const [, options] = InteractiveMap.mock.calls.at(-1)
+        expect(options.mapStyle.url).toBe('https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json')
+      })
+
+      it('ignores attribute changes before the element is connected', async () => {
+        const el = document.createElement('parcel-map')
+        const callsBefore = InteractiveMap.mock.calls.length
+        el.setAttribute('basemap-provider', 'openstreetmap')
+        // No mountElement/appendChild here — attributeChangedCallback should no-op
+        expect(InteractiveMap.mock.calls.length).toBe(callsBefore)
+      })
     })
   })
 

--- a/src/client/javascripts/parcel-map/index.test.js
+++ b/src/client/javascripts/parcel-map/index.test.js
@@ -97,8 +97,6 @@ function waitForEvent(el, eventName) {
   return new Promise((resolve) => el.addEventListener(eventName, resolve, { once: true }))
 }
 
-// Latest InteractiveMap mock instance — used to emit plugin events (e.g.
-// interact:selectionchange) the way the real event bus would.
 function lastMapInstance() {
   return InteractiveMap.mock.instances.at(-1)
 }
@@ -172,9 +170,9 @@ describe('parcel-map web component', () => {
       global.fetch = vi.fn().mockResolvedValue({ ok: false })
       const el = await mountElement()
       await waitForEvent(el, EVENT_ERROR)
+
       expect(el.querySelector('[role="status"]')).toBeNull()
-      // Map wrapper (the div wrapping the canvas) should be gone too
-      expect(el.querySelectorAll('div').length).toBeLessThanOrEqual(1) // only the error overlay
+      expect(el.querySelectorAll('div').length).toBeLessThanOrEqual(1) 
     })
 
     it('removes skeleton once ready', async () => {
@@ -241,8 +239,6 @@ describe('parcel-map web component', () => {
       expect(options.mapStyle.url).toBe('/api/map/os-basemap')
     })
 
-    // TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up) —
-    // delete this describe block once the comparison is complete.
     describe('OpenStreetMap comparison (temporary)', () => {
       it('switches to the OpenStreetMap style when basemap-provider="openstreetmap"', async () => {
         global.fetch = fetchOk(PARCELS_RESPONSE)
@@ -438,9 +434,6 @@ describe('parcel-map web component', () => {
       const { MapProvider } = await options.mapProvider.load()
       const provider = new MapProvider()
 
-      // Both are single-point "polygons" (only the corner matters for the
-      // bounding-box centre this test exercises) — `near` projects to a
-      // screen point right at the click, `far` projects well outside it.
       const near = {
         layer: { id: LAYER_ID_FILL },
         properties: { id: 'SD7148-9160' },

--- a/src/client/javascripts/parcel-map/index.test.js
+++ b/src/client/javascripts/parcel-map/index.test.js
@@ -274,6 +274,39 @@ describe('parcel-map web component', () => {
         expect(options.mapStyle.url).toBe('https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json')
       })
 
+      it('re-initialises with the latest provider when the attribute changes mid-load', async () => {
+        global.fetch = fetchOk(PARCELS_RESPONSE)
+
+        // First InteractiveMap instance never signals map:ready on its own —
+        // lets the test control exactly when the in-flight load settles.
+        let firstInstance
+        InteractiveMap.mockImplementationOnce(function () {
+          this._handlers = {}
+          this.on = vi.fn((event, cb) => {
+            this._handlers[event] = this._handlers[event] ?? []
+            this._handlers[event].push(cb)
+          })
+          this.destroy = vi.fn()
+          this._emit = (event, payload) => {
+            ;(this._handlers[event] ?? []).forEach((fn) => fn(payload))
+          }
+          firstInstance = this
+        })
+        setupInteractiveMapMock(ml) // second (and any later) instance auto-readies
+
+        const el = await mountElement()
+        // basemap-provider changes while the first load is still in flight
+        el.setAttribute('basemap-provider', 'openstreetmap')
+
+        const readyEvent = waitForEvent(el, EVENT_READY)
+        firstInstance._emit('map:ready', { map: ml })
+        firstInstance._emit('map:stylechange')
+        await readyEvent
+
+        const [, options] = InteractiveMap.mock.calls.at(-1)
+        expect(options.mapStyle.url).toBe('https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json')
+      })
+
       it('ignores attribute changes before the element is connected', async () => {
         const el = document.createElement('parcel-map')
         const callsBefore = InteractiveMap.mock.calls.length

--- a/src/client/javascripts/parcel-map/map-helpers.js
+++ b/src/client/javascripts/parcel-map/map-helpers.js
@@ -1,0 +1,275 @@
+import {
+  MAP_STYLE_URL,
+  getMapStyleAttribution,
+  OSM_STYLE_URL,
+  OSM_STYLE_ATTRIBUTION,
+  BASEMAP_PROVIDER_OPENSTREETMAP,
+  PARCEL_COLORS,
+  LAYER_TEXT_SIZE,
+  LAYER_TEXT_HALO_WIDTH,
+  LAYER_LINE_WIDTH,
+  AREA_DECIMAL_PLACES,
+  PARCEL_ID_PROPERTY,
+  PARCEL_CLICK_TOLERANCE_PX,
+  LAYER_ID_FILL,
+  LAYER_ID_OUTLINE,
+  LAYER_ID_LABEL,
+  FILL_OPACITY_DEFAULT,
+  ERROR_OVERLAY_STYLES,
+  ERROR_LABEL_STYLES,
+  LABEL_TEXT_COLOR,
+  LABEL_HALO_COLOR,
+  MSG_LOADING,
+  MSG_UNKNOWN_PARCEL,
+  MSG_UNKNOWN_AREA,
+  TOOLTIP_OFFSET_X,
+  TOOLTIP_MAX_WIDTH,
+  TOOLTIP_FALLBACK_MAP_WIDTH,
+  TOOLTIP_VERTICAL_OFFSET
+} from './config.js'
+
+/**
+ * @import { MapGeoJSONFeature } from 'maplibre-gl'
+ */
+
+/**
+ * @typedef {{ sheet_id?: unknown, parcel_id?: unknown, areaHa?: unknown, [key: string]: unknown }} ParcelProperties
+ * @typedef {{ id: string } & ParcelProperties} ParcelMeta
+ * @typedef {Record<string, ParcelMeta>} MetaIndex
+ */
+
+// Same PARCEL_ID_PROPERTY the interact plugin matches on, so label/colour/
+// highlight logic can't disagree with what's selected.
+export const COMPOUND_ID_EXPR = ['get', PARCEL_ID_PROPERTY]
+
+/**
+ * @param {unknown[]} colorExpr  MapLibre `match` expression
+ * @param {string}   [sourceLayer]
+ * @param {string}   [basemapProvider]  BASEMAP_PROVIDER_ORDNANCE_SURVEY | BASEMAP_PROVIDER_OPENSTREETMAP
+ */
+export function buildParcelLayers(colorExpr, sourceLayer, basemapProvider) {
+  const src = sourceLayer ? { 'source-layer': sourceLayer } : {}
+  // OS Maps sets no `glyphs` URL, so any font renders locally via MapLibre's
+  // TinySDF fallback. TEMPORARY (TGC-1418 follow-up): CartoCDN's OpenStreetMap
+  // style DOES set a glyphs URL, and only serves the fonts it declares in its
+  // own layers ('Open Sans Regular' etc) — 'Arial Regular' 404s against it.
+  // Delete this branch (keep 'Arial Regular') once OSM support is removed.
+  const labelFont = basemapProvider === BASEMAP_PROVIDER_OPENSTREETMAP ? 'Open Sans Regular' : 'Arial Regular'
+  return {
+    fill: {
+      id: LAYER_ID_FILL,
+      type: 'fill',
+      source: 'parcels',
+      ...src,
+      paint: {
+        'fill-color': colorExpr,
+        'fill-opacity': FILL_OPACITY_DEFAULT
+      }
+    },
+    outline: {
+      id: LAYER_ID_OUTLINE,
+      type: 'line',
+      source: 'parcels',
+      ...src,
+      paint: {
+        'line-color': colorExpr,
+        'line-width': LAYER_LINE_WIDTH
+      }
+    },
+    label: {
+      id: LAYER_ID_LABEL,
+      type: 'symbol',
+      source: 'parcels',
+      ...src,
+      layout: {
+        'text-field': COMPOUND_ID_EXPR,
+        'text-font': [labelFont],
+        'text-size': LAYER_TEXT_SIZE,
+        'text-anchor': 'center'
+      },
+      paint: {
+        'text-color': LABEL_TEXT_COLOR,
+        'text-halo-color': LABEL_HALO_COLOR,
+        'text-halo-width': LAYER_TEXT_HALO_WIDTH
+      }
+    }
+  }
+}
+
+/**
+ * Resolves the MapLibre style URL/attribution for the chosen basemap provider.
+ * TEMPORARY (TGC-1418 follow-up): delete the ternary + provider param once
+ * the OpenStreetMap comparison ends.
+ * @param {string} provider  BASEMAP_PROVIDER_ORDNANCE_SURVEY | BASEMAP_PROVIDER_OPENSTREETMAP
+ * @returns {{ url: string, attribution: string }}
+ */
+export function getMapStyle(provider) {
+  // OSM's style/tiles are public (no key to protect), so its URL points
+  // straight at CartoCDN; OS Maps stays server-proxied.
+  return provider === BASEMAP_PROVIDER_OPENSTREETMAP
+    ? { url: OSM_STYLE_URL, attribution: OSM_STYLE_ATTRIBUTION }
+    : { url: MAP_STYLE_URL, attribution: getMapStyleAttribution() }
+}
+
+/**
+ * Falls back to the nearest rendered parcel within PARCEL_CLICK_TOLERANCE_PX
+ * when the interact plugin's strict inside-the-shape hit test finds nothing —
+ * which is common for small parcels at low zoom.
+ *
+ * Wrapped via `load()` because the map library hands us a provider
+ * *descriptor*, not the provider itself — the real class only exists once
+ * `load()` resolves.
+ * @param {{ load: () => Promise<{ MapProvider: new (...args: never[]) => { map?: import('maplibre-gl').Map } }> }} descriptor
+ */
+export function withParcelHitTolerance(descriptor) {
+  const originalLoad = descriptor.load
+  descriptor.load = async () => {
+    const result = await originalLoad()
+    class ParcelHitToleranceProvider extends result.MapProvider {
+      /**
+       * @param {{ x: number, y: number }} point
+       * @param {{ radius?: number }} [options]
+       */
+      getFeaturesAtPoint(point, options) {
+        // @ts-ignore — base method exists on the runtime provider
+        const hits = super.getFeaturesAtPoint(point, options)
+        if (hits.length > 0 || !this.map?.getLayer(LAYER_ID_FILL)) {
+          return hits
+        }
+        const r = PARCEL_CLICK_TOLERANCE_PX
+        const rendered = this.map.queryRenderedFeatures(
+          [
+            [point.x - r, point.y - r],
+            [point.x + r, point.y + r]
+          ],
+          { layers: [LAYER_ID_FILL] }
+        )
+        return nearestFeatureToPoint(this.map, point, rendered)
+      }
+    }
+    return { ...result, MapProvider: ParcelHitToleranceProvider }
+  }
+  return descriptor
+}
+
+/**
+ * Picks the rendered feature whose on-screen bounding-box centre is closest
+ * to the click point. Used when two or more adjacent parcels both land in
+ * the tolerance box — without this, `queryRenderedFeatures` order (not
+ * proximity) would decide which one gets selected.
+ * @param {import('maplibre-gl').Map} map
+ * @param {{ x: number, y: number }} point
+ * @param {import('maplibre-gl').MapGeoJSONFeature[]} features
+ * @returns {import('maplibre-gl').MapGeoJSONFeature[]}
+ */
+export function nearestFeatureToPoint(map, point, features) {
+  if (features.length <= 1) {
+    return features
+  }
+  const distSq = (/** @type {import('maplibre-gl').MapGeoJSONFeature} */ f) => {
+    const box = f.geometry.type.includes('Polygon') ? getScreenBounds(map, f) : null
+    if (!box) {
+      return Infinity
+    }
+    const cx = (box.minX + box.maxX) / 2
+    const cy = (box.minY + box.maxY) / 2
+    return (point.x - cx) ** 2 + (point.y - cy) ** 2
+  }
+  return [[...features].sort((a, b) => distSq(a) - distSq(b))[0]]
+}
+
+/**
+ * On-screen pixel bounding box of a polygon/multipolygon feature.
+ * @param {import('maplibre-gl').Map} map
+ * @param {import('maplibre-gl').MapGeoJSONFeature} feature
+ */
+export function getScreenBounds(map, feature) {
+  const geometry = /** @type {import('geojson').Polygon | import('geojson').MultiPolygon} */ (feature.geometry)
+  const { type, coordinates } = geometry
+  const rings = type === 'Polygon' ? coordinates : coordinates.flat()
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const ring of rings) {
+    for (const [lng, lat] of ring) {
+      const { x, y } = map.project([lng, lat])
+      minX = Math.min(minX, x)
+      minY = Math.min(minY, y)
+      maxX = Math.max(maxX, x)
+      maxY = Math.max(maxY, y)
+    }
+  }
+  return minX === Infinity ? null : { minX, minY, maxX, maxY }
+}
+
+/** @returns {HTMLDivElement} */
+export function buildSkeleton() {
+  const el = /** @type {HTMLDivElement} */ (document.createElement('div'))
+  el.setAttribute('aria-label', MSG_LOADING)
+  el.setAttribute('role', 'status')
+  el.style.cssText = ERROR_OVERLAY_STYLES
+  const label = document.createElement('span')
+  label.style.cssText = ERROR_LABEL_STYLES
+  label.textContent = MSG_LOADING
+  el.appendChild(label)
+  return el
+}
+
+/**
+ * MapLibre `match` expression mapping compound parcel ID → colour.
+ * @param {string[]} ids
+ * @returns {unknown[]}
+ */
+export function buildColorExpr(ids) {
+  const expr = /** @type {unknown[]} */ (['match', COMPOUND_ID_EXPR])
+  ;[...new Set(ids)].forEach((id, i) => {
+    expr.push(id, PARCEL_COLORS[i % PARCEL_COLORS.length])
+  })
+  expr.push(PARCEL_COLORS[0])
+  return expr
+}
+
+/**
+ * Compound parcel ID (e.g. "SD7148-9160") from a feature's PARCEL_ID_PROPERTY.
+ * @param {MapGeoJSONFeature} feature
+ * @returns {string}
+ */
+export function resolveFeatureId(feature) {
+  const id = /** @type {ParcelProperties | undefined} */ (feature.properties)?.[PARCEL_ID_PROPERTY]
+  return typeof id === 'string' || typeof id === 'number' ? String(id) : ''
+}
+
+/**
+ * @param {HTMLElement} tooltip
+ * @param {string} id
+ * @param {ParcelProperties} props
+ * @param {number} x
+ * @param {number} y
+ * @param {HTMLDivElement | null} mapEl
+ */
+export function showTooltip(tooltip, id, props, x, y, mapEl) {
+  const areaHa = props.areaHa == null ? null : Number(props.areaHa)
+  tooltip.innerHTML = `
+    <strong style="display:block;margin-bottom:8px;font-size:15px">${htmlEncode(id || MSG_UNKNOWN_PARCEL)}</strong>
+    <table style="border-collapse:collapse;width:100%">
+      <tr><td style="color:#505a5f;padding:2px 12px 2px 0;white-space:nowrap">Total area</td>
+          <td>${areaHa == null ? MSG_UNKNOWN_AREA : htmlEncode(areaHa.toFixed(AREA_DECIMAL_PLACES) + ' ha')}</td></tr>
+    </table>`
+  tooltip.style.left = `${Math.min(x + TOOLTIP_OFFSET_X, (mapEl?.offsetWidth ?? TOOLTIP_FALLBACK_MAP_WIDTH) - TOOLTIP_MAX_WIDTH)}px`
+  tooltip.style.top = `${y - TOOLTIP_VERTICAL_OFFSET}px`
+  tooltip.style.display = 'block'
+}
+
+/** @param {HTMLElement} tooltip */
+export function hideTooltip(tooltip) {
+  tooltip.style.display = 'none'
+}
+
+/** @param {string} value @returns {string} */
+export function htmlEncode(value) {
+  const text = document.createTextNode(value)
+  const div = document.createElement('div')
+  div.appendChild(text)
+  return div.innerHTML
+}

--- a/src/client/javascripts/parcel-map/map-helpers.test.js
+++ b/src/client/javascripts/parcel-map/map-helpers.test.js
@@ -53,7 +53,15 @@ describe('getMapStyle', () => {
 describe('buildColorExpr', () => {
   it('assigns each distinct parcel ID a colour', () => {
     const expr = buildColorExpr(['A-1', 'A-2'])
-    expect(expr).toEqual(['match', COMPOUND_ID_EXPR, 'A-1', expect.any(String), 'A-2', expect.any(String), expect.any(String)])
+    expect(expr).toEqual([
+      'match',
+      COMPOUND_ID_EXPR,
+      'A-1',
+      expect.any(String),
+      'A-2',
+      expect.any(String),
+      expect.any(String)
+    ])
   })
 
   it('de-duplicates repeated IDs', () => {
@@ -81,8 +89,32 @@ describe('nearestFeatureToPoint', () => {
 
   it('picks the polygon feature whose bounding box centre is closest to the point', () => {
     const map = { project: ([lng, lat]) => ({ x: lng, y: lat }) }
-    const near = { geometry: { type: 'Polygon', coordinates: [[[0, 0], [2, 0], [2, 2], [0, 2]]] } }
-    const far = { geometry: { type: 'Polygon', coordinates: [[[100, 100], [102, 100], [102, 102], [100, 102]]] } }
+    const near = {
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [2, 0],
+            [2, 2],
+            [0, 2]
+          ]
+        ]
+      }
+    }
+    const far = {
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [100, 100],
+            [102, 100],
+            [102, 102],
+            [100, 102]
+          ]
+        ]
+      }
+    }
 
     expect(nearestFeatureToPoint(map, { x: 1, y: 1 }, [far, near])).toEqual([near])
   })
@@ -91,7 +123,19 @@ describe('nearestFeatureToPoint', () => {
 describe('getScreenBounds', () => {
   it('computes the pixel bounding box of a Polygon', () => {
     const map = { project: ([lng, lat]) => ({ x: lng, y: lat }) }
-    const feature = { geometry: { type: 'Polygon', coordinates: [[[0, 0], [4, 0], [4, 4], [0, 4]]] } }
+    const feature = {
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [4, 0],
+            [4, 4],
+            [0, 4]
+          ]
+        ]
+      }
+    }
 
     expect(getScreenBounds(map, feature)).toEqual({ minX: 0, minY: 0, maxX: 4, maxY: 4 })
   })
@@ -101,7 +145,20 @@ describe('getScreenBounds', () => {
     const feature = {
       geometry: {
         type: 'MultiPolygon',
-        coordinates: [[[[0, 0], [1, 1]]], [[[5, 5], [6, 6]]]]
+        coordinates: [
+          [
+            [
+              [0, 0],
+              [1, 1]
+            ]
+          ],
+          [
+            [
+              [5, 5],
+              [6, 6]
+            ]
+          ]
+        ]
       }
     }
 
@@ -141,7 +198,19 @@ describe('withParcelHitTolerance', () => {
     const descriptor = makeDescriptor(() => [])
     const { MapProvider } = await withParcelHitTolerance(descriptor).load()
     const provider = new MapProvider()
-    const nearby = { geometry: { type: 'Polygon', coordinates: [[[0, 0], [2, 0], [2, 2], [0, 2]]] } }
+    const nearby = {
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [2, 0],
+            [2, 2],
+            [0, 2]
+          ]
+        ]
+      }
+    }
     provider.map = {
       getLayer: () => true,
       queryRenderedFeatures: vi.fn().mockReturnValue([nearby]),

--- a/src/client/javascripts/parcel-map/map-helpers.test.js
+++ b/src/client/javascripts/parcel-map/map-helpers.test.js
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  COMPOUND_ID_EXPR,
+  buildParcelLayers,
+  getMapStyle,
+  withParcelHitTolerance,
+  nearestFeatureToPoint,
+  getScreenBounds,
+  buildSkeleton,
+  buildColorExpr,
+  resolveFeatureId,
+  showTooltip,
+  hideTooltip,
+  htmlEncode
+} from './map-helpers.js'
+
+describe('buildParcelLayers', () => {
+  it('labels with Arial Regular for the OS provider', () => {
+    const layers = buildParcelLayers(['match', COMPOUND_ID_EXPR], undefined, 'ordnance-survey')
+    expect(layers.label.layout['text-font']).toEqual(['Arial Regular'])
+  })
+
+  it('labels with Open Sans Regular for the OpenStreetMap provider', () => {
+    const layers = buildParcelLayers(['match', COMPOUND_ID_EXPR], undefined, 'openstreetmap')
+    expect(layers.label.layout['text-font']).toEqual(['Open Sans Regular'])
+  })
+
+  it('sets source-layer on every layer when provided (vector tiles)', () => {
+    const layers = buildParcelLayers(['match', COMPOUND_ID_EXPR], 'parcels', 'ordnance-survey')
+    expect(layers.fill['source-layer']).toBe('parcels')
+    expect(layers.outline['source-layer']).toBe('parcels')
+    expect(layers.label['source-layer']).toBe('parcels')
+  })
+
+  it('omits source-layer when not provided (geojson source)', () => {
+    const layers = buildParcelLayers(['match', COMPOUND_ID_EXPR], undefined, 'ordnance-survey')
+    expect(layers.fill).not.toHaveProperty('source-layer')
+  })
+})
+
+describe('getMapStyle', () => {
+  it('returns the OS Maps style by default', () => {
+    const style = getMapStyle('ordnance-survey')
+    expect(style.url).toBe('/api/map/os-basemap')
+  })
+
+  it('returns the CartoCDN style for openstreetmap', () => {
+    const style = getMapStyle('openstreetmap')
+    expect(style.url).toBe('https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json')
+  })
+})
+
+describe('buildColorExpr', () => {
+  it('assigns each distinct parcel ID a colour', () => {
+    const expr = buildColorExpr(['A-1', 'A-2'])
+    expect(expr).toEqual(['match', COMPOUND_ID_EXPR, 'A-1', expect.any(String), 'A-2', expect.any(String), expect.any(String)])
+  })
+
+  it('de-duplicates repeated IDs', () => {
+    const expr = buildColorExpr(['A-1', 'A-1'])
+    // ['match', COMPOUND_ID_EXPR, 'A-1', colour, fallbackColour] — one pair, not two
+    expect(expr).toHaveLength(5)
+  })
+})
+
+describe('resolveFeatureId', () => {
+  it('reads the compound id property off a feature', () => {
+    const feature = { properties: { id: 'SD7148-9160' } }
+    expect(resolveFeatureId(feature)).toBe('SD7148-9160')
+  })
+
+  it('returns an empty string when the id is missing', () => {
+    expect(resolveFeatureId({ properties: {} })).toBe('')
+  })
+})
+
+describe('nearestFeatureToPoint', () => {
+  it('returns the input unchanged when 0 or 1 features', () => {
+    expect(nearestFeatureToPoint(null, { x: 0, y: 0 }, [])).toEqual([])
+  })
+
+  it('picks the polygon feature whose bounding box centre is closest to the point', () => {
+    const map = { project: ([lng, lat]) => ({ x: lng, y: lat }) }
+    const near = { geometry: { type: 'Polygon', coordinates: [[[0, 0], [2, 0], [2, 2], [0, 2]]] } }
+    const far = { geometry: { type: 'Polygon', coordinates: [[[100, 100], [102, 100], [102, 102], [100, 102]]] } }
+
+    expect(nearestFeatureToPoint(map, { x: 1, y: 1 }, [far, near])).toEqual([near])
+  })
+})
+
+describe('getScreenBounds', () => {
+  it('computes the pixel bounding box of a Polygon', () => {
+    const map = { project: ([lng, lat]) => ({ x: lng, y: lat }) }
+    const feature = { geometry: { type: 'Polygon', coordinates: [[[0, 0], [4, 0], [4, 4], [0, 4]]] } }
+
+    expect(getScreenBounds(map, feature)).toEqual({ minX: 0, minY: 0, maxX: 4, maxY: 4 })
+  })
+
+  it('flattens MultiPolygon rings', () => {
+    const map = { project: ([lng, lat]) => ({ x: lng, y: lat }) }
+    const feature = {
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [[[[0, 0], [1, 1]]], [[[5, 5], [6, 6]]]]
+      }
+    }
+
+    expect(getScreenBounds(map, feature)).toEqual({ minX: 0, minY: 0, maxX: 6, maxY: 6 })
+  })
+
+  it('returns null when there are no rings', () => {
+    const map = { project: vi.fn() }
+    const feature = { geometry: { type: 'Polygon', coordinates: [] } }
+
+    expect(getScreenBounds(map, feature)).toBeNull()
+  })
+})
+
+describe('withParcelHitTolerance', () => {
+  function makeDescriptor(baseGetFeaturesAtPoint) {
+    class BaseProvider {
+      getFeaturesAtPoint(...args) {
+        return baseGetFeaturesAtPoint(...args)
+      }
+    }
+    return {
+      load: vi.fn().mockResolvedValue({ MapProvider: BaseProvider })
+    }
+  }
+
+  it('returns the base provider hits unchanged when there are any', async () => {
+    const descriptor = makeDescriptor(() => [{ id: 'hit' }])
+    const { MapProvider } = await withParcelHitTolerance(descriptor).load()
+    const provider = new MapProvider()
+    provider.map = { getLayer: () => true }
+
+    expect(provider.getFeaturesAtPoint({ x: 0, y: 0 })).toEqual([{ id: 'hit' }])
+  })
+
+  it('falls back to the nearest rendered parcel within tolerance when there are no exact hits', async () => {
+    const descriptor = makeDescriptor(() => [])
+    const { MapProvider } = await withParcelHitTolerance(descriptor).load()
+    const provider = new MapProvider()
+    const nearby = { geometry: { type: 'Polygon', coordinates: [[[0, 0], [2, 0], [2, 2], [0, 2]]] } }
+    provider.map = {
+      getLayer: () => true,
+      queryRenderedFeatures: vi.fn().mockReturnValue([nearby]),
+      project: ([lng, lat]) => ({ x: lng, y: lat })
+    }
+
+    expect(provider.getFeaturesAtPoint({ x: 1, y: 1 })).toEqual([nearby])
+  })
+
+  it('returns no hits when the parcels layer is not on the map', async () => {
+    const descriptor = makeDescriptor(() => [])
+    const { MapProvider } = await withParcelHitTolerance(descriptor).load()
+    const provider = new MapProvider()
+    provider.map = { getLayer: () => false }
+
+    expect(provider.getFeaturesAtPoint({ x: 0, y: 0 })).toEqual([])
+  })
+})
+
+describe('buildSkeleton', () => {
+  it('builds an accessible loading status element', () => {
+    const el = buildSkeleton()
+    expect(el.getAttribute('role')).toBe('status')
+    expect(el.textContent).toBe('Loading map…')
+  })
+})
+
+describe('tooltip helpers', () => {
+  it('shows area and parcel id, escaping HTML in the id', () => {
+    const tooltip = document.createElement('div')
+    showTooltip(tooltip, '<b>SD1</b>', { areaHa: 2.5 }, 10, 20, null)
+
+    expect(tooltip.style.display).toBe('block')
+    expect(tooltip.innerHTML).toContain('&lt;b&gt;SD1&lt;/b&gt;')
+    expect(tooltip.innerHTML).toContain('2.50 ha')
+  })
+
+  it('falls back to "Unknown parcel"/"Unknown" when id/area are missing', () => {
+    const tooltip = document.createElement('div')
+    showTooltip(tooltip, '', {}, 0, 0, null)
+
+    expect(tooltip.innerHTML).toContain('Unknown parcel')
+    expect(tooltip.innerHTML).toContain('Unknown')
+  })
+
+  it('hides the tooltip', () => {
+    const tooltip = document.createElement('div')
+    tooltip.style.display = 'block'
+    hideTooltip(tooltip)
+
+    expect(tooltip.style.display).toBe('none')
+  })
+})
+
+describe('htmlEncode', () => {
+  it('escapes HTML-significant characters', () => {
+    expect(htmlEncode('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+})

--- a/src/plugins/content-security-policy.js
+++ b/src/plugins/content-security-policy.js
@@ -13,11 +13,20 @@ const defaultContentPolicy = (/** @type {string} */ nonce) => {
   // This is a known hash published by the Design System team.
   // See: https://frontend.design-system.service.gov.uk/import-javascript/
   const govukFrontendHash = "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='"
+  // --- TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up) ---
+  // The parcel map's OpenStreetMap basemap option loads its style/tiles
+  // directly from CartoCDN (unlike OS Maps, which is proxied server-side).
+  // Allowed unconditionally because the basemap-provider toggle is a
+  // runtime choice, not a per-deployment one. Delete cartoCdn/cartoTiles and
+  // their two usages below once the comparison is complete.
+  const cartoCdn = 'https://basemaps.cartocdn.com'
+  const cartoTiles = 'https://*.basemaps.cartocdn.com'
+  // --- END TEMPORARY ---
 
   const scriptSrc = [self, "'strict-dynamic'", `'nonce-${nonce}'`, govukFrontendHash, gtmWildCard, ga4].join(' ')
-  const connectSrc = [self, ga4, statsDblClick, ga4WildCard, gtmWildCard].join(' ')
+  const connectSrc = [self, ga4, statsDblClick, ga4WildCard, gtmWildCard, cartoCdn, cartoTiles].join(' ')
   const fontSrc = [self, 'data:', 'https://fonts.gstatic.com'].join(' ')
-  const imgSrc = [self, 'data:', 'blob:', ga4, statsDblClick, ga4WildCard].join(' ')
+  const imgSrc = [self, 'data:', 'blob:', ga4, statsDblClick, ga4WildCard, cartoCdn, cartoTiles].join(' ')
   const workerSrc = [self, 'blob:'].join(' ')
 
   const formActionSrc = [self]

--- a/src/plugins/content-security-policy.test.js
+++ b/src/plugins/content-security-policy.test.js
@@ -147,6 +147,24 @@ describe('contentSecurityPolicy plugin', () => {
       expect(mockHeader).toHaveBeenNthCalledWith(3, 'X-CSP-Nonce', request.app.cspNonce)
     })
 
+    it('allows CartoCDN for the parcel map basemap-provider toggle', async () => {
+      const request = {
+        response: {
+          isBoom: false,
+          header: mockHeader,
+          variety: ''
+        },
+        app: {}
+      }
+
+      await onRequest(request, h)
+      await onPreResponse(request, h)
+
+      const [, policy] = mockHeader.mock.calls.find(([name]) => name === 'Content-Security-Policy')
+      expect(policy).toContain('https://basemaps.cartocdn.com')
+      expect(policy).toContain('https://*.basemaps.cartocdn.com')
+    })
+
     it.each([
       { initialContext: {}, description: 'empty context object' },
       { initialContext: undefined, description: 'undefined context' },

--- a/src/server/common/forms/definitions/example-grant-with-map.yaml
+++ b/src/server/common/forms/definitions/example-grant-with-map.yaml
@@ -43,6 +43,8 @@ pages:
     id: a1b2c3d4-0001-0001-0001-000000000003
     path: /select-land-parcel
     controller: MapSelectPageController
+    config:
+      devMode: true
     components:
       - name: selectedParcelsDisplay
         id: a1b2c3d4-0001-0001-0001-000000000010

--- a/src/server/common/map/README.md
+++ b/src/server/common/map/README.md
@@ -117,6 +117,20 @@ Extends `QuestionPageController`. Renders `map-select-parcel.html`.
 
 `multi-select` is read once when the component connects — changing it afterwards has no effect (re-create the element to reconfigure).
 
+### Accessible selection (interact plugin)
+
+Selection is handled by the `@defra/interactive-map` **interact plugin**, not raw MapLibre click handlers. This gives every input method a route to select a parcel:
+
+- **Pointer** — click a parcel
+- **Touch** — a crosshair with a "Select" action button
+- **Keyboard** — <kbd>Enter</kbd> selects at the crosshair target; <kbd>Tab</kbd> opens a listbox of parcels (labelled by compound parcel ID) navigable with arrow keys
+
+The plugin only matches polygons when the click is geometrically inside them, which makes small zoomed-out parcels effectively unselectable. The component wraps the MapLibre provider (`withParcelHitTolerance` in `index.js`) so that when the strict query misses, it falls back to a rendered-pixel query on the fill layer within `PARCEL_CLICK_TOLERANCE_PX` (10px) of the point — parcels stay selectable by pointer and keyboard crosshair at any zoom. The keyboard listbox is fully zoom-independent.
+
+The component listens to the plugin's `interact:selectionchange` event and re-dispatches it as `parcel-map:selection`, so page-level consumers are unaffected by the plugin internals. The fill-opacity highlight is applied by the component on top of the plugin's own selection stroke.
+
+The plugin identifies and labels features via the `id` feature property (`SHEET-PARCEL`). The land-grants API tiles only carry `sheet_id` and `parcel_id` (`parcel_id` alone is not unique across sheets), so the grants-ui tile proxy stamps the compound `id` onto every feature — `withCompoundParcelIds` in `mvt-compound-id.js` decodes each proxied tile, adds the property, and re-encodes it. Mock GeoJSON features already carry `id`. The plugin's UI styles (crosshair, listbox, action buttons) are bundled in the core `interactive-map.css` — no extra stylesheet is needed.
+
 ### Height
 
 Set height via CSS directly on the element. The component fills 100% of whatever dimensions it is given:
@@ -214,7 +228,7 @@ Returns the full GeoJSON `FeatureCollection` for mock mode. Reads features store
 
 ### `GET /api/map/parcel-tiles/{z}/{x}/{y}`
 
-Proxies MapLibre vector tile requests to the land-grants API. Fetches the current user's parcel IDs from `fetchParcels` (concurrent tile requests share one in-flight lookup per SBI) and sends them in the POST body so they are never exposed in the tile URL. Returns the protobuf tile buffer with `Cache-Control: private, max-age=3600` — `private` because tiles are per-user.
+Proxies MapLibre vector tile requests to the land-grants API. Fetches the current user's parcel IDs from `fetchParcels` (concurrent tile requests share one in-flight lookup per SBI) and sends them in the POST body so they are never exposed in the tile URL. Each tile is re-encoded on the way through (`withCompoundParcelIds`) to stamp the compound `id` property onto every feature — see the interact plugin section above. Returns the protobuf tile buffer with `Cache-Control: private, max-age=3600` — `private` because tiles are per-user.
 
 ### `GET /api/map/os-basemap`
 
@@ -255,7 +269,14 @@ The basemap is Ordnance Survey's **OS Maps API** (raster ZXY tiles), which requi
 
 ### Local setup
 
-Get a key from the [OS Data Hub](https://osdatahub.os.uk/) with the OS Maps API product added, then add it to `.env`:
+#### Generating a key on the OS Data Hub
+
+1. Go to [osdatahub.os.uk](https://osdatahub.os.uk/) and sign up (the free **OS OpenData plan** is enough — the OS Maps API is included in it).
+2. Once logged in, open **API Dashboard → API Projects** and click **Create a new project** (any name, e.g. `grants-ui-local`).
+3. In the project, click **Add API** and select **OS Maps API**.
+4. Copy the **Project API Key** shown on the project page.
+
+Then add it to `.env`:
 
 ```
 OS_MAPS_API_KEY=your-key-here

--- a/src/server/common/map/README.md
+++ b/src/server/common/map/README.md
@@ -84,7 +84,12 @@ pages:
       multiSelect: true
 ```
 
-`MapSelectPageController` reads `pageDef.config.multiSelect` in its constructor and passes it to the template and the component's `multi-select` attribute.
+#### Page `config` flags
+
+| Flag          | Type      | Default | Effect                                                                                                                                                                                                                                                                                                                        |
+| ------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `multiSelect` | `boolean` | `false` | Allow selecting more than one parcel — see above.                                                                                                                                                                                                                                                                             |
+| `devMode`     | `boolean` | `false` | TEMPORARY (TGC-1418 follow-up). Shows the OS Maps / OpenStreetMap comparison toggle and the performance metrics readout on this page. Leave unset (or `false`) on real user-facing journeys — it's a developer/stakeholder-comparison aid, not a feature for end users. Currently only `example-grant-with-map.yaml` sets it. |
 
 ---
 
@@ -111,8 +116,9 @@ Extends `QuestionPageController`. Renders `map-select-parcel.html`.
 | ------------------ | ----------------------------------------- | ------------------- | ---------------------------------------------- |
 | `multi-select`     | `"true"` / `"false"`                      | `"false"`           | Allow selecting more than one parcel at a time |
 | `basemap-provider` | `"ordnance-survey"` / `"openstreetmap"` † | `"ordnance-survey"` | Which basemap to render — see below            |
+| `basemap-metrics`  | `"true"` / `"false"` †                    | `"false"`           | Emit `parcel-map:basemap-metrics` — see below  |
 
-† `"openstreetmap"` is temporary, see below.
+† Both temporary, see below.
 
 **Single-select** — clicking a parcel selects it and deselects any previously selected one. Clicking the same parcel again deselects it.
 
@@ -124,14 +130,42 @@ Extends `QuestionPageController`. Renders `map-select-parcel.html`.
 
 ### Basemap providers
 
-> **TEMPORARY (TGC-1418 follow-up):** OpenStreetMap support exists only for a side-by-side comparison and is expected to be removed within weeks. Everything OpenStreetMap-specific is wrapped in a `TEMPORARY … END TEMPORARY` comment block — grep the repo for `TGC-1418` to find every piece to delete: the constants and `getMapStyle` branch in `config.js`/`index.js`, the CartoCDN CSP allowances in `content-security-policy.js`, and the toggle control + listener in `map-select-parcel.html`. See the OS Maps vs OpenStreetMap comparison report for why OS Maps is the recommended (and, after removal, only) provider.
+> **TEMPORARY (TGC-1418 follow-up):** OpenStreetMap support exists only for a side-by-side comparison and is expected to be removed within weeks. It is **opt-in per journey** via `devMode` in the page's YAML `config` block (same pattern as `multiSelect`) — journeys that don't set it get the toggle-free, metrics-free OS-only experience, so this only reaches real users on journeys that explicitly ask for it (currently just `example-grant-with-map.yaml`).
+>
+> Everything OpenStreetMap-specific is wrapped in a `TEMPORARY … END TEMPORARY` comment block — grep the repo for `TGC-1418` to find every piece to delete:
+>
+> - the `devMode` field in `map-select-page.controller.js` (and its tests)
+> - the `config: { devMode: true }` block in `example-grant-with-map.yaml`
+> - the constants and `getMapStyle`/label-font branches in `config.js`/`index.js`
+> - the CartoCDN CSP allowances in `content-security-policy.js`
+> - the toggle control, metrics panel, and their `{% if devMode %}`-gated listeners in `map-select-parcel.html`
+> - `basemap-metrics.js` and `basemap-metrics.test.js` in full, plus their one import/call site in `index.js`
+>
+> See the OS Maps vs OpenStreetMap comparison report for why OS Maps is the recommended (and, after removal, only) provider.
 
 Two basemap sources are currently supported, selected via the `basemap-provider` attribute (`getMapStyle` in `index.js` resolves the actual style/attribution for each):
 
 - **`"ordnance-survey"` (default)** — Ordnance Survey's raster basemap, served through the server-side proxy described below. Authoritative UK survey data, including farmland/parcel boundary detail that the alternative lacks.
-- **`"openstreetmap"`** — OpenStreetMap, via CartoCDN's hosted vector style (`https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json`). No server proxy — CartoCDN's tiles are public, so the browser fetches them directly. Requires the CartoCDN CSP allowances in `content-security-policy.js` (`connect-src`/`img-src`).
+- **`"openstreetmap"`** — OpenStreetMap, via CartoCDN's hosted vector style (`https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json`). No server proxy — CartoCDN's tiles are public, so the browser fetches them directly. Requires the CartoCDN CSP allowances in `content-security-policy.js` (`connect-src`/`img-src`). Its style also sets its own `glyphs` URL, so the parcel label layer switches to a font (`Open Sans Regular`) that CartoCDN's font server actually serves — `Arial Regular`, used for OS Maps, 404s against it.
 
 The [`map-select-parcel.html`](views/map-select-parcel.html) template wires a small GOV.UK radios control (`#basemap-provider-toggle`) to the attribute, for side-by-side comparison during development.
+
+#### Performance metrics (temporary)
+
+`basemap-metrics.js` times each basemap load and dispatches a `parcel-map:basemap-metrics` event that `map-select-parcel.html` renders as a small text readout next to the toggle:
+
+```js
+{
+  ;(provider, tileRequests, tileErrors, loadMs, firstTileMs, bytesTransferred)
+}
+```
+
+- **`loadMs`** — anchored on MapLibre's own `idle` event, fired once every pending tile/source has settled. A fairer finish line than first paint alone, since OS (raster, many small tiles) and OSM (vector, fewer larger tiles) have different loading shapes.
+- **`firstTileMs`** — time to the first `sourcedata` event carrying a tile, i.e. perceived speed — users see something on screen well before every last tile settles.
+- **`bytesTransferred`** — summed via `PerformanceObserver` on Resource Timing entries whose URL matches `/api/map/os-tiles`, `/api/map/os-basemap`, or `basemaps.cartocdn.com`, so only basemap-related requests count (not unrelated page assets). `transferSize` is `0` for cross-origin responses without `Timing-Allow-Origin` — CartoCDN doesn't send that header, so this reads as `0` for OSM rather than being silently wrong. Known limitation, not a bug.
+- **`tileRequests`/`tileErrors`** — counted from `sourcedata`/`error` events on the raw MapLibre instance.
+
+Both metrics tracking and the display panel only run when the page opts in — see `basemap-metrics` attribute below.
 
 ### Accessible selection (interact plugin)
 
@@ -181,7 +215,7 @@ The inline script in `map-select-parcel.html` is the canonical example of how to
 - On an `'unavailable'` error the component replaces the map with an inline "There was a problem loading the map." overlay (`role="alert"`).
 - On a `'no-parcels'` error it renders nothing — messaging is left to the page (`map-select-parcel.html` un-hides a GOV.UK error summary and disables the continue button).
 - The viewport is fitted to the parcels' bounding box on load; the map does not persist its viewport in the URL (`urlPosition: 'none'`).
-- Zoom-out is capped at `MAP_MIN_ZOOM` (7) — the OS basemap has no tiles below z7, so without the cap users could zoom out into a blank void.
+- Zoom-out is capped at `MAP_MIN_ZOOM` (7) — the OS raster basemap has no tiles below z7, so without the cap users could zoom out into a blank void. TEMPORARY (TGC-1418 follow-up): this cap is skipped when `basemap-provider="openstreetmap"`, since CartoCDN's vector style covers the full zoom range.
 
 ### Asset loading
 

--- a/src/server/common/map/README.md
+++ b/src/server/common/map/README.md
@@ -107,15 +107,31 @@ Extends `QuestionPageController`. Renders `map-select-parcel.html`.
 
 ### Attributes
 
-| Attribute      | Values               | Default   | Description                                    |
-| -------------- | -------------------- | --------- | ---------------------------------------------- |
-| `multi-select` | `"true"` / `"false"` | `"false"` | Allow selecting more than one parcel at a time |
+| Attribute          | Values                                    | Default             | Description                                    |
+| ------------------ | ----------------------------------------- | ------------------- | ---------------------------------------------- |
+| `multi-select`     | `"true"` / `"false"`                      | `"false"`           | Allow selecting more than one parcel at a time |
+| `basemap-provider` | `"ordnance-survey"` / `"openstreetmap"` † | `"ordnance-survey"` | Which basemap to render — see below            |
+
+† `"openstreetmap"` is temporary, see below.
 
 **Single-select** — clicking a parcel selects it and deselects any previously selected one. Clicking the same parcel again deselects it.
 
 **Multi-select** — clicking toggles each parcel independently. Multiple parcels can be selected simultaneously.
 
 `multi-select` is read once when the component connects — changing it afterwards has no effect (re-create the element to reconfigure).
+
+`basemap-provider` **does** support runtime changes: setting it after the component has connected tears the map down and re-initialises it with the new basemap, keeping the same parcel data (no re-fetch). Any in-progress parcel selection is lost on switch — this attribute exists for comparing the two basemaps, not as a saved user preference, and always starts on `"ordnance-survey"` regardless of what was previously selected.
+
+### Basemap providers
+
+> **TEMPORARY (TGC-1418 follow-up):** OpenStreetMap support exists only for a side-by-side comparison and is expected to be removed within weeks. Everything OpenStreetMap-specific is wrapped in a `TEMPORARY … END TEMPORARY` comment block — grep the repo for `TGC-1418` to find every piece to delete: the constants and `getMapStyle` branch in `config.js`/`index.js`, the CartoCDN CSP allowances in `content-security-policy.js`, and the toggle control + listener in `map-select-parcel.html`. See the OS Maps vs OpenStreetMap comparison report for why OS Maps is the recommended (and, after removal, only) provider.
+
+Two basemap sources are currently supported, selected via the `basemap-provider` attribute (`getMapStyle` in `index.js` resolves the actual style/attribution for each):
+
+- **`"ordnance-survey"` (default)** — Ordnance Survey's raster basemap, served through the server-side proxy described below. Authoritative UK survey data, including farmland/parcel boundary detail that the alternative lacks.
+- **`"openstreetmap"`** — OpenStreetMap, via CartoCDN's hosted vector style (`https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json`). No server proxy — CartoCDN's tiles are public, so the browser fetches them directly. Requires the CartoCDN CSP allowances in `content-security-policy.js` (`connect-src`/`img-src`).
+
+The [`map-select-parcel.html`](views/map-select-parcel.html) template wires a small GOV.UK radios control (`#basemap-provider-toggle`) to the attribute, for side-by-side comparison during development.
 
 ### Accessible selection (interact plugin)
 

--- a/src/server/common/map/README.md
+++ b/src/server/common/map/README.md
@@ -123,13 +123,13 @@ Selection is handled by the `@defra/interactive-map` **interact plugin**, not ra
 
 - **Pointer** — click a parcel
 - **Touch** — a crosshair with a "Select" action button
-- **Keyboard** — <kbd>Enter</kbd> selects at the crosshair target; <kbd>Tab</kbd> opens a listbox of parcels (labelled by compound parcel ID) navigable with arrow keys
+- **Keyboard** — <kbd>Enter</kbd> selects at the crosshair target; <kbd>Tab</kbd> opens a listbox of parcels navigable with arrow keys
 
-The plugin only matches polygons when the click is geometrically inside them, which makes small zoomed-out parcels effectively unselectable. The component wraps the MapLibre provider (`withParcelHitTolerance` in `index.js`) so that when the strict query misses, it falls back to a rendered-pixel query on the fill layer within `PARCEL_CLICK_TOLERANCE_PX` (10px) of the point — parcels stay selectable by pointer and keyboard crosshair at any zoom. The keyboard listbox is fully zoom-independent.
+The plugin only selects a polygon on an exact geometric hit, which is impractical for small zoomed-out parcels — the component adds a rendered-pixel fallback (see `withParcelHitTolerance` in `index.js`) so parcels stay selectable at any zoom, by pointer and by keyboard.
 
-The component listens to the plugin's `interact:selectionchange` event and re-dispatches it as `parcel-map:selection`, so page-level consumers are unaffected by the plugin internals. The fill-opacity highlight is applied by the component on top of the plugin's own selection stroke.
+The component listens to the plugin's selection events and re-dispatches them as `parcel-map:selection`, so page-level consumers are unaffected by the plugin internals.
 
-The plugin identifies and labels features via the `id` feature property (`SHEET-PARCEL`). The land-grants API tiles only carry `sheet_id` and `parcel_id` (`parcel_id` alone is not unique across sheets), so the grants-ui tile proxy stamps the compound `id` onto every feature — `withCompoundParcelIds` in `mvt-compound-id.js` decodes each proxied tile, adds the property, and re-encodes it. Mock GeoJSON features already carry `id`. The plugin's UI styles (crosshair, listbox, action buttons) are bundled in the core `interactive-map.css` — no extra stylesheet is needed.
+The plugin needs a single property that uniquely identifies each parcel feature. The land-grants API tiles don't provide one directly, so the grants-ui tile proxy adds it — see `withCompoundParcelIds` in `mvt-compound-id.js` for why and how.
 
 ### Height
 

--- a/src/server/common/map/map-select-page.controller.js
+++ b/src/server/common/map/map-select-page.controller.js
@@ -7,16 +7,22 @@ export default class MapSelectPageController extends withTaskContext(QuestionPag
   /** @type {boolean} */
   multiSelect = false
 
+  // TEMPORARY (TGC-1418 follow-up): OS Maps vs OpenStreetMap comparison —
+  // delete this field and its usages once the comparison is complete.
+  /** @type {boolean} */
+  devMode = false
+
   /**
    * @param {FormModel} model
    * @param {PageDef} pageDef
    */
   constructor(model, pageDef) {
     super(model, pageDef)
-    const pageConfig = /** @type {Record<string, unknown>} */ (
-      /** @type {{ config?: Record<string, unknown> }} */ (/** @type {unknown} */ (pageDef)).config ?? {}
-    )
-    this.multiSelect = Boolean(pageConfig.multiSelect)
+
+    const config = model.def.metadata?.pageConfig?.[pageDef.path] ?? {}
+
+    this.multiSelect = Boolean(config.multiSelect)
+    this.devMode = Boolean(config.devMode)
   }
 
   makeGetRouteHandler() {
@@ -38,6 +44,7 @@ export default class MapSelectPageController extends withTaskContext(QuestionPag
     return h.view(this.viewName, {
       ...super.getViewModel(request, context),
       multiSelect: this.multiSelect,
+      devMode: this.devMode,
       formAction: request.path
     })
   }
@@ -56,6 +63,7 @@ export default class MapSelectPageController extends withTaskContext(QuestionPag
       return h.view(this.viewName, {
         ...super.getViewModel(request, context),
         multiSelect: this.multiSelect,
+        devMode: this.devMode,
         selectedParcelIds: [],
         formAction: request.path,
         errors: this.multiSelect

--- a/src/server/common/map/map-select-page.controller.test.js
+++ b/src/server/common/map/map-select-page.controller.test.js
@@ -3,10 +3,14 @@ import { vi } from 'vitest'
 import MapSelectPageController from './map-select-page.controller.js'
 import { setupControllerMocks } from '~/src/__mocks__/controller-mocks.js'
 
-const mockModel = {}
+const PAGE_PATH = '/select-land-parcel'
 
-function makePageDef(config = {}) {
-  return { config }
+function makePageDef(path = PAGE_PATH) {
+  return { path }
+}
+
+function makeModel(config = {}) {
+  return { def: { metadata: { pageConfig: { [PAGE_PATH]: config } } } }
 }
 
 vi.mock('~/src/server/task-list/task-list.helper.js', async (importOriginal) => {
@@ -18,7 +22,7 @@ vi.mock('~/src/server/task-list/task-list.helper.js', async (importOriginal) => 
 })
 
 function makeController(config = {}) {
-  const controller = new MapSelectPageController(mockModel, makePageDef(config))
+  const controller = new MapSelectPageController(makeModel(config), makePageDef())
   setupControllerMocks(controller)
   controller.getViewModel = vi.fn().mockReturnValue({ pageTitle: 'Select a land parcel' })
   return controller
@@ -42,18 +46,35 @@ function makeH() {
 describe('MapSelectPageController', () => {
   describe('constructor', () => {
     it('defaults multiSelect to false', () => {
-      const controller = new MapSelectPageController(mockModel, makePageDef())
+      const controller = new MapSelectPageController(makeModel(), makePageDef())
       expect(controller.multiSelect).toBe(false)
     })
 
-    it('sets multiSelect true from pageDef.config', () => {
-      const controller = new MapSelectPageController(mockModel, makePageDef({ multiSelect: true }))
+    it('sets multiSelect true from model.def.metadata.pageConfig', () => {
+      const controller = new MapSelectPageController(makeModel({ multiSelect: true }), makePageDef())
       expect(controller.multiSelect).toBe(true)
     })
 
     it('sets multiSelect false when config.multiSelect is falsy', () => {
-      const controller = new MapSelectPageController(mockModel, makePageDef({ multiSelect: false }))
+      const controller = new MapSelectPageController(makeModel({ multiSelect: false }), makePageDef())
       expect(controller.multiSelect).toBe(false)
+    })
+
+    // TEMPORARY (TGC-1418 follow-up): remove these three tests along with
+    // devMode once the OS Maps vs OpenStreetMap comparison is complete.
+    it('defaults devMode to false', () => {
+      const controller = new MapSelectPageController(makeModel(), makePageDef())
+      expect(controller.devMode).toBe(false)
+    })
+
+    it('sets devMode true from model.def.metadata.pageConfig', () => {
+      const controller = new MapSelectPageController(makeModel({ devMode: true }), makePageDef())
+      expect(controller.devMode).toBe(true)
+    })
+
+    it('sets devMode false when config.devMode is falsy', () => {
+      const controller = new MapSelectPageController(makeModel({ devMode: false }), makePageDef())
+      expect(controller.devMode).toBe(false)
     })
   })
 
@@ -85,6 +106,35 @@ describe('MapSelectPageController', () => {
         'map-select-parcel',
         expect.objectContaining({
           multiSelect: true
+        })
+      )
+    })
+
+    // TEMPORARY (TGC-1418 follow-up): remove once the comparison is complete.
+    it('passes devMode: false by default', async () => {
+      const controller = makeController()
+      const h = makeH()
+
+      await controller.handleGet(makeRequest(), makeContext(), h)
+
+      expect(h.view).toHaveBeenCalledWith(
+        'map-select-parcel',
+        expect.objectContaining({
+          devMode: false
+        })
+      )
+    })
+
+    it('passes devMode: true when configured', async () => {
+      const controller = makeController({ devMode: true })
+      const h = makeH()
+
+      await controller.handleGet(makeRequest(), makeContext(), h)
+
+      expect(h.view).toHaveBeenCalledWith(
+        'map-select-parcel',
+        expect.objectContaining({
+          devMode: true
         })
       )
     })
@@ -128,6 +178,21 @@ describe('MapSelectPageController', () => {
 
       expect(h.view).toHaveBeenCalled()
       expect(controller.setState).not.toHaveBeenCalled()
+    })
+
+    // TEMPORARY (TGC-1418 follow-up): remove once the comparison is complete.
+    it('re-renders with devMode carried through on validation error', async () => {
+      const controller = makeController({ devMode: true })
+      const h = makeH()
+
+      await controller.handlePost(makeRequest({}), makeContext(), h)
+
+      expect(h.view).toHaveBeenCalledWith(
+        'map-select-parcel',
+        expect.objectContaining({
+          devMode: true
+        })
+      )
     })
   })
 

--- a/src/server/common/map/map.plugin.js
+++ b/src/server/common/map/map.plugin.js
@@ -67,9 +67,6 @@ function publicOrigin(request) {
  * @returns {Promise<Response | null>}
  */
 async function fetchUpstream(url, service, request, init) {
-  // Logging happens outside the catch — the grants-ui/try-catch-allowed-functions
-  // lint rule forbids log calls inside catch blocks.
-  /** @type {unknown} */
   let fetchError
   try {
     return await fetch(url, init)
@@ -78,7 +75,6 @@ async function fetchUpstream(url, service, request, init) {
   }
   logUpstreamError(
     {
-      // Strip the query string — OS Maps URLs carry the API key in it
       endpoint: stripQueryString(url),
       service,
       upstreamStatus: null,
@@ -182,10 +178,9 @@ function mockGeojsonHandler(request, h) {
  */
 async function tilesHandler(request, h) {
   const { z, x, y } = request.params
-  /** @type {HydratedParcel[]} */
   let parcels = []
-  /** @type {unknown} */
   let parcelsError
+
   try {
     parcels = /** @type {HydratedParcel[]} */ (
       await fetchParcels(/** @type {AnyFormRequest} */ (/** @type {unknown} */ (request)))
@@ -251,8 +246,6 @@ function osBasemapHandler(request, h) {
     sources: {
       'os-raster': {
         type: 'raster',
-        // The route path doubles as the MapLibre tile URL template — {z}/{x}/{y}
-        // are filled in by MapLibre, and the layer is fixed server-side.
         tiles: [`${origin}${ROUTES.osTiles}`],
         tileSize: OS_TILE_SIZE_PX,
         minzoom: OS_MIN_ZOOM,
@@ -287,8 +280,6 @@ async function osTileProxyHandler(request, h) {
     return h.response().code(statusCodes.serviceUnavailable)
   }
   if (!response.ok) {
-    // Surface non-OK upstream statuses — a 401 here is the signature of a key
-    // without the "OS Maps API" product added to its Data Hub project.
     logUpstreamError(
       {
         endpoint: stripQueryString(upstream),

--- a/src/server/common/map/map.plugin.js
+++ b/src/server/common/map/map.plugin.js
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream'
 import Joi from 'joi'
 import { config } from '~/src/config/config.js'
 import { createApiHeadersForLandGrantsBackend } from '~/src/server/common/helpers/auth/backend-auth-helper.js'
@@ -300,15 +301,18 @@ async function osTileProxyHandler(request, h) {
     return h.response().code(response.status)
   }
 
-  const buffer = await response.arrayBuffer()
-  return (
-    h
-      .response(Buffer.from(buffer))
-      .code(statusCodes.ok)
-      .type(response.headers.get('content-type') ?? 'image/png')
-      // public — OS basemap tiles are identical for every user
-      .header(CACHE_CONTROL_HEADER, `public, max-age=${TILE_CACHE_MAX_AGE_SECONDS}`)
-  )
+  // Stream the tile straight through instead of buffering it whole first.
+  const contentLength = response.headers.get('content-length')
+  let tileResponse = h
+    .response(Readable.fromWeb(/** @type {import('stream/web').ReadableStream} */ (response.body)))
+    .code(statusCodes.ok)
+    .type(response.headers.get('content-type') ?? 'image/png')
+    // public — OS basemap tiles are identical for every user
+    .header(CACHE_CONTROL_HEADER, `public, max-age=${TILE_CACHE_MAX_AGE_SECONDS}`)
+  if (contentLength) {
+    tileResponse = tileResponse.bytes(Number(contentLength))
+  }
+  return tileResponse
 }
 
 const ROUTES = {

--- a/src/server/common/map/map.plugin.js
+++ b/src/server/common/map/map.plugin.js
@@ -5,6 +5,7 @@ import { fetchParcels, fetchParcelTileLocation } from '~/src/server/land-grants/
 import { stringifyParcel } from '~/src/server/land-grants/utils/format-parcel.js'
 import { statusCodes } from '~/src/server/common/constants/status-codes.js'
 import { isMockData, buildMockFeatures } from './map.mock.js'
+import { withCompoundParcelIds } from './mvt-compound-id.js'
 import { logUpstreamError } from '~/src/server/common/helpers/logging/upstream-error.js'
 
 const LAND_GRANTS_API_URL = config.get('landGrants.grantsServiceApiEndpoint')
@@ -224,7 +225,7 @@ async function tilesHandler(request, h) {
   const buffer = await response.arrayBuffer()
   return (
     h
-      .response(Buffer.from(buffer))
+      .response(withCompoundParcelIds(Buffer.from(buffer)))
       .code(statusCodes.ok)
       .type('application/x-protobuf')
       // private — tiles are per-user (session-authed), so only the browser may cache them

--- a/src/server/common/map/map.plugin.test.js
+++ b/src/server/common/map/map.plugin.test.js
@@ -72,7 +72,8 @@ function makeH() {
   const responseObj = {
     code: vi.fn().mockReturnThis(),
     type: vi.fn().mockReturnThis(),
-    header: vi.fn().mockReturnThis()
+    header: vi.fn().mockReturnThis(),
+    bytes: vi.fn().mockReturnThis()
   }
   return {
     response: vi.fn().mockReturnValue(responseObj),
@@ -448,11 +449,16 @@ describe('mapPlugin', () => {
       expect(schema.validate({ z: 'abc', x: 0, y: 0 }).error).toBeDefined()
     })
 
+    function mockOsTileHeaders(overrides = {}) {
+      const values = { 'content-type': 'image/png', 'content-length': '1024', ...overrides }
+      return { get: vi.fn((key) => values[key] ?? null) }
+    }
+
     it('proxies to the OS raster endpoint with the server-side layer and key', async () => {
       global.fetch.mockResolvedValue({
         ok: true,
-        headers: { get: vi.fn().mockReturnValue('image/png') },
-        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(4))
+        headers: mockOsTileHeaders(),
+        body: new ReadableStream()
       })
       const request = makeOsRequest({ z: '12', x: '100', y: '200' })
       const h = makeH()
@@ -467,11 +473,39 @@ describe('mapPlugin', () => {
       expect(h._responseObj.code).toHaveBeenCalledWith(200)
     })
 
+    it('forwards Content-Length so streamed tiles are not chunked (needed for Resource Timing transferSize)', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        headers: mockOsTileHeaders({ 'content-length': '2048' }),
+        body: new ReadableStream()
+      })
+      const request = makeOsRequest({ z: '12', x: '100', y: '200' })
+      const h = makeH()
+
+      await osTilesHandler(request, h)
+
+      expect(h._responseObj.bytes).toHaveBeenCalledWith(2048)
+    })
+
+    it('does not call bytes() when upstream sends no Content-Length', async () => {
+      global.fetch.mockResolvedValue({
+        ok: true,
+        headers: mockOsTileHeaders({ 'content-length': undefined }),
+        body: new ReadableStream()
+      })
+      const request = makeOsRequest({ z: '12', x: '100', y: '200' })
+      const h = makeH()
+
+      await osTilesHandler(request, h)
+
+      expect(h._responseObj.bytes).not.toHaveBeenCalled()
+    })
+
     it('marks tiles as publicly cacheable (same for every user)', async () => {
       global.fetch.mockResolvedValue({
         ok: true,
-        headers: { get: vi.fn().mockReturnValue('image/png') },
-        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0))
+        headers: mockOsTileHeaders(),
+        body: new ReadableStream()
       })
       const request = makeOsRequest({ z: '7', x: '62', y: '40' })
       const h = makeH()

--- a/src/server/common/map/mvt-compound-id.js
+++ b/src/server/common/map/mvt-compound-id.js
@@ -2,26 +2,19 @@ import { PbfReader } from 'pbf'
 import { VectorTile } from '@mapbox/vector-tile'
 // @ts-ignore — no type declarations shipped with this package
 import vtpbf from 'vt-pbf'
+import { stringifyParcel } from '~/src/server/land-grants/utils/format-parcel.js'
+import { log, LogCodes } from '~/src/server/common/helpers/logging/log.js'
 
 /**
  * Adds an `id` property like "SD7148-9160" to every parcel in a map tile.
  *
- * Why: the map's selection plugin needs ONE property that uniquely identifies
- * each parcel — it uses it to know which parcel you clicked, to draw the
- * highlight ring, and to label parcels in the keyboard menu. The tiles from
- * the land-grants API only carry `sheet_id` ("SD7148") and `parcel_id`
- * ("9160") as two separate properties, and neither is unique on its own
- * (parcel numbers repeat across sheets). The obvious fix would be for the
- * API to add the combined ID to its tiles, but we don't own that service —
- * so we do it here instead, as the tile passes through our proxy.
+ * The map's selection plugin needs one property that uniquely identifies each
+ * parcel, but the land-grants API tiles only carry `sheet_id` and `parcel_id`
+ * separately — and `parcel_id` alone repeats across sheets. We don't own that
+ * API, so we stamp the combined ID on here as the tile passes through our proxy.
  *
- * How: a map tile is a compressed binary file (protobuf). We unpack it, loop
- * over the parcels, add `id` = sheet_id + "-" + parcel_id to each one, and
- * pack it back up. The shapes themselves are copied through untouched.
- *
- * If anything about the tile is unexpected (empty, unparseable, no parcels
- * layer) we return it exactly as we received it — the map still draws, and
- * only selection would be affected.
+ * Any unexpected tile (empty, unparseable, no parcels layer) is returned
+ * unchanged — the map still draws, only selection is affected.
  * @param {Buffer} buffer  raw tile bytes from the land-grants API
  * @param {string} [layerName]
  * @returns {Buffer} the same tile with `id` stamped on every parcel
@@ -30,10 +23,15 @@ export function withCompoundParcelIds(buffer, layerName = 'parcels') {
   if (buffer.length === 0) {
     return buffer
   }
+
+  /** @type {unknown} */
+  let transformError
+  /** @type {Buffer | undefined} */
+  let transformed
   try {
     const tile = new VectorTile(new PbfReader(buffer))
     const layer = tile.layers[layerName]
-    if (!layer) {
+    if (!layer || layer.length === 0) {
       return buffer
     }
 
@@ -45,7 +43,7 @@ export function withCompoundParcelIds(buffer, layerName = 'parcels') {
       const feature = layer.feature(i)
       const { sheet_id: sheetId, parcel_id: parcelId } = feature.properties
       if (sheetId != null && parcelId != null) {
-        feature.properties.id = `${sheetId}-${parcelId}`
+        feature.properties.id = stringifyParcel({ sheetId: String(sheetId), parcelId: String(parcelId) })
       }
       features.push(feature)
     }
@@ -58,10 +56,18 @@ export function withCompoundParcelIds(buffer, layerName = 'parcels') {
       feature: (/** @type {number} */ i) => features[i]
     }
 
-    return Buffer.from(vtpbf.fromVectorTileJs({ layers: { [layerName]: cachedLayer } }))
-  } catch {
-    // A malformed tile is the upstream's bug — pass it through unchanged so
-    // the map still renders; selection simply won't match those features.
+    transformed = Buffer.from(vtpbf.fromVectorTileJs({ layers: { [layerName]: cachedLayer } }))
+  } catch (error) {
+    transformError = error
+  }
+
+  if (transformError !== undefined) {
+    // A malformed tile, or a shape mismatch between the pbf/vt-pbf versions in
+    // use, means the map still renders but selection silently stops matching
+    // features — log it so that isn't invisible in production.
+    log(LogCodes.SYSTEM.GENERIC_ERROR, { errorMessage: /** @type {Error} */ (transformError).message })
     return buffer
   }
+
+  return transformed ?? buffer
 }

--- a/src/server/common/map/mvt-compound-id.js
+++ b/src/server/common/map/mvt-compound-id.js
@@ -35,9 +35,6 @@ export function withCompoundParcelIds(buffer, layerName = 'parcels') {
       return buffer
     }
 
-    // Parse each feature once and cache it — vt-pbf reads `properties` and
-    // `loadGeometry()` from whatever `feature(i)` returns, so mutations on
-    // cached instances survive serialisation.
     const features = []
     for (let i = 0; i < layer.length; i++) {
       const feature = layer.feature(i)

--- a/src/server/common/map/mvt-compound-id.js
+++ b/src/server/common/map/mvt-compound-id.js
@@ -1,0 +1,67 @@
+import { PbfReader } from 'pbf'
+import { VectorTile } from '@mapbox/vector-tile'
+// @ts-ignore — no type declarations shipped with this package
+import vtpbf from 'vt-pbf'
+
+/**
+ * Adds an `id` property like "SD7148-9160" to every parcel in a map tile.
+ *
+ * Why: the map's selection plugin needs ONE property that uniquely identifies
+ * each parcel — it uses it to know which parcel you clicked, to draw the
+ * highlight ring, and to label parcels in the keyboard menu. The tiles from
+ * the land-grants API only carry `sheet_id` ("SD7148") and `parcel_id`
+ * ("9160") as two separate properties, and neither is unique on its own
+ * (parcel numbers repeat across sheets). The obvious fix would be for the
+ * API to add the combined ID to its tiles, but we don't own that service —
+ * so we do it here instead, as the tile passes through our proxy.
+ *
+ * How: a map tile is a compressed binary file (protobuf). We unpack it, loop
+ * over the parcels, add `id` = sheet_id + "-" + parcel_id to each one, and
+ * pack it back up. The shapes themselves are copied through untouched.
+ *
+ * If anything about the tile is unexpected (empty, unparseable, no parcels
+ * layer) we return it exactly as we received it — the map still draws, and
+ * only selection would be affected.
+ * @param {Buffer} buffer  raw tile bytes from the land-grants API
+ * @param {string} [layerName]
+ * @returns {Buffer} the same tile with `id` stamped on every parcel
+ */
+export function withCompoundParcelIds(buffer, layerName = 'parcels') {
+  if (buffer.length === 0) {
+    return buffer
+  }
+  try {
+    const tile = new VectorTile(new PbfReader(buffer))
+    const layer = tile.layers[layerName]
+    if (!layer) {
+      return buffer
+    }
+
+    // Parse each feature once and cache it — vt-pbf reads `properties` and
+    // `loadGeometry()` from whatever `feature(i)` returns, so mutations on
+    // cached instances survive serialisation.
+    const features = []
+    for (let i = 0; i < layer.length; i++) {
+      const feature = layer.feature(i)
+      const { sheet_id: sheetId, parcel_id: parcelId } = feature.properties
+      if (sheetId != null && parcelId != null) {
+        feature.properties.id = `${sheetId}-${parcelId}`
+      }
+      features.push(feature)
+    }
+
+    const cachedLayer = {
+      version: layer.version,
+      name: layer.name,
+      extent: layer.extent,
+      length: features.length,
+      feature: (/** @type {number} */ i) => features[i]
+    }
+
+    return Buffer.from(vtpbf.fromVectorTileJs({ layers: { [layerName]: cachedLayer } }))
+  } catch {
+    // A malformed tile is the upstream's bug — pass it through unchanged so
+    // the map still renders; selection simply won't match those features.
+    return buffer
+  }
+}

--- a/src/server/common/map/mvt-compound-id.test.js
+++ b/src/server/common/map/mvt-compound-id.test.js
@@ -1,0 +1,96 @@
+import { PbfReader } from 'pbf'
+import { VectorTile } from '@mapbox/vector-tile'
+import vtpbf from 'vt-pbf'
+import { withCompoundParcelIds } from './mvt-compound-id.js'
+
+// Minimal vector-tile-js-compatible feature: vt-pbf reads `properties`,
+// `type` (1=point, 2=line, 3=polygon) and `loadGeometry()` (tile coords).
+function makeFeature(properties) {
+  return {
+    properties,
+    type: 3,
+    loadGeometry: () => [
+      [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 },
+        { x: 0, y: 0 }
+      ]
+    ]
+  }
+}
+
+function makeTileBuffer(features, layerName = 'parcels') {
+  const layer = {
+    version: 2,
+    name: layerName,
+    extent: 4096,
+    length: features.length,
+    feature: (i) => features[i]
+  }
+  return Buffer.from(vtpbf.fromVectorTileJs({ layers: { [layerName]: layer } }))
+}
+
+function decode(buffer) {
+  return new VectorTile(new PbfReader(buffer))
+}
+
+describe('withCompoundParcelIds', () => {
+  it('adds the compound id property to every parcel feature', () => {
+    const buffer = makeTileBuffer([
+      makeFeature({ sheet_id: 'SD7148', parcel_id: '9160' }),
+      makeFeature({ sheet_id: 'SD7149', parcel_id: '0001' })
+    ])
+
+    const layer = decode(withCompoundParcelIds(buffer)).layers.parcels
+
+    expect(layer.length).toBe(2)
+    expect(layer.feature(0).properties.id).toBe('SD7148-9160')
+    expect(layer.feature(1).properties.id).toBe('SD7149-0001')
+  })
+
+  it('preserves the original properties and geometry', () => {
+    const buffer = makeTileBuffer([makeFeature({ sheet_id: 'SD7148', parcel_id: '9160' })])
+
+    const feature = decode(withCompoundParcelIds(buffer)).layers.parcels.feature(0)
+
+    expect(feature.properties.sheet_id).toBe('SD7148')
+    expect(feature.properties.parcel_id).toBe('9160')
+    expect(feature.loadGeometry()).toEqual([
+      [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 },
+        { x: 0, y: 0 }
+      ]
+    ])
+  })
+
+  it('skips features missing sheet_id or parcel_id', () => {
+    const buffer = makeTileBuffer([makeFeature({ parcel_id: '9160' })])
+
+    const feature = decode(withCompoundParcelIds(buffer)).layers.parcels.feature(0)
+
+    expect(feature.properties.id).toBeUndefined()
+  })
+
+  it('returns the buffer unchanged when the parcels layer is absent', () => {
+    const buffer = makeTileBuffer([makeFeature({ sheet_id: 'SD7148', parcel_id: '9160' })], 'other-layer')
+
+    expect(withCompoundParcelIds(buffer)).toBe(buffer)
+  })
+
+  it('returns an empty buffer unchanged', () => {
+    const buffer = Buffer.alloc(0)
+
+    expect(withCompoundParcelIds(buffer)).toBe(buffer)
+  })
+
+  it('returns the original buffer when the tile cannot be parsed', () => {
+    const garbage = Buffer.from([0xff, 0xff, 0xff, 0xff])
+
+    expect(withCompoundParcelIds(garbage)).toBe(garbage)
+  })
+})

--- a/src/server/common/map/views/map-select-parcel.html
+++ b/src/server/common/map/views/map-select-parcel.html
@@ -38,8 +38,12 @@
       </noscript>
 
       {# TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up).
-         Delete this block and the "change" listener + basemap-provider
-         attribute below once the comparison is complete. #}
+         Gated on devMode (page config in the journey YAML) so
+         it only appears on journeys explicitly opted in for the comparison.
+         Delete this block, the basemap-provider attribute default below, and
+         the "change" listener + metrics listener in {% block bodyEnd %} once
+         the comparison is complete. #}
+      {% if devMode %}
       <div id="basemap-provider-toggle">
         {{ govukRadios({
           idPrefix: "basemap-provider",
@@ -56,7 +60,9 @@
             { value: "openstreetmap", text: "OpenStreetMap" }
           ]
         }) }}
+        <p id="basemap-metrics" class="govuk-body-s" aria-live="polite" style="margin-top:-10px;color:#505a5f"></p>
       </div>
+      {% endif %}
       {# END TEMPORARY #}
 
       <form method="post" action="{{ formAction }}" id="parcel-select-form">
@@ -66,6 +72,7 @@
           id="parcel-map"
           multi-select="{{ 'true' if multiSelect else 'false' }}"
           basemap-provider="ordnance-survey"
+          basemap-metrics="{{ 'true' if devMode else 'false' }}"
           aria-label="Land parcel selection map"
           style="display:block;width:100%;height:500px;position:relative"
         >
@@ -104,6 +111,7 @@
       var mapEl = document.getElementById('parcel-map');
       var multiSelect = mapEl.getAttribute('multi-select') === 'true';
 
+      {% if devMode %}
       // TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up).
       // Delete this block once the comparison is complete.
       var toggle = document.getElementById('basemap-provider-toggle');
@@ -114,6 +122,21 @@
           }
         });
       }
+
+      var metricsLabel = { 'ordnance-survey': 'OS Maps', openstreetmap: 'OpenStreetMap' };
+      var metricsEl = document.getElementById('basemap-metrics');
+      mapEl.addEventListener('parcel-map:basemap-metrics', function (e) {
+        if (!metricsEl) { return; }
+        var m = e.detail;
+        var parts = [metricsLabel[m.provider] || m.provider];
+        if (m.firstTileMs !== null) { parts.push(m.firstTileMs + 'ms to first tile'); }
+        parts.push(m.loadMs === null ? 'loading…' : m.loadMs + 'ms to idle');
+        parts.push(m.tileRequests + ' tile' + (m.tileRequests === 1 ? '' : 's'));
+        if (m.bytesTransferred > 0) { parts.push(Math.round(m.bytesTransferred / 1024) + 'KB'); }
+        if (m.tileErrors > 0) { parts.push(m.tileErrors + ' error' + (m.tileErrors === 1 ? '' : 's')); }
+        metricsEl.textContent = parts.join(' · ');
+      });
+      {% endif %}
       // END TEMPORARY
 
       mapEl.addEventListener('parcel-map:ready', function () {

--- a/src/server/common/map/views/map-select-parcel.html
+++ b/src/server/common/map/views/map-select-parcel.html
@@ -115,16 +115,17 @@
       // TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up).
       // Delete this block once the comparison is complete.
       var toggle = document.getElementById('basemap-provider-toggle');
+      var metricsEl = document.getElementById('basemap-metrics');
       if (toggle) {
         toggle.addEventListener('change', function (e) {
           if (e.target && e.target.name === 'basemapProviderDisplay') {
+            if (metricsEl) { metricsEl.textContent = ''; }
             mapEl.setAttribute('basemap-provider', e.target.value);
           }
         });
       }
 
       var metricsLabel = { 'ordnance-survey': 'OS Maps', openstreetmap: 'OpenStreetMap' };
-      var metricsEl = document.getElementById('basemap-metrics');
       mapEl.addEventListener('parcel-map:basemap-metrics', function (e) {
         if (!metricsEl) { return; }
         var m = e.detail;
@@ -132,7 +133,11 @@
         if (m.firstTileMs !== null) { parts.push(m.firstTileMs + 'ms to first tile'); }
         parts.push(m.loadMs === null ? 'loading…' : m.loadMs + 'ms to idle');
         parts.push(m.tileRequests + ' tile' + (m.tileRequests === 1 ? '' : 's'));
-        if (m.bytesTransferred > 0) { parts.push(Math.round(m.bytesTransferred / 1024) + 'KB'); }
+        if (m.bytesTransferred > 0) {
+          parts.push(Math.round(m.bytesTransferred / 1024) + 'KB');
+        } else if (m.loadMs !== null) {
+          parts.push('size not measurable');
+        }
         if (m.tileErrors > 0) { parts.push(m.tileErrors + ' error' + (m.tileErrors === 1 ? '' : 's')); }
         metricsEl.textContent = parts.join(' · ');
       });

--- a/src/server/common/map/views/map-select-parcel.html
+++ b/src/server/common/map/views/map-select-parcel.html
@@ -2,6 +2,7 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block content %}
 <div class="govuk-body">
@@ -36,12 +37,35 @@
         <p class="govuk-body">The interactive map requires JavaScript to be enabled in your browser.</p>
       </noscript>
 
+      {# TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up).
+         Delete this block and the "change" listener + basemap-provider
+         attribute below once the comparison is complete. #}
+      <div id="basemap-provider-toggle">
+        {{ govukRadios({
+          idPrefix: "basemap-provider",
+          name: "basemapProviderDisplay",
+          classes: "govuk-radios--inline govuk-radios--medium",
+          fieldset: {
+            legend: {
+              text: "Basemap",
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            { value: "ordnance-survey", text: "OS Maps", checked: true },
+            { value: "openstreetmap", text: "OpenStreetMap" }
+          ]
+        }) }}
+      </div>
+      {# END TEMPORARY #}
+
       <form method="post" action="{{ formAction }}" id="parcel-select-form">
         <input type="hidden" name="crumb" value="{{ crumb }}">
 
         <parcel-map
           id="parcel-map"
           multi-select="{{ 'true' if multiSelect else 'false' }}"
+          basemap-provider="ordnance-survey"
           aria-label="Land parcel selection map"
           style="display:block;width:100%;height:500px;position:relative"
         >
@@ -79,6 +103,18 @@
     (function () {
       var mapEl = document.getElementById('parcel-map');
       var multiSelect = mapEl.getAttribute('multi-select') === 'true';
+
+      // TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up).
+      // Delete this block once the comparison is complete.
+      var toggle = document.getElementById('basemap-provider-toggle');
+      if (toggle) {
+        toggle.addEventListener('change', function (e) {
+          if (e.target && e.target.name === 'basemapProviderDisplay') {
+            mapEl.setAttribute('basemap-provider', e.target.value);
+          }
+        });
+      }
+      // END TEMPORARY
 
       mapEl.addEventListener('parcel-map:ready', function () {
         var hint = document.getElementById('map-hint');


### PR DESCRIPTION
Summary

- Migrate parcel selection from hand-rolled MapLibre click handlers to @defra/interactive-map's interact plugin, giving pointer, touch (crosshair), and keyboard (listbox) users a consistent, accessible way to select parcels
- Add an OpenStreetMap basemap option alongside OS Maps, toggleable per-journey via a devMode page-config flag, for side-by-side comparison during the OS Maps vs OpenStreetMap evaluation
- Add basemap performance metrics (loadMs, firstTileMs, tileRequests, tileErrors, bytesTransferred) surfaced in a dev-only readout, gated behind the same devMode flag