### PR TITLE
Use backend DELETE test-data endpoint for acceptance test pre-teardown

### DIFF
--- a/acceptance/test/features/address-handling.feature
+++ b/acceptance/test/features/address-handling.feature
@@ -3,7 +3,7 @@ Feature: Address Handling
     addresses by preference and ensuring the address shown to the user is sent to GAS.
 
     Scenario: Applicant with a structured (UPRN) address sees it formatted correctly and it is sent to GAS
-        Given there is no application state stored for CRN "1103823647" and SBI "106700730" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "106700730" and grant "example-grant-with-auth"
 
         # start
         Given the user navigates to "/example-grant-with-auth"
@@ -156,7 +156,7 @@ Feature: Address Handling
             | postalCode | BB7 4LQ                       |
 
     Scenario: Applicant with an unstructured (no UPRN) address sees it formatted correctly and it is sent to GAS
-        Given there is no application state stored for CRN "1102821879" and SBI "106450896" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "106450896" and grant "example-grant-with-auth"
 
         # start
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/features/allowlist.feature
+++ b/acceptance/test/features/allowlist.feature
@@ -1,8 +1,8 @@
 Feature: Allowlisting
 
     Scenario: Attempt to access an allowlist-enabled journey with allowlisted and non-allowlisted CRNs and SBIs
-        Given there is no application state stored for CRN "1100953760" and SBI "108633093" and grant "example-whitelist"
-        And there is no application state stored for CRN "1100955380" and SBI "115425713" and grant "example-whitelist"
+        Given there is no application data for SBI "108633093" and grant "example-whitelist"
+        And there is no application data for SBI "115425713" and grant "example-whitelist"
 
         # login
         Given the user navigates to "/example-whitelist"

--- a/acceptance/test/features/application-amendment.feature
+++ b/acceptance/test/features/application-amendment.feature
@@ -1,7 +1,7 @@
 Feature: Application Amendment
 
     Scenario: A submitted application can be amended and re-submitted as a new application multiple times
-        Given there is no application state stored for CRN "1100964517" and SBI "115482347" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "115482347" and grant "example-grant-with-auth"
 
         # start
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/features/application-lifecycle.feature
+++ b/acceptance/test/features/application-lifecycle.feature
@@ -1,7 +1,7 @@
 Feature: Application Lifecycle
 
     Scenario: Application is successfully submitted and taken thru to agreement offer stages
-        Given there is no application state stored for CRN "1100995048" and SBI "115664358" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "115664358" and grant "example-grant-with-auth"
 
         # start
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/features/application-withdrawal.feature
+++ b/acceptance/test/features/application-withdrawal.feature
@@ -1,7 +1,7 @@
 Feature: Application Withdrawal
 
     Scenario: A withdrawn application can be re-submitted as a new application
-        Given there is no application state stored for CRN "1100954058" and SBI "106527272" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "106527272" and grant "example-grant-with-auth"
 
         # start
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/features/clear-application-state.feature
+++ b/acceptance/test/features/clear-application-state.feature
@@ -1,7 +1,7 @@
 Feature: Clear Application State
 
     Scenario: Clicking the 'Clear application state' footer link in non-prod environments clears saved journey answers
-        Given there is no application state stored for CRN "1101006005" and SBI "106834980" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "106834980" and grant "example-grant-with-auth"
 
         # start
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/features/defra-id-signout.feature
+++ b/acceptance/test/features/defra-id-signout.feature
@@ -1,8 +1,8 @@
 Feature: Defra ID Signout
 
     Scenario: Sign out of Defra ID and sign in as another user
-        Given there is no application state stored for CRN "1101003693" and SBI "115722586" and grant "example-grant-with-auth"
-        And there is no application state stored for CRN "1100995056" and SBI "115680267" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "115722586" and grant "example-grant-with-auth"
+        And there is no application data for SBI "115680267" and grant "example-grant-with-auth"
 
         # login as user 1
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/features/footer-links.feature
+++ b/acceptance/test/features/footer-links.feature
@@ -1,7 +1,7 @@
 Feature: Footer Links
 
     Scenario: Footer should contain expected links
