### PR TITLE
harden map tile routes with clamped z/x/y schemas, generic parcel err…

### DIFF
--- a/src/plugins/content-security-policy.js
+++ b/src/plugins/content-security-policy.js
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto'
 import { config } from '~/src/config/config.js'
 import { error, LogCodes } from '~/src/server/common/helpers/logging/log.js'
 
-const defaultContentPolicy = (/** @type {string} */ nonce) => {
+const defaultContentPolicy = (/** @type {string} */ nonce, { devMode = false } = {}) => {
   const gtm = 'https://www.googletagmanager.com'
   const gtmWildCard = 'https://*.googletagmanager.com'
   const ga4 = 'https://www.google-analytics.com'
@@ -16,17 +16,16 @@ const defaultContentPolicy = (/** @type {string} */ nonce) => {
   // --- TEMPORARY: OS Maps vs OpenStreetMap comparison (TGC-1418 follow-up) ---
   // The parcel map's OpenStreetMap basemap option loads its style/tiles
   // directly from CartoCDN (unlike OS Maps, which is proxied server-side).
-  // Allowed unconditionally because the basemap-provider toggle is a
-  // runtime choice, not a per-deployment one. Delete cartoCdn/cartoTiles and
+  // Gated on devMode: the basemap-provider toggle only renders on devMode map
+  // pages, so carto is never needed on a normal journey. Delete cartoHosts and
   // their two usages below once the comparison is complete.
-  const cartoCdn = 'https://basemaps.cartocdn.com'
-  const cartoTiles = 'https://*.basemaps.cartocdn.com'
+  const cartoHosts = devMode ? ['https://basemaps.cartocdn.com', 'https://*.basemaps.cartocdn.com'] : []
   // --- END TEMPORARY ---
 
   const scriptSrc = [self, "'strict-dynamic'", `'nonce-${nonce}'`, govukFrontendHash, gtmWildCard, ga4].join(' ')
-  const connectSrc = [self, ga4, statsDblClick, ga4WildCard, gtmWildCard, cartoCdn, cartoTiles].join(' ')
+  const connectSrc = [self, ga4, statsDblClick, ga4WildCard, gtmWildCard, ...cartoHosts].join(' ')
   const fontSrc = [self, 'data:', 'https://fonts.gstatic.com'].join(' ')
-  const imgSrc = [self, 'data:', 'blob:', ga4, statsDblClick, ga4WildCard, cartoCdn, cartoTiles].join(' ')
+  const imgSrc = [self, 'data:', 'blob:', ga4, statsDblClick, ga4WildCard, ...cartoHosts].join(' ')
   const workerSrc = [self, 'blob:'].join(' ')
 
   const formActionSrc = [self]
@@ -85,8 +84,12 @@ export const contentSecurityPolicy = {
         return h.continue
       }
 
+      // Only the map-select page puts devMode on its view context; everywhere
+      // else this is undefined/falsy, so carto stays out of the CSP.
+      const devMode = Boolean(response.variety === 'view' && response.source?.context?.devMode)
+
       if (typeof response.header === 'function') {
-        response.header('Content-Security-Policy', defaultContentPolicy(/** @type {string} */ (nonce)))
+        response.header('Content-Security-Policy', defaultContentPolicy(/** @type {string} */ (nonce), { devMode }))
         response.header('Referrer-Policy', 'no-referrer')
 
         // Only set this header in non-production environments for debugging

--- a/src/plugins/content-security-policy.test.js
+++ b/src/plugins/content-security-policy.test.js
@@ -81,15 +81,6 @@ describe('contentSecurityPolicy plugin', () => {
   }
 
   describe('onRequest handler', () => {
-    test('registers an onRequest handler', () => {
-      // ensure ext was called with onRequest
-      expect(fakeServer.ext).toHaveBeenCalled()
-      const call = fakeServer.ext.mock.calls.find(([ev]) => ev === 'onRequest')
-      expect(call).toBeTruthy()
-      const [, handler] = call
-      expect(typeof handler).toBe('function')
-    })
-
     test('sets a base64 nonce on request.app.cspNonce and continues', async () => {
       const request = { app: {} }
 
@@ -147,12 +138,23 @@ describe('contentSecurityPolicy plugin', () => {
       expect(mockHeader).toHaveBeenNthCalledWith(3, 'X-CSP-Nonce', request.app.cspNonce)
     })
 
-    it('allows CartoCDN for the parcel map basemap-provider toggle', async () => {
+    it('omits CartoCDN from the CSP on a normal (non-devMode) response', async () => {
+      const request = { response: { isBoom: false, header: mockHeader, variety: '' }, app: {} }
+
+      await onRequest(request, h)
+      await onPreResponse(request, h)
+
+      const [, policy] = mockHeader.mock.calls.find(([name]) => name === 'Content-Security-Policy')
+      expect(policy).not.toContain('cartocdn.com')
+    })
+
+    it('allows CartoCDN only on a devMode map view', async () => {
       const request = {
         response: {
           isBoom: false,
           header: mockHeader,
-          variety: ''
+          variety: 'view',
+          source: { context: { devMode: true } }
         },
         app: {}
       }
@@ -163,6 +165,24 @@ describe('contentSecurityPolicy plugin', () => {
       const [, policy] = mockHeader.mock.calls.find(([name]) => name === 'Content-Security-Policy')
       expect(policy).toContain('https://basemaps.cartocdn.com')
       expect(policy).toContain('https://*.basemaps.cartocdn.com')
+    })
+
+    it('omits CartoCDN on a normal (non-devMode) view render', async () => {
+      const request = {
+        response: {
+          isBoom: false,
+          header: mockHeader,
+          variety: 'view',
+          source: { context: { devMode: false } }
+        },
+        app: {}
+      }
+
+      await onRequest(request, h)
+      await onPreResponse(request, h)
+
+      const [, policy] = mockHeader.mock.calls.find(([name]) => name === 'Content-Security-Policy')
+      expect(policy).not.toContain('cartocdn.com')
     })
 
     it.each([
@@ -191,14 +211,12 @@ describe('contentSecurityPolicy plugin', () => {
       }
     })
 
-    it('should include GOV.UK Frontend SHA-256 hash in script-src', async () => {
-      const cspHeader = await getCspHeader()
-      expect(cspHeader).toContain("'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='")
-    })
-
-    it('should include form-action self directive', async () => {
-      const cspHeader = await getCspHeader()
-      expect(cspHeader).toContain("form-action 'self'")
+    it.each([
+      "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",
+      "form-action 'self'",
+      'https://*.googletagmanager.com'
+    ])('includes %s in the CSP', async (fragment) => {
+      expect(await getCspHeader()).toContain(fragment)
     })
 
     it('should allowlist the SFD origin in form-action when SFD is enabled', async () => {
@@ -226,11 +244,6 @@ describe('contentSecurityPolicy plugin', () => {
 
       const cspHeader = await getCspHeader()
       expect(cspHeader).toContain("form-action 'self';")
-    })
-
-    it('should include GTM wildcard in script-src', async () => {
-      const cspHeader = await getCspHeader()
-      expect(cspHeader).toContain('https://*.googletagmanager.com')
     })
   })
 

--- a/src/server/common/helpers/logging/log-codes/system.js
+++ b/src/server/common/helpers/logging/log-codes/system.js
@@ -168,5 +168,10 @@ export const SYSTEM = {
     level: 'warn',
     messageFunc: (messageOptions) =>
       `check-details: SFD is enabled but externalLinks.sfd.updateUrl is missing or invalid (value=${messageOptions.updateUrl}); falling through to the update-details page instead of redirecting to SFD`
+  },
+  OS_MAPS_API_KEY_MISSING: {
+    level: 'error',
+    messageFunc: () =>
+      `map: osMapsApiKey (OS_MAPS_API_KEY) is not set; every /api/map/os-tiles request will fail as a 401 from OS with no diagnostic`
   }
 }

--- a/src/server/common/map/handlers.js
+++ b/src/server/common/map/handlers.js
@@ -18,6 +18,9 @@ const LAND_GRANTS_API_URL = config.get('landGrants.grantsServiceApiEndpoint')
 const TILE_CACHE_MAX_AGE_SECONDS = config.get('mapTileCacheMaxAgeSeconds')
 const SERVICE_LAND_GRANTS = 'land-grants-api'
 const CACHE_CONTROL_HEADER = 'Cache-Control'
+// Generic, so the upstream land-grants response body never reaches the browser;
+// the real message is preserved in logUpstreamError.
+const PARCELS_ERROR_MESSAGE = 'Unable to load your land parcels'
 
 /**
  * Returns the signed-in user's parcels as GeoJSON features (id, sheet_id,
@@ -35,7 +38,7 @@ export async function parcelsHandler(request, h) {
       { endpoint: ROUTES.parcels, service: SERVICE_LAND_GRANTS, upstreamStatus, errorMessage: err.message },
       request
     )
-    return h.response({ error: err.message }).code(upstreamStatus ?? statusCodes.serviceUnavailable)
+    return h.response({ error: PARCELS_ERROR_MESSAGE }).code(upstreamStatus ?? statusCodes.serviceUnavailable)
   }
 
   const parcelData = toParcelData(result.value)
@@ -123,6 +126,11 @@ export async function osTileProxyHandler(request, h) {
   }
   if (!response.ok) {
     return h.response().code(response.status)
+  }
+  // An ok-but-empty upstream (204/null body) would throw in Readable.fromWeb and
+  // surface as a 500; degrade to a clean 502 instead.
+  if (!response.body) {
+    return h.response().code(statusCodes.badGateway)
   }
 
   const contentLength = response.headers.get('content-length')

--- a/src/server/common/map/handlers.test.js
+++ b/src/server/common/map/handlers.test.js
@@ -149,27 +149,20 @@ describe('parcelsHandler', () => {
     expect(result).toBe(sentinel)
   })
 
-  it('returns 503 with error message when fetchParcels throws without a status', async () => {
-    fetchParcels.mockRejectedValue(new Error('backend down'))
-    const h = makeH()
-
-    await parcelsHandler(makeRequest(), h)
-
-    expect(h.response).toHaveBeenCalledWith({ error: 'backend down' })
-    expect(h.code).toHaveBeenCalledWith(503)
-  })
-
+  // Every failure returns the generic body — the raw upstream message must
+  // never reach the browser — with the upstream status passed through, or 503.
   it.each([
-    ['code', 500],
-    ['code', 404],
-    ['status', 403]
-  ])('passes through upstream %s status %d', async (field, status) => {
-    fetchParcels.mockRejectedValue(Object.assign(new Error('upstream'), { [field]: status }))
+    ['503 without an upstream status', new Error('backend down'), 503],
+    ['upstream code 500', Object.assign(new Error('upstream'), { code: 500 }), 500],
+    ['upstream code 404', Object.assign(new Error('upstream'), { code: 404 }), 404],
+    ['upstream status 403', Object.assign(new Error('upstream'), { status: 403 }), 403]
+  ])('returns a generic error and %s when fetchParcels throws', async (_name, error, status) => {
+    fetchParcels.mockRejectedValue(error)
     const h = makeH()
 
     await parcelsHandler(makeRequest(), h)
 
-    expect(h.response).toHaveBeenCalledWith({ error: 'upstream' })
+    expect(h.response).toHaveBeenCalledWith({ error: 'Unable to load your land parcels' })
     expect(h.code).toHaveBeenCalledWith(status)
   })
 })
@@ -355,5 +348,15 @@ describe('osTileProxyHandler', () => {
     await osTileProxyHandler(makeOsRequest({ z: '12', x: '100', y: '200' }), h)
 
     expect(h.code).toHaveBeenCalledWith(503)
+  })
+
+  it('returns 502 when an ok upstream response has a null body', async () => {
+    global.fetch.mockResolvedValue({ ok: true, headers: mockOsTileHeaders(), body: null })
+    const h = makeH()
+
+    await osTileProxyHandler(makeOsRequest({ z: '12', x: '100', y: '200' }), h)
+
+    expect(h.code).toHaveBeenCalledWith(502)
+    expect(h.type).not.toHaveBeenCalled()
   })
 })

--- a/src/server/common/map/map-routes.js
+++ b/src/server/common/map/map-routes.js
@@ -1,5 +1,3 @@
-import Joi from 'joi'
-
 /** Every map route path in one place, so handlers and the mock plugin agree. */
 export const ROUTES = {
   parcels: '/api/map/parcels',
@@ -7,16 +5,4 @@ export const ROUTES = {
   parcelTiles: '/api/map/parcel-tiles/{z}/{x}/{y}',
   osBasemap: '/api/map/os-basemap',
   osTiles: '/api/map/os-tiles/{z}/{x}/{y}'
-}
-
-// Shared by both tile routes. NOTE: this single schema is wrong for both routes
-// by construction — the OS and parcel tile services have different valid zoom
-// ranges — and it places no upper bound on z/x/y forwarded to a metered key.
-// Stage 6 replaces it with two per-route schemas that clamp the range.
-export const tileParamsValidation = {
-  params: Joi.object({
-    z: Joi.number().integer().min(0).required(),
-    x: Joi.number().integer().min(0).required(),
-    y: Joi.number().integer().min(0).required()
-  })
 }

--- a/src/server/common/map/map.plugin.js
+++ b/src/server/common/map/map.plugin.js
@@ -1,4 +1,7 @@
-import { ROUTES, tileParamsValidation } from './map-routes.js'
+import { config } from '~/src/config/config.js'
+import { error, LogCodes } from '~/src/server/common/helpers/logging/log.js'
+import { ROUTES } from './map-routes.js'
+import { osTileParams, parcelTileParams } from './tile-params.js'
 import { parcelsHandler, tilesHandler, osBasemapHandler, osTileProxyHandler } from './handlers.js'
 
 const sessionAuth = { auth: { mode: 'required', strategy: 'session' } }
@@ -12,6 +15,11 @@ export const mapPlugin = {
   plugin: {
     name: 'map',
     register(server) {
+      // Surface a missing OS key at startup
+      if (!config.get('osMapsApiKey')) {
+        error(LogCodes.SYSTEM.OS_MAPS_API_KEY_MISSING, {})
+      }
+
       server.route({
         method: 'GET',
         path: ROUTES.parcels,
@@ -21,7 +29,7 @@ export const mapPlugin = {
       server.route({
         method: 'GET',
         path: ROUTES.parcelTiles,
-        options: { ...sessionAuth, validate: tileParamsValidation },
+        options: { ...sessionAuth, validate: parcelTileParams },
         handler: tilesHandler
       })
       server.route({
@@ -33,7 +41,7 @@ export const mapPlugin = {
       server.route({
         method: 'GET',
         path: ROUTES.osTiles,
-        options: { ...sessionAuth, validate: tileParamsValidation },
+        options: { ...sessionAuth, validate: osTileParams },
         handler: osTileProxyHandler
       })
     }

--- a/src/server/common/map/map.plugin.test.js
+++ b/src/server/common/map/map.plugin.test.js
@@ -1,22 +1,23 @@
 // @ts-nocheck
 import { vi } from 'vitest'
 
-vi.mock('~/src/config/config.js', () => ({
-  config: {
-    get: vi.fn((key) => {
-      if (key === 'mapTileCacheMaxAgeSeconds') {
-        return 3600
-      }
-      if (key === 'baseUrl') {
-        return ''
-      }
-      return 'https://land-grants-api'
-    })
-  }
+const { defaultConfigGet } = vi.hoisted(() => ({
+  defaultConfigGet: (/** @type {string} */ key) =>
+    key === 'mapTileCacheMaxAgeSeconds' ? 3600 : key === 'baseUrl' ? '' : 'https://land-grants-api'
+}))
+vi.mock('~/src/config/config.js', () => ({ config: { get: vi.fn(defaultConfigGet) } }))
+
+const mockError = vi.fn()
+vi.mock('~/src/server/common/helpers/logging/log.js', () => ({
+  error: (...args) => mockError(...args),
+  LogCodes: { SYSTEM: { OS_MAPS_API_KEY_MISSING: { level: 'error', messageFunc: () => 'missing key' } } }
 }))
 
+import { config } from '~/src/config/config.js'
 import { mapPlugin } from './map.plugin.js'
 import { ROUTES } from './map-routes.js'
+import { osTileParams, parcelTileParams } from './tile-params.js'
+import { LogCodes } from '~/src/server/common/helpers/logging/log.js'
 
 function makeServer() {
   const routes = []
@@ -30,6 +31,8 @@ describe('mapPlugin route registration', () => {
   let server
 
   beforeEach(() => {
+    mockError.mockClear()
+    config.get.mockImplementation(defaultConfigGet)
     server = makeServer()
     mapPlugin.plugin.register(server)
   })
@@ -53,19 +56,23 @@ describe('mapPlugin route registration', () => {
     }
   })
 
-  it('validates tile params on both tile routes and nowhere else', () => {
+  it('wires the matching tile-param schema onto each tile route and nowhere else', () => {
     const byPath = Object.fromEntries(server._routes.map((r) => [r.path, r]))
-    expect(byPath[ROUTES.parcelTiles].options.validate).toBeDefined()
-    expect(byPath[ROUTES.osTiles].options.validate).toBeDefined()
+    expect(byPath[ROUTES.osTiles].options.validate).toBe(osTileParams)
+    expect(byPath[ROUTES.parcelTiles].options.validate).toBe(parcelTileParams)
     expect(byPath[ROUTES.parcels].options.validate).toBeUndefined()
     expect(byPath[ROUTES.osBasemap].options.validate).toBeUndefined()
   })
 
-  it('applies integer tile-param validation on the tile routes', () => {
-    const schema = server._routes.find((r) => r.path === ROUTES.osTiles).options.validate.params
-    expect(schema.validate({ z: 12, x: 100, y: 200 }).error).toBeUndefined()
-    expect(schema.validate({ z: -1, x: 0, y: 0 }).error).toBeDefined()
-    expect(schema.validate({ z: 1.5, x: 0, y: 0 }).error).toBeDefined()
-    expect(schema.validate({ z: 'abc', x: 0, y: 0 }).error).toBeDefined()
+  it('logs a startup error when the OS Maps API key is not set', () => {
+    config.get.mockImplementation((key) => (key === 'osMapsApiKey' ? '' : 'x'))
+
+    mapPlugin.plugin.register(makeServer())
+
+    expect(mockError).toHaveBeenCalledWith(LogCodes.SYSTEM.OS_MAPS_API_KEY_MISSING, {})
+  })
+
+  it('does not log when the OS Maps API key is present', () => {
+    expect(mockError).not.toHaveBeenCalled()
   })
 })

--- a/src/server/common/map/tile-params.js
+++ b/src/server/common/map/tile-params.js
@@ -1,0 +1,29 @@
+import Joi from 'joi'
+import { OS_MIN_ZOOM, OS_MAX_ZOOM } from './os-maps.js'
+
+/**
+ * Builds a per-route tile-param schema that clamps `z` to a valid zoom range and
+ * `x`/`y` to `[0, 2^z)` — the only valid tile coordinates at that zoom. The
+ * `x`/`y` bound depends on `z`, so it lives in an object-level `.custom()`; a
+ * per-key `.max()` can't reference `2^z`. Without this, `/api/map/os-tiles`
+ * forwards arbitrary coordinates straight to the metered OS key.
+ * @param {{ minZoom: number, maxZoom: number }} range
+ */
+function makeTileParams({ minZoom, maxZoom }) {
+  return {
+    params: Joi.object({
+      z: Joi.number().integer().min(minZoom).max(maxZoom).required(),
+      x: Joi.number().integer().min(0).required(),
+      y: Joi.number().integer().min(0).required()
+    }).custom((value, helpers) => {
+      const bound = 2 ** value.z
+      return value.x >= bound || value.y >= bound ? helpers.error('any.invalid') : value
+    })
+  }
+}
+
+// Two named schemas so each route validates its own range. They share the OS
+// zoom window today (same viewport), but the seam lets the parcel range diverge
+// without touching the OS route.
+export const osTileParams = makeTileParams({ minZoom: OS_MIN_ZOOM, maxZoom: OS_MAX_ZOOM })
+export const parcelTileParams = makeTileParams({ minZoom: OS_MIN_ZOOM, maxZoom: OS_MAX_ZOOM })

--- a/src/server/common/map/tile-params.test.js
+++ b/src/server/common/map/tile-params.test.js
@@ -1,0 +1,35 @@
+import { osTileParams, parcelTileParams } from './tile-params.js'
+
+describe.each([
+  ['osTileParams', osTileParams],
+  ['parcelTileParams', parcelTileParams]
+])('%s', (_name, schema) => {
+  const validate = (params) => schema.params.validate(params).error
+
+  it('accepts an in-range tile coordinate', () => {
+    expect(validate({ z: 12, x: 100, y: 200 })).toBeUndefined()
+  })
+
+  it('accepts the OS zoom bounds', () => {
+    expect(validate({ z: 7, x: 0, y: 0 })).toBeUndefined()
+    expect(validate({ z: 20, x: 0, y: 0 })).toBeUndefined()
+  })
+
+  it.each([
+    ['z below the min zoom', { z: 6, x: 0, y: 0 }],
+    ['z above the max zoom', { z: 21, x: 0, y: 0 }],
+    ['a scripted out-of-range z', { z: 9999, x: 0, y: 0 }],
+    ['a non-integer z', { z: 1.5, x: 0, y: 0 }],
+    ['a non-numeric z', { z: 'abc', x: 0, y: 0 }],
+    ['a negative x', { z: 12, x: -1, y: 0 }],
+    ['a negative y', { z: 12, x: 0, y: -1 }],
+    ['x equal to 2^z', { z: 12, x: 2 ** 12, y: 0 }],
+    ['y equal to 2^z', { z: 12, x: 0, y: 2 ** 12 }]
+  ])('rejects %s', (_desc, params) => {
+    expect(validate(params)).toBeDefined()
+  })
+
+  it('accepts the largest valid x/y at a given zoom', () => {
+    expect(validate({ z: 12, x: 2 ** 12 - 1, y: 2 ** 12 - 1 })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Clamp OS/parcel tile params to valid zoom and x/y ranges so a signed-in user can no longer script arbitrary coordinates against the metered OS key; return a generic parcels error instead of leaking the upstream body; guard a null OS tile body (502) and a missing OS_MAPS_API_KEY at startup; and gate CartoCDN in the CSP on devMode so it no longer ships on every page.