### PR TITLE
TGC-1490 - Mock parcels displaying wrong parcelId / data on tooltip

### DIFF
--- a/src/server/common/map/map.mock.js
+++ b/src/server/common/map/map.mock.js
@@ -5642,44 +5642,23 @@ function mockBbox() {
 }
 
 /**
- * Returns a copy of a geometry translated east by `dLng` degrees.
- * @param {{ type: 'Polygon' | 'MultiPolygon', coordinates: unknown }} geometry
- * @param {number} dLng
- * @returns {{ type: 'Polygon' | 'MultiPolygon', coordinates: unknown }}
- */
-function shiftGeometry(geometry, dLng) {
-  /** @param {unknown} coords @returns {unknown} */
-  const shift = (coords) => {
-    const arr = /** @type {unknown[]} */ (coords)
-    return typeof arr[0] === 'number' ? [/** @type {number} */ (arr[0]) + dLng, arr[1]] : arr.map(shift)
-  }
-  return { type: geometry.type, coordinates: shift(geometry.coordinates) }
-}
-
-/**
  * @param {{ id: string, sheetId: string, parcelId: string, areaHa: number | null }[]} parcels
  * @returns {{ features: import('./types.js').ParcelFeature[], bbox: { minLng: number, minLat: number, maxLng: number, maxLat: number } }}
  */
 export function buildMockFeatures(parcels) {
-  const bbox = mockBbox()
-  // An account can hold more parcels than there are embedded shapes. Each
-  // repeat of the round-robin ("lap") is shifted east by a full bbox width so
-  // no two parcels ever share a footprint — stacked identical shapes made the
-  // rendered label and the clicked feature disagree on which parcel it was.
-  const lapWidth = (bbox.maxLng - bbox.minLng) * 1.05
-  const features = parcels.map((p, i) => {
-    const idx = i % MOCK_GEOMETRIES.length
-    const lap = Math.floor(i / MOCK_GEOMETRIES.length)
-    const geometry = lap === 0 ? MOCK_GEOMETRIES[idx] : shiftGeometry(MOCK_GEOMETRIES[idx], lap * lapWidth)
+  // An account can hold more parcels than there are embedded shapes (some
+  // local test accounts have 50+). Parcels beyond the limit are not rendered:
+  // reusing a shape stacked two parcels on one footprint, so the rendered
+  // label and the clicked feature disagreed on which parcel it was.
+  const features = parcels.slice(0, MOCK_GEOMETRIES.length).map((p, i) => {
     return /** @type {import('./types.js').ParcelFeature} */ ({
       type: 'Feature',
       id: p.id,
-      geometry,
-      // Real area when the size API supplied one; the shape's own area only
-      // as a fallback, so the tooltip matches what the rest of the journey shows.
-      properties: { id: p.id, sheet_id: p.sheetId, parcel_id: p.parcelId, areaHa: p.areaHa ?? MOCK_AREAS[idx] }
+      geometry: MOCK_GEOMETRIES[i],
+      // Real area when the size API supplied one, so the tooltip matches what
+      // the rest of the journey shows; the shape's own area only as a fallback.
+      properties: { id: p.id, sheet_id: p.sheetId, parcel_id: p.parcelId, areaHa: p.areaHa ?? MOCK_AREAS[i] }
     })
   })
-  const laps = Math.max(1, Math.ceil(parcels.length / MOCK_GEOMETRIES.length))
-  return { features, bbox: { ...bbox, maxLng: bbox.maxLng + (laps - 1) * lapWidth } }
+  return { features, bbox: mockBbox() }
 }

--- a/src/server/common/map/map.mock.js
+++ b/src/server/common/map/map.mock.js
@@ -5642,18 +5642,44 @@ function mockBbox() {
 }
 
 /**
+ * Returns a copy of a geometry translated east by `dLng` degrees.
+ * @param {{ type: 'Polygon' | 'MultiPolygon', coordinates: unknown }} geometry
+ * @param {number} dLng
+ * @returns {{ type: 'Polygon' | 'MultiPolygon', coordinates: unknown }}
+ */
+function shiftGeometry(geometry, dLng) {
+  /** @param {unknown} coords @returns {unknown} */
+  const shift = (coords) => {
+    const arr = /** @type {unknown[]} */ (coords)
+    return typeof arr[0] === 'number' ? [/** @type {number} */ (arr[0]) + dLng, arr[1]] : arr.map(shift)
+  }
+  return { type: geometry.type, coordinates: shift(geometry.coordinates) }
+}
+
+/**
  * @param {{ id: string, sheetId: string, parcelId: string, areaHa: number | null }[]} parcels
  * @returns {{ features: import('./types.js').ParcelFeature[], bbox: { minLng: number, minLat: number, maxLng: number, maxLat: number } }}
  */
 export function buildMockFeatures(parcels) {
+  const bbox = mockBbox()
+  // An account can hold more parcels than there are embedded shapes. Each
+  // repeat of the round-robin ("lap") is shifted east by a full bbox width so
+  // no two parcels ever share a footprint — stacked identical shapes made the
+  // rendered label and the clicked feature disagree on which parcel it was.
+  const lapWidth = (bbox.maxLng - bbox.minLng) * 1.05
   const features = parcels.map((p, i) => {
     const idx = i % MOCK_GEOMETRIES.length
+    const lap = Math.floor(i / MOCK_GEOMETRIES.length)
+    const geometry = lap === 0 ? MOCK_GEOMETRIES[idx] : shiftGeometry(MOCK_GEOMETRIES[idx], lap * lapWidth)
     return /** @type {import('./types.js').ParcelFeature} */ ({
       type: 'Feature',
       id: p.id,
-      geometry: MOCK_GEOMETRIES[idx],
-      properties: { id: p.id, sheet_id: p.sheetId, parcel_id: p.parcelId, areaHa: MOCK_AREAS[idx] }
+      geometry,
+      // Real area when the size API supplied one; the shape's own area only
+      // as a fallback, so the tooltip matches what the rest of the journey shows.
+      properties: { id: p.id, sheet_id: p.sheetId, parcel_id: p.parcelId, areaHa: p.areaHa ?? MOCK_AREAS[idx] }
     })
   })
-  return { features, bbox: mockBbox() }
+  const laps = Math.max(1, Math.ceil(parcels.length / MOCK_GEOMETRIES.length))
+  return { features, bbox: { ...bbox, maxLng: bbox.maxLng + (laps - 1) * lapWidth } }
 }

--- a/src/server/common/map/map.mock.test.js
+++ b/src/server/common/map/map.mock.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildMockFeatures } from './map.mock.js'
+
+vi.mock('~/src/config/config.js', () => ({ config: { get: vi.fn() } }))
+
+const makeParcels = (n) =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `SD0000-${i}`,
+    sheetId: 'SD0000',
+    parcelId: String(i),
+    areaHa: null
+  }))
+
+describe('buildMockFeatures', () => {
+  it('keeps parcel identity on each feature', () => {
+    const { features } = buildMockFeatures([{ id: 'SD1234-5678', sheetId: 'SD1234', parcelId: '5678', areaHa: null }])
+    expect(features).toHaveLength(1)
+    expect(features[0].id).toBe('SD1234-5678')
+    expect(features[0].properties).toMatchObject({ id: 'SD1234-5678', sheet_id: 'SD1234', parcel_id: '5678' })
+    expect(features[0].geometry).toBeDefined()
+  })
+
+  it('never renders two parcels on the same footprint, dropping parcels beyond the shape limit', () => {
+    const parcels = makeParcels(500)
+    const { features } = buildMockFeatures(parcels)
+    expect(features.length).toBeLessThan(parcels.length)
+    const footprints = new Set(features.map((f) => JSON.stringify(f.geometry)))
+    expect(footprints.size).toBe(features.length)
+  })
+
+  it('prefers the parcel real area over the mock shape area, falling back when missing', () => {
+    const { features } = buildMockFeatures([
+      { id: 'SD1-1', sheetId: 'SD1', parcelId: '1', areaHa: 3.21 },
+      { id: 'SD1-2', sheetId: 'SD1', parcelId: '2', areaHa: null }
+    ])
+    expect(features[0].properties.areaHa).toBe(3.21)
+    expect(typeof features[1].properties.areaHa).toBe('number')
+  })
+
+  it('returns a bbox that contains every rendered feature', () => {
+    const { features, bbox } = buildMockFeatures(makeParcels(60))
+    const inBbox = ([lng, lat]) => lng >= bbox.minLng && lng <= bbox.maxLng && lat >= bbox.minLat && lat <= bbox.maxLat
+    for (const f of features) {
+      const rings = f.geometry.type === 'MultiPolygon' ? f.geometry.coordinates.flat(1) : f.geometry.coordinates
+      expect(rings.flat(1).every(inBbox)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
Fixes a bug with mock parcel data when user has more than 50 parcels, we were displaying wrong info on the tooltip for that scenario.