-        Given there is no application state stored for CRN "1100961682" and SBI "106281016" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "106281016" and grant "example-grant-with-auth"
 
         # start
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/features/gas-error-handling.feature
+++ b/acceptance/test/features/gas-error-handling.feature
@@ -1,7 +1,7 @@
 Feature: GAS Error-Handling
 
     Scenario: Handle unexpected GAS errors with a generic response to the user
-        Given there is no application state stored for CRN "1100988734" and SBI "115646286" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "115646286" and grant "example-grant-with-auth"
         And the next application submitted to GAS for SBI "115646286" will return HTTP 429 "Too many requests" for 3 requests
 
         # start

--- a/acceptance/test/features/google-analytics.feature
+++ b/acceptance/test/features/google-analytics.feature
@@ -1,7 +1,7 @@
 Feature: Google Analytics
 
     Scenario: Grants should not fire GA requests before analytics cookie consent is given, and should fire after accepting cookies
-        Given there is no application state stored for CRN "1100943757" and SBI "113593357" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "113593357" and grant "example-grant-with-auth"
         And the user starts a new browser session with GA request tracking
         And the user navigates to "/example-grant-with-auth"
         And logs in as CRN "1100943757"
@@ -12,7 +12,7 @@ Feature: Google Analytics
         And a GA collect request should fire
 
     Scenario: Grants should fire GA no-script request when JavaScript is disabled
-        Given there is no application state stored for CRN "1100943838" and SBI "107173507" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "107173507" and grant "example-grant-with-auth"
         And the user starts a new browser session with JavaScript disabled
         And the user navigates to "/example-grant-with-auth"
         And logs in as CRN "1100943838"

--- a/acceptance/test/features/mapping.feature
+++ b/acceptance/test/features/mapping.feature
@@ -1,7 +1,7 @@
 Feature: Mapping
 
     Scenario: User selects a land parcel from an interactive map
-        Given there is no application state stored for CRN "1100945520" and SBI "106842593" and grant "example-grant-with-map"
+        Given there is no application data for SBI "106842593" and grant "example-grant-with-map"
 
         # start
         Given the user navigates to "/example-grant-with-map"

--- a/acceptance/test/features/pigs-might-fly.feature
+++ b/acceptance/test/features/pigs-might-fly.feature
@@ -1,7 +1,7 @@
 Feature: Pigs Might Fly
 
     Scenario: Application is successfully submitted through the pigs-might-fly journey
-        Given there is no application state stored for CRN "1100946268" and SBI "106498131" and grant "pigs-might-fly"
+        Given there is no application data for SBI "106498131" and grant "pigs-might-fly"
 
         # start
         Given the user navigates to "/pigs-might-fly"

--- a/acceptance/test/features/purging.feature
+++ b/acceptance/test/features/purging.feature
@@ -1,7 +1,7 @@
 Feature: Purging
 
     Scenario: A user whose application has been purged sees the application deleted page
-        Given there is no application state stored for CRN "1300000002" and SBI "300000002" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "300000002" and grant "example-grant-with-auth"
 
         # start
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/features/reusable-components.feature
+++ b/acceptance/test/features/reusable-components.feature
@@ -1,7 +1,7 @@
 Feature: Reusable Components
 
     Scenario: Use all available components in example journey and analyze accessibility
-        Given there is no application state stored for CRN "1100957269" and SBI "107593059" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "107593059" and grant "example-grant-with-auth"
 
         # start
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/features/save-and-continue.feature
+++ b/acceptance/test/features/save-and-continue.feature
@@ -2,7 +2,7 @@ Feature: Save and Continue
 
     Scenario: Use the Save and Continue feature, checking which pages are returned to when resuming a journey
         # clear Mongo state storage
