### PR TITLE
Add pigs-might-fly acceptance test coverage

### DIFF
--- a/acceptance/cucumber.local.js
+++ b/acceptance/cucumber.local.js
@@ -1,3 +1,7 @@
+process.env.CUCUMBER_STEP_TIMEOUT_MS = '30000'
+process.env.PLAYWRIGHT_PAGE_TIMEOUT_MS = '25000'
+process.env.PLAYWRIGHT_EXPECT_TIMEOUT_MS = '25000'
+
 const common = {
   paths: ['test/features/**/*.feature'],
   require: ['test/support/world.js', 'test/steps/*.js'],

--- a/acceptance/test/features/pigs-might-fly.feature
+++ b/acceptance/test/features/pigs-might-fly.feature
@@ -1,0 +1,83 @@
+Feature: Pigs Might Fly
+
+    Scenario: Application is successfully submitted through the pigs-might-fly journey
+        Given there is no application state stored for CRN "1100946268" and SBI "106498131" and grant "pigs-might-fly"
+
+        # start
+        Given the user navigates to "/pigs-might-fly"
+        And logs in as CRN "1100946268"
+        Then the user should see heading "Check if you can apply for a Pigs Might Fly Grant"
+        When the user clicks on "Start now"
+
+        # are-you-pig-farmer
+        Then the user should be at URL "are-you-pig-farmer"
+        And should see heading "Are you a pig farmer?"
+        When the user selects "Yes"
+        And continues
+
+        # pig-count
+        Then the user should be at URL "pig-count"
+        And should see heading "How many pigs do you have?"
+        When the user enters "100" for "Enter number of pigs"
+        And continues
+
+        # what-type-of-pigs
+        Then the user should be at URL "what-type-of-pigs"
+        And should see heading "What type of pigs?"
+        When the user selects the following
+            | Large White       |
+            | British Landrace  |
+            | Berkshire         |
+            | Other             |
+        And continues
+
+        # how-many-white-pigs
+        Then the user should be at URL "how-many-white-pigs"
+        And should see heading "How many White pigs do you have?"
+        When the user enters "25" for "How many White pigs do you have?"
+        And continues
+
+        # how-many-british-landrace
+        Then the user should be at URL "how-many-british-landrace"
+        And should see heading "How many British Landrace pigs do you have?"
+        When the user enters "25" for "How many British Landrace pigs do you have?"
+        And continues
+
+        # how-many-berkshire-pigs
+        Then the user should be at URL "how-many-berkshire-pigs"
+        And should see heading "How many Berkshire pigs do you have?"
+        When the user enters "25" for "How many Berkshire pigs do you have?"
+        And continues
+
+        # how-many-other-pigs
+        Then the user should be at URL "how-many-other-pigs"
+        And should see heading "How many Other pigs do you have?"
+        When the user enters "25" for "How many Other pigs do you have?"
+        And continues
+
+        # potential-funding
+        Then the user should be at URL "potential-funding"
+        And should see heading "Potential funding"
+        When the user continues
+
+        # check-answers
+        Then the user should be at URL "check-answers"
+        And should see heading "Check your answers"
+        When the user submits their form
+
+        # confirmation
+        Then the user should be at URL "confirmation"
+        And should see heading "Application complete"
+        And should see a reference number for their application
+
+        # validate Mongo state storage
+        And the following application state should be stored for CRN "1100946268" and SBI "106498131" and grant "pigs-might-fly"
+            | FIELD                | VALUE              |
+            | $$__referenceNumber  | {REFERENCE NUMBER} |
+            | applicationStatus    | SUBMITTED          |
+            | submittedBy          | 1100946268         |
+
+        # validate Mongo submission storage
+        And the following application submissions should be stored for CRN "1100946268" and SBI "106498131" and grant "pigs-might-fly"
+            | REFERENCE NUMBER   | CRN        |
+            | {REFERENCE NUMBER} | 1100946268 |

--- a/acceptance/test/steps/then.steps.js
+++ b/acceptance/test/steps/then.steps.js
@@ -157,6 +157,12 @@ Then('(the user )should see a/an {string} reference number for their application
   referenceNumbers.push(await selector.textContent())
 })
 
+Then('(the user )should see a reference number for their application', async function () {
+  const selector = this.page.locator('//h1/following-sibling::div[1]/strong')
+  await expect(selector).toBeVisible()
+  referenceNumbers.push(await selector.textContent())
+})
+
 Then('(the user )should see body {string}', async function (text) {
   await expect(this.page.locator(`//p[@class='govuk-body' and contains(text(),'${text}')]`)).toBeVisible()
 })

--- a/acceptance/test/support/world.js
+++ b/acceptance/test/support/world.js
@@ -2,9 +2,9 @@ import { setWorldConstructor, Before, After, setDefaultTimeout } from '@cucumber
 import { chromium } from '@playwright/test'
 import { createScenarioAuditQueue, deleteScenarioAuditQueue } from '../utils/audit.js'
 
-export const CUCUMBER_STEP_TIMEOUT_MS = 60000
-export const PLAYWRIGHT_PAGE_TIMEOUT_MS = 55000
-export const PLAYWRIGHT_EXPECT_TIMEOUT_MS = 55000
+export const CUCUMBER_STEP_TIMEOUT_MS = parseInt(process.env.CUCUMBER_STEP_TIMEOUT_MS) || 60000
+export const PLAYWRIGHT_PAGE_TIMEOUT_MS = parseInt(process.env.PLAYWRIGHT_PAGE_TIMEOUT_MS) || 55000
+export const PLAYWRIGHT_EXPECT_TIMEOUT_MS = parseInt(process.env.PLAYWRIGHT_EXPECT_TIMEOUT_MS) || 55000
 
 setDefaultTimeout(CUCUMBER_STEP_TIMEOUT_MS)
 


### PR DESCRIPTION
- Automate Cucumber coverage for `pigs-might-fly` as we now support the journey
- Use smaller Cucumber and Playwright timeouts when running locally to reduce development time (recently increased in CI for reliability)