-        Given there is no application state stored for CRN "1100960953" and SBI "115460751" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "115460751" and grant "example-grant-with-auth"
 
         # start
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/features/sbi-driven-applications.feature
+++ b/acceptance/test/features/sbi-driven-applications.feature
@@ -1,9 +1,7 @@
 Feature: SBI-Driven Applications
 
     Scenario: Begin a journey as an applicant, continue as an agent and complete the application as the applicant, checking application locking is enforced along the way
-        Given there is no application lock for CRN "1109990002" and SBI "119000002" and grant "example-grant-with-auth"
-        And there is no application lock for CRN "1109990001" and SBI "119000002" and grant "example-grant-with-auth"
-        And there is no application state stored for CRN "1109990002" and SBI "119000002" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "119000002" and grant "example-grant-with-auth"
 
         # login as applicant farmer
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/features/task-list-hide-questions.feature
+++ b/acceptance/test/features/task-list-hide-questions.feature
@@ -1,7 +1,7 @@
 Feature: Task Lists Hiding Questions
 
     Scenario: Complete a task list based grant application hiding all questions
-        Given there is no application state stored for CRN "1100946179" and SBI "115371673" and grant "example-grant-with-task-list-hide-questions"
+        Given there is no application data for SBI "115371673" and grant "example-grant-with-task-list-hide-questions"
 
         # start
         Given the user navigates to "example-grant-with-task-list-hide-questions"

--- a/acceptance/test/features/task-list-show-questions.feature
+++ b/acceptance/test/features/task-list-show-questions.feature
@@ -1,7 +1,7 @@
 Feature: Task Lists Showing Questions
 
     Scenario: Complete a task list based grant application showing all questions
-        Given there is no application state stored for CRN "1100957579" and SBI "106604915" and grant "example-grant-with-task-list"
+        Given there is no application data for SBI "106604915" and grant "example-grant-with-task-list"
 
         # start
         Given the user navigates to "example-grant-with-task-list"

--- a/acceptance/test/features/user-permissions.feature
+++ b/acceptance/test/features/user-permissions.feature
@@ -7,17 +7,7 @@ Feature: User Permissions
         CRN 1062311184 - No permissions
 
     Scenario: Complete a grant application with multiple users with different permissions
-        # attempt to unlock the application in the order it could have been left by the test
-        Given there is no application lock for CRN "1062311184" and SBI "106238911" and grant "example-grant-with-auth"
-        And there is no application lock for CRN "1062311183" and SBI "106238911" and grant "example-grant-with-auth"
-        And there is no application lock for CRN "1062311181" and SBI "106238911" and grant "example-grant-with-auth"
-        And there is no application lock for CRN "1062311182" and SBI "106238911" and grant "example-grant-with-auth"
-
-        # delete any state
-        And there is no application state stored for CRN "1062311181" and SBI "106238911" and grant "example-grant-with-auth"
-
-        # unlock from CRN 1062311181 (deleting state above acquires a lock as a side effect)
-        Given there is no application lock for CRN "1062311181" and SBI "106238911" and grant "example-grant-with-auth"
+        Given there is no application data for SBI "106238911" and grant "example-grant-with-auth"
 
         # attempt to start as CRN 1062311183 with VIEW permission only, before any application exists
         Given the user navigates to "/example-grant-with-auth"

--- a/acceptance/test/steps/backend.steps.js
+++ b/acceptance/test/steps/backend.steps.js
@@ -4,17 +4,14 @@ import { transformStepArgument } from '../utils/step-argument-transformation.js'
 import Backend from '../utils/backend.js'
 import Mongo from '../utils/mongo.js'
 
+Given('there is no application data for SBI {string} and grant {string}', async function (sbi, grantCode) {
+  await Backend.clearTestData(sbi, grantCode)
+})
+
 Given(
   'there is no application lock for CRN {string} and SBI {string} and grant {string}',
   async function (crn, sbi, grantCode) {
     await Backend.deleteLock(crn, sbi, grantCode)
-  }
-)
-
-Given(
-  'there is no application state stored for CRN {string} and SBI {string} and grant {string}',
-  async function (crn, sbi, grantCode) {
-    await Backend.deleteState(crn, sbi, grantCode)
   }
 )
 

--- a/acceptance/test/utils/backend.js
+++ b/acceptance/test/utils/backend.js
@@ -2,13 +2,9 @@ import { expect } from '@playwright/test'
 import { getBackendAuthorizationToken } from './backend-auth-helper.js'
 import { mintLockToken } from './lock-token.js'
 
-const BASE_BACKEND_URL = () => process.env.BASE_BACKEND_URL || 'http://localhost:3001'
+const BASE_BACKEND_URL = () => process.env.BASE_BACKEND_URL
 
 const LOCKED = Symbol('locked')
-
-// The resolved grant version is a grant-level property, so cache it per grant
-// code to avoid re-probing the backend on every state/lock operation.
-const grantVersionCache = new Map()
 
 class Backend {
   /**
@@ -54,16 +50,12 @@ class Backend {
    * mirroring the grants-ui app. Backend-sourced (config-broker) grants are
    * served at their released version (e.g. "1.0.1"); legacy YAML-only grants
    * have no backend definition and resolve to undefined (the backend default
-   * applies). The version is grant-level, so when the requested application is
-   * locked by another applicant it is resolved from an unlocked probe instead.
+   * applies). When the requested application is locked by another applicant
+   * it is resolved from an unlocked probe instead.
    *
    * @returns {Promise<string | undefined>} the resolved version, or undefined
    */
   async resolveGrantVersion(crn, sbi, grantCode) {
-    if (grantVersionCache.has(grantCode)) {
-      return grantVersionCache.get(grantCode)
-    }
-
     let version = await this.probeGrantVersion(crn, sbi, grantCode)
     if (version === LOCKED) {
       const unlockedSbi = String(Math.floor(900000000 + Math.random() * 99999999))
@@ -73,10 +65,14 @@ class Backend {
       version = undefined
     }
 
-    grantVersionCache.set(grantCode, version)
     return version
   }
 
+  /**
+   * Releases the application lock held by a specific owner (crn), leaving
+   * any other user's lock on the same (sbi, grantCode) untouched. Used
+   * mid-scenario to unlock one user's session without disturbing another's.
+   */
   async deleteLock(crn, sbi, grantCode) {
     const grantVersion = (await this.resolveGrantVersion(crn, sbi, grantCode)) ?? 1
     const response = await fetch(
@@ -91,17 +87,21 @@ class Backend {
     expect(response.status === 200 || response.status === 404).toBe(true)
   }
 
-  async deleteState(crn, sbi, grantCode) {
-    const grantVersion = await this.resolveGrantVersion(crn, sbi, grantCode)
-    const versionQuery = grantVersion ? `&grantVersion=${grantVersion}` : ''
-    const response = await fetch(`${BASE_BACKEND_URL()}/state?sbi=${sbi}&grantCode=${grantCode}${versionQuery}`, {
+  /**
+   * Clears all test data (application state, submissions, and locks) for an
+   * (sbi, grantCode) pair, across every grantVersion, via the backend's
+   * /admin/test-data endpoint. Used as pre-test teardown in place of the
+   * older per-resource deleteState/deleteLock calls.
+   */
+  async clearTestData(sbi, grantCode) {
+    const response = await fetch(`${BASE_BACKEND_URL()}/admin/test-data?sbi=${sbi}&grantCode=${grantCode}`, {
       method: 'DELETE',
       headers: {
-        Authorization: `Bearer ${getBackendAuthorizationToken()}`,
-        'x-application-lock-owner': mintLockToken(crn, sbi, grantCode, grantVersion)
+        Authorization: `Bearer ${getBackendAuthorizationToken()}`
       }
     })
-    expect(response.status === 200 || response.status === 404).toBe(true)
+    expect(response.status).toBe(200)
+    return await response.json()
   }
 
   async getState(crn, sbi, grantCode) {


### PR DESCRIPTION
- Switch teardown to using new DELETE `/admin/test-data` backend endpoint for more reliable pre-test teardown
- Remove grant version caching at grant code level, should be at SBI level technically but removal simplifies code also