### PR TITLE
add headless gt journey CLI to drive Journey Runner journeys from the…

### DIFF
--- a/acceptance/journey-cli.js
+++ b/acceptance/journey-cli.js
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+/**
+ * Headless CLI driver for the Journey Runner.
+ *
+ * The Journey Runner engine (src/server/dev-tools/journey-runner/runner-engine.js)
+ * is DOM-bound and normally driven from the browser console via `runJourney()`.
+ * This script drives it headlessly instead: it launches chromium (reusing the
+ * acceptance suite's Playwright install), signs in through the DefraID stub, then
+ * calls `runJourney()` on the page and forwards the engine's `[journey-runner]`
+ * console output to the terminal, exiting non-zero if the journey gets stuck.
+ *
+ * The engine script is auto-injected on every local page by page.njk, and it
+ * resumes across navigations via sessionStorage, so this driver only has to kick
+ * the run off once and then watch the console for a terminal outcome.
+ *
+ * Usage:
+ *   node journey-cli.js <slug> [--crn <crn>] [--stop <n|section>] [--headed]
+ *                              [--base-url <url>] [--timeout <ms>]
+ *
+ * Invoked by `gt journey <slug>` (tools/grants-tui/journey.js).
+ */
+
+import { chromium } from '@playwright/test'
+
+const DEFAULT_CRN = '1102838829'
+const DEFAULT_BASE_URL = 'http://localhost:3000'
+const DEFAULT_TIMEOUT_MS = 120000
+const LOG_PREFIX = '[journey-runner]'
+
+// Substrings the engine logs when it reaches a clean stopping point…
+// Keep in sync with the `[journey-runner]` log wording in
+// src/server/dev-tools/journey-runner/runner-engine.js — a message reword there
+// silently breaks terminal-outcome detection here.
+const SUCCESS_MARKERS = ['stopping here', 'journey complete', 'complete - stopping at']
+// …and when it fails / stalls.
+const FAILURE_MARKERS = [
+  'Stuck on',
+  'Failed on',
+  'Page has errors',
+  'Unknown step type',
+  'No steps found for section',
+  'No journey steps found'
+]
+
+function parseArgs(argv) {
+  const opts = {
+    slug: null,
+    crn: DEFAULT_CRN,
+    stop: undefined,
+    start: 'start',
+    headed: false,
+    clear: false,
+    baseUrl: DEFAULT_BASE_URL,
+    timeout: DEFAULT_TIMEOUT_MS
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--headed') {
+      opts.headed = true
+    } else if (arg === '--clear') {
+      opts.clear = true
+    } else if (arg === '--crn') {
+      opts.crn = argv[++i]
+    } else if (arg === '--stop') {
+      opts.stop = argv[++i]
+    } else if (arg === '--start') {
+      opts.start = argv[++i]
+    } else if (arg === '--base-url') {
+      opts.baseUrl = argv[++i]
+    } else if (arg === '--timeout') {
+      opts.timeout = parseInt(argv[++i], 10)
+    } else if (!arg.startsWith('-') && !opts.slug) {
+      opts.slug = arg
+    }
+  }
+  return opts
+}
+
+/**
+ * Coerce the `--stop` value into the shape `runJourney` expects: a number when
+ * numeric (stop before that 1-indexed step), otherwise the section string, or
+ * undefined to run to the end.
+ * @param {string | undefined} stop
+ * @returns {number | string | undefined}
+ */
+function normaliseStop(stop) {
+  if (stop === undefined) {
+    return undefined
+  }
+  const asNumber = Number(stop)
+  return Number.isInteger(asNumber) && asNumber > 0 ? asNumber : stop
+}
+
+/**
+ * Sign in through the DefraID stub if its login form is on the page. No-op for
+ * journeys that don't require auth (the CRN input simply won't be present).
+ * @param {import('@playwright/test').Page} page
+ * @param {string} crn
+ * @returns {Promise<void>}
+ */
+async function loginIfNeeded(page, crn) {
+  const crnInput = page.locator("//input[@id='crn']")
+  if (!(await crnInput.isVisible().catch(() => false))) {
+    return
+  }
+
+  console.log(`${LOG_PREFIX} Signing in via DefraID stub as CRN ${crn}`)
+  await crnInput.fill(crn)
+  await page.locator("//input[@id='password']").fill(process.env.DEFRA_ID_USER_PASSWORD ?? 'x')
+  await page.locator("//button[@type='submit']").click()
+  // The stub processes the sign-in once its login form detaches (mirrors the
+  // acceptance suite) — more reliable than networkidle, which GA keeps busy.
+  await crnInput.waitFor({ state: 'hidden' }).catch(() => {})
+
+  // Multi-business CRNs land on an SBI chooser after submit — pick the first if
+  // it appears; single-business CRNs skip straight through.
+  const sbiRadio = page.locator("input[type='radio']").first()
+  if (await sbiRadio.isVisible().catch(() => false)) {
+    const continueButton = page.locator("//button[@type='submit']")
+    if (await continueButton.isVisible().catch(() => false)) {
+      await sbiRadio.click()
+      await continueButton.click()
+      await page.waitForLoadState('load').catch(() => {})
+    }
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2))
+  if (!opts.slug) {
+    console.error(
+      'Usage: node journey-cli.js <slug> [--crn <crn>] [--stop <n|section>] [--start <page>] [--headed] [--clear] [--base-url <url>]'
+    )
+    process.exit(2)
+  }
+
+  // Headed runs use the system-installed Google Chrome (channel: 'chrome') so
+  // you watch the journey in a real Chrome window; headless uses the bundled
+  // Chromium. `channel` and `executablePath` are mutually exclusive.
+  const launchOpts = {
+    headless: !opts.headed,
+    args: ['--no-sandbox', '--disable-dev-shm-usage']
+  }
+  if (opts.headed) {
+    launchOpts.channel = 'chrome'
+  } else {
+    launchOpts.executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+  }
+  const browser = await chromium.launch(launchOpts)
+  const context = await browser.newContext({
+    baseURL: opts.baseUrl,
+    ignoreHTTPSErrors: true,
+    viewport: { width: 1920, height: 1080 }
+  })
+  // Pre-accept the cookie choice so the GOV.UK cookie banner never renders — its
+  // <form> otherwise sits above the page form and the engine submits it by
+  // mistake (getting stuck on the start page). 'false' = reject analytics, which
+  // also keeps Google Analytics from adding network noise.
+  await context.addCookies([{ name: 'cookie_consent', value: 'false', url: opts.baseUrl }])
+  const page = await context.newPage()
+  page.setDefaultTimeout(opts.timeout)
+  page.setDefaultNavigationTimeout(opts.timeout)
+
+  // Resolve once the engine logs a terminal outcome; forward all engine logs.
+  let settle
+  const outcome = new Promise((resolve) => {
+    settle = resolve
+  })
+  page.on('console', (msg) => {
+    const text = msg.text()
+    if (!text.startsWith(LOG_PREFIX)) {
+      return
+    }
+    console.log(text)
+    if (SUCCESS_MARKERS.some((m) => text.includes(m))) {
+      settle('success')
+    } else if (FAILURE_MARKERS.some((m) => text.includes(m))) {
+      settle('failure')
+    }
+  })
+
+  let result = 'timeout'
+  try {
+    // 'networkidle' is unreliable here — GA and the cross-origin DefraID login
+    // redirect keep the network busy, so wait only for the DOM.
+    await page.goto(`${opts.baseUrl}/${opts.slug}/${opts.start}`, { waitUntil: 'domcontentloaded' })
+    await loginIfNeeded(page, opts.crn)
+
+    // Optionally flush saved application state so the run starts from step 1 —
+    // otherwise the app resumes the furthest-reached page and --stop overshoots.
+    if (opts.clear) {
+      console.log(`${LOG_PREFIX} Clearing application state`)
+      await page.goto(`${opts.baseUrl}/${opts.slug}/clear-application-state`, { waitUntil: 'domcontentloaded' })
+      await page.goto(`${opts.baseUrl}/${opts.slug}/${opts.start}`, { waitUntil: 'domcontentloaded' })
+    }
+
+    // Wait for the auto-injected engine to define its API before triggering it.
+    console.log(`${LOG_PREFIX} Waiting for engine on ${page.url()}`)
+    await page.waitForFunction(() => typeof globalThis.runJourney === 'function')
+
+    const stopArg = normaliseStop(opts.stop)
+    // The first step submits and navigates, which can tear down the evaluate
+    // context — that's expected, not an error.
+    await page.evaluate((arg) => globalThis.runJourney(arg), stopArg ?? null).catch(() => {})
+
+    const timer = new Promise((resolve) => setTimeout(() => resolve('timeout'), opts.timeout))
+    result = await Promise.race([outcome, timer])
+  } catch (err) {
+    console.error(`${LOG_PREFIX} Driver error: ${err.message}`)
+    result = 'failure'
+  }
+
+  if (result !== 'success') {
+    // Surface whatever the final page shows so a stall is diagnosable.
+    const heading = await page
+      .locator('h1')
+      .first()
+      .textContent()
+      .catch(() => null)
+    const errorSummary = await page
+      .locator('.govuk-error-summary')
+      .textContent()
+      .catch(() => null)
+    console.error(
+      `${LOG_PREFIX} Journey did not complete (${result}) at ${page.url()}` +
+        (heading ? `\n  Page heading: "${heading.trim()}"` : '') +
+        (errorSummary ? `\n  Errors: ${errorSummary.trim()}` : '')
+    )
+  }
+
+  // On a headed run, leave the browser open on the page for inspection — exit
+  // only when the user closes the window (or presses Ctrl+C), not on a timer.
+  if (opts.headed) {
+    console.log(`${LOG_PREFIX} Browser left open — close the window (or press Ctrl+C) to exit.`)
+    await new Promise((resolve) => {
+      browser.on('disconnected', resolve)
+      page.on('close', resolve)
+    })
+  }
+
+  await context.close().catch(() => {})
+  await browser.close().catch(() => {})
+  process.exit(result === 'success' ? 0 : 1)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/docs/DEV-TOOLS.md
+++ b/docs/DEV-TOOLS.md
@@ -117,6 +117,46 @@ stopJourney() // Cancel a running journey
 
 Sections allow you to complete one task list section at a time. The section name must match the `section` property in the journey JSON steps.
 
+### Run from the CLI
+
+The same journeys can be driven headlessly from the terminal with `gt journey <slug>`, without opening a browser or the devtools console:
+
+```sh
+gt journey woodland                                   # walk the whole journey headlessly
+gt journey example-grant-with-auth --stop 8           # stop before step 8
+gt journey woodland --stop eligibility                # run only the "eligibility" section
+gt journey example-grant-with-auth --headed           # watch a real browser drive it
+```
+
+#### Or pick from the interactive menu
+
+Prefer not to remember slugs and flags? Run `gt` with no arguments to open the interactive TUI, then choose **`journey ⇢`** from the main menu. It walks you through the same options as prompts — no flags needed:
+
+1. **Journey** — pick from the discovered journey definitions (each annotated with the CRN it uses, or a ⚠ warning if it can't complete on a standard local stack).
+2. **CRN** — only asked when a journey has more than one known-good CRN (e.g. woodland); otherwise the right CRN is chosen automatically.
+3. **Headed or headless** — headless runs in the background (bundled Chromium); headed watches it in your installed Google Chrome.
+4. **Clear state?** — keep the saved application state (resume where it left off) or reset to step 1, matching the footer "Clear application state" link.
+5. **Stop on which page?** — headed runs only: halt the browser on a chosen page for inspection, or run to the end.
+
+Journeys flagged as won't-complete (e.g. **farm-payments**, **methane**) make you acknowledge why before running. The `journey ⇢` item is disabled until the Docker stack is up; for a plain `npm run dev` server use the `gt journey <slug>` form above instead.
+
+Under the hood this launches a Chromium browser (reusing the acceptance suite's Playwright install in `acceptance/`), signs in through the DefraID stub, then calls `runJourney()` on the page and streams the `[journey-runner]` console output to your terminal. It exits non-zero if the journey gets stuck, and prints the final page heading and any error summary to help diagnose the stall.
+
+| Flag               | Default                   | Purpose                                                                                                                                                                                                                                                                                              |
+| ------------------ | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--crn <crn>`      | journey's allowlisted CRN | DefraID CRN to sign in as. Defaults per journey to a CRN on that grant's allowlist — most grants are `allowAll` (uses `1102838829`), but **woodland** needs `1100943757`/`1100943838`, and **farm-payments** uses `1102838829`. The interactive menu lets you pick when a journey has more than one. |
+| `--stop <n\|sect>` | run to the end            | Stop before step `n` (1-indexed), or run only section `sect`                                                                                                                                                                                                                                         |
+| `--headed`         | headless                  | Watch the run in your installed Google Chrome (headless uses bundled Chromium)                                                                                                                                                                                                                       |
+| `--clear`          | keeps state               | Flush saved application state first, so `--stop` starts from step 1                                                                                                                                                                                                                                  |
+| `--base-url <url>` | auto-detected             | App base URL — defaults to `https://localhost:4000` when the HA addon is running, otherwise `http://localhost:3000`                                                                                                                                                                                  |
+| `--skip-install`   | installs chromium         | Skip `playwright install chromium`                                                                                                                                                                                                                                                                   |
+
+The app must already be running (`gt up` or `npm run dev`), and the same land-grants/mockserver setup described below is needed for journeys that reach `/select-land-parcel` or `/total-area-of-woodland`. The stub password comes from `DEFRA_ID_USER_PASSWORD` (defaults to `x`, matching `acceptance/run-local.sh`).
+
+The base URL is auto-detected from the running stack: `http://localhost:3000` normally, or `https://localhost:4000` when the **High Availability** addon (`gt up --ha`) fronts the app with its HTTPS nginx proxy (the self-signed cert is accepted automatically). Override with `--base-url` for a non-standard setup.
+
+The journey must be allowlisted for the signed-in user, or the app redirects to `/auth/journey-unauthorised` and the run reports as stuck. Locally the allowlist lives in the `config__allowlist_entries` collection in the `grants-ui-backend` Mongo database; `example-grant-with-auth` is seeded `allowAll`, so it's the most reliable journey to smoke-test with.
+
 ### Adding a new journey
 
 Create a JSON file in `journey-runner/journeys/` named after the grant's URL slug (e.g. `methane.json`).
@@ -142,19 +182,20 @@ Each step requires:
 
 ### Step types
 
-| Type            | Description                            | Extra fields                                                                   |
-| --------------- | -------------------------------------- | ------------------------------------------------------------------------------ |
-| `submitOnly`    | Clicks the submit button               | None                                                                           |
-| `yesNo`         | Selects a radio button and submits     | `fieldName`, `value` (default `"true"`)                                        |
-| `radios`        | Selects the first radio option         | `fieldName`                                                                    |
-| `checkboxes`    | Selects the first checkbox             | `fieldName`, `selectAll` (optional; `true` ticks every checkbox for the field) |
-| `numberField`   | Fills a number/text input              | `fieldName`, `value`                                                           |
-| `selectField`   | Selects the first non-empty option     | `fieldName`                                                                    |
-| `multilineText` | Fills a textarea                       | `fieldName`, `value`                                                           |
-| `dateParts`     | Fills day/month/year inputs with today | `fieldName`, `offsetDays` (optional, shifts date)                              |
-| `monthYear`     | Fills month/year inputs with current   | `fieldName`                                                                    |
-| `textFields`    | Fills multiple text inputs at once     | `fields` (object of `{ name: value }` pairs)                                   |
-| `clickLink`     | Clicks a link by its href suffix       | `linkSlug`                                                                     |
+| Type            | Description                                                                                             | Extra fields                                                                                            |
+| --------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `submitOnly`    | Clicks the submit button                                                                                | None                                                                                                    |
+| `yesNo`         | Selects a radio button and submits                                                                      | `fieldName`, `value` (default `"true"`)                                                                 |
+| `radios`        | Selects a radio option                                                                                  | `fieldName`, `value` (optional; selects that specific option, e.g. a land parcel, instead of the first) |
+| `checkboxes`    | Selects the first checkbox                                                                              | `fieldName`, `selectAll` (optional; `true` ticks every checkbox for the field)                          |
+| `landActions`   | Ticks a land-grants action checkbox and fills its revealed quantity input (`landActionQuantity_<code>`) | `fieldName`, `value` (optional quantity, default `1`)                                                   |
+| `numberField`   | Fills a number/text input                                                                               | `fieldName`, `value`                                                                                    |
+| `selectField`   | Selects the first non-empty option                                                                      | `fieldName`                                                                                             |
+| `multilineText` | Fills a textarea                                                                                        | `fieldName`, `value`                                                                                    |
+| `dateParts`     | Fills day/month/year inputs with today                                                                  | `fieldName`, `offsetDays` (optional, shifts date)                                                       |
+| `monthYear`     | Fills month/year inputs with current                                                                    | `fieldName`                                                                                             |
+| `textFields`    | Fills multiple text inputs at once                                                                      | `fields` (object of `{ name: value }` pairs)                                                            |
+| `clickLink`     | Clicks a link by its href suffix                                                                        | `linkSlug`                                                                                              |
 
 ### Existing journeys
 
@@ -162,10 +203,12 @@ Each step requires:
 | ----------------------------------- | ------------------------- |
 | `example-grant-with-auth.json`      | Example grant (with auth) |
 | `example-grant-with-task-list.json` | Example grant (task list) |
-| `farm-payments.json`                | Farm payments             |
+| `farm-payments.json`                | Farm payments (see note)  |
 | `pigs-might-fly.json`               | Flying pigs               |
 | `methane.json`                      | Methane                   |
 | `woodland.json`                     | Woodland Management Plan  |
+
+> **farm-payments note:** the journey enters at `/confirm-farm-details` (this grant has no `/start` page) and runs cleanly up to `/select-actions-for-land-parcel`. Completing `select-actions` needs a land parcel that the land-grants backend accepts for the offered actions — the seeded actions are moorland-only (`CMOR1`, `UPL1`–`UPL3`), so a **majority-moorland parcel** is required. If the local land-grants seed has no moorland parcel, every parcel is rejected with _"This parcel is not majority on the moorland"_ and the runner stops there. That is a backend seed-data condition, not a journey-spec problem. Once such a parcel exists, add its ID as the `value` on the `select-land-parcel` step to target it.
 
 ### Example grant with auth
 
@@ -234,9 +277,9 @@ If `runJourney()` reports `Stuck on "SelectLandParcel"`, the most likely cause i
 
 ### Woodland Management Plan
 
-Navigate to `http://localhost:3000/woodland/start` and open the browser console.
+Navigate to `http://localhost:3000/woodland/check-details` (woodland's first page — it has no `/start`) and open the browser console.
 
-Sign in with CRN `1102838829` — this CRN has selectable land parcels, which the woodland journey requires.
+Sign in with CRN `1100943757` (or `1100943838`) — woodland's allowlist only admits these CRNs, **not** `1102838829`. (`gt journey woodland` picks the right CRN automatically.)
 
 The `total-area-of-woodland` page POSTs to the land-grants-api `/api/v1/wmp/validate` endpoint. To keep the journey runner reliable regardless of which compose stack is running, point `LAND_GRANTS_API_URL` at mockserver — which has a mock success response in `mockserver/expectations.json`. If you're running with `compose.land-grants.yml` (real backend), layer in `compose.journey-runner.yml` to override the URL back to mockserver:
 
@@ -251,46 +294,47 @@ If you change `mockserver/expectations.json` mid-session and the journey still s
 
 1. `docker compose restart mockserver` — reload expectations
 2. Visit `http://localhost:3000/woodland/clear-application-state` — flushes Redis session state and the in-memory parcel cache in one hit
-3. Re-run `runJourney()` from `/woodland/start`
+3. Re-run `runJourney()` from `/woodland/check-details`
 
 A full grants-ui restart is _not_ needed thanks to step 2.
 
 ```js
-// Run from /woodland/start or /woodland/tasks
+// Run from /woodland/check-details or /woodland/tasks
 runJourney() // Run all remaining sections from the current page
-
-// Run from /woodland/start
-runJourney('start') // Submit start and check details pages to reach task list
 
 // Run from /woodland/tasks
 runJourney('eligibility') // Complete the eligibility section
 runJourney('about-woodland') // Complete the about your woodland section
+runJourney('check-and-submit') // Summary, potential funding and declaration
 ```
 
 Available sections:
 
-| Section          | Description                                       |
-| ---------------- | ------------------------------------------------- |
-| `start`          | Start and check details pages (reaches task list) |
-| `eligibility`    | Eligibility questions (land, tenancy, WMP, etc.)  |
-| `about-woodland` | Woodland details (area, grid ref, FC team)        |
+| Section            | Description                                      |
+| ------------------ | ------------------------------------------------ |
+| `eligibility`      | Eligibility questions (land, tenancy, WMP, etc.) |
+| `about-woodland`   | Woodland details (area, grid ref, FC team)       |
+| `check-and-submit` | Summary, potential funding and declaration       |
 
 Steps (use with `runJourney(N)` to stop before step `N`):
 
-| Step | Page slug                        | Section          | Purpose                                                      |
-| ---- | -------------------------------- | ---------------- | ------------------------------------------------------------ |
-| 1    | `start`                          | `start`          | Start page (submit only)                                     |
-| 2    | `check-details`                  | `start`          | Confirm business details (DefraID) — answers "Yes"           |
-| 3    | `tasks`                          | `eligibility`    | Task list — clicks the "eligibility-land-registered" link    |
-| 4    | `eligibility-land-registered`    | `eligibility`    | Land registered with RPA — "Yes"                             |
-| 5    | `eligibility-management-control` | `eligibility`    | Management control of the land — "Yes"                       |
-| 6    | `eligibility-tenant`             | `eligibility`    | Public body tenant — "No"                                    |
-| 7    | `eligibility-grazing-rights`     | `eligibility`    | Land has grazing rights — "No"                               |
-| 8    | `eligibility-valid-wmp`          | `eligibility`    | Existing valid WMP — "No"                                    |
-| 9    | `eligibility-higher-tier`        | `eligibility`    | Intent to apply for Higher Tier — "No"                       |
-| 10   | `tasks`                          | `about-woodland` | Task list — clicks the "land-parcels" link                   |
-| 11   | `land-parcels`                   | `about-woodland` | Select land parcels (`selectAll: true` ticks every checkbox) |
-| 12   | `total-area-of-woodland`         | `about-woodland` | Hectares ≥10 years old (30) and <10 years old (20)           |
-| 13   | `centre-of-woodland`             | `about-woodland` | Centre-of-woodland OS grid reference (`SP 4178 2432`)        |
-| 14   | `woodland-name`                  | `about-woodland` | Woodland name (`Test Woodland`)                              |
-| 15   | `which-forestry-commission-team` | `about-woodland` | Forestry Commission team — selects the first radio option    |
+| Step | Page slug                        | Section            | Purpose                                                         |
+| ---- | -------------------------------- | ------------------ | --------------------------------------------------------------- |
+| 1    | `check-details`                  | —                  | Confirm business details (DefraID) — answers "Yes" (entry page) |
+| 2    | `tasks`                          | `eligibility`      | Task list — clicks the "eligibility-land-registered" link       |
+| 3    | `eligibility-land-registered`    | `eligibility`      | Land registered with RPA — "Yes"                                |
+| 4    | `eligibility-management-control` | `eligibility`      | Management control of the land — "Yes"                          |
+| 5    | `eligibility-tenant`             | `eligibility`      | Public body tenant — "No"                                       |
+| 6    | `eligibility-grazing-rights`     | `eligibility`      | Land has grazing rights — "No"                                  |
+| 7    | `eligibility-valid-wmp`          | `eligibility`      | Existing valid WMP — "No"                                       |
+| 8    | `eligibility-higher-tier`        | `eligibility`      | Intent to apply for Higher Tier — "No"                          |
+| 9    | `tasks`                          | `about-woodland`   | Task list — clicks the "land-parcels" link                      |
+| 10   | `land-parcels`                   | `about-woodland`   | Select land parcels (`selectAll: true` ticks every checkbox)    |
+| 11   | `total-area-of-woodland`         | `about-woodland`   | Hectares ≥10 years old (30) and <10 years old (20)              |
+| 12   | `centre-of-woodland`             | `about-woodland`   | Centre-of-woodland OS grid reference (`SP 4178 2432`)           |
+| 13   | `woodland-name`                  | `about-woodland`   | Woodland name (`Test Woodland`)                                 |
+| 14   | `which-forestry-commission-team` | `about-woodland`   | Forestry Commission team — selects the first radio option       |
+| 15   | `tasks`                          | `check-and-submit` | Task list — clicks the "summary" link                           |
+| 16   | `summary`                        | `check-and-submit` | Check your answers — submit                                     |
+| 17   | `potential-funding`              | `check-and-submit` | Potential funding — submit                                      |
+| 18   | `declaration`                    | `check-and-submit` | Confirm and send — submits the application                      |

--- a/src/server/dev-tools/journey-runner/journeys/example-grant-with-task-list.json
+++ b/src/server/dev-tools/journey-runner/journeys/example-grant-with-task-list.json
@@ -1,9 +1,10 @@
 [
   { "slug": "start", "name": "Start", "type": "submitOnly" },
   { "slug": "eligibility-check", "name": "Eligibility check", "type": "yesNo", "fieldName": "eligibilityCheck" },
+
   {
     "slug": "tasks",
-    "name": "Task list — section one task one",
+    "name": "Task list — task one",
     "type": "clickLink",
     "linkSlug": "multiple-components-task-page"
   },
@@ -17,11 +18,12 @@
       "lastName": "User"
     }
   },
+  { "slug": "optional-choice-task-page", "name": "Optional choice", "type": "yesNo", "fieldName": "choice" },
   {
-    "slug": "tasks",
-    "name": "Task list — section one task two",
-    "type": "clickLink",
-    "linkSlug": "single-component-task-page"
+    "slug": "conditional-question",
+    "name": "Conditional question",
+    "type": "yesNo",
+    "fieldName": "conditionalQuestion"
   },
   {
     "slug": "single-component-task-page",
@@ -31,9 +33,10 @@
       "exampleEmailField": "test@example.com"
     }
   },
+
   {
     "slug": "tasks",
-    "name": "Task list — section two task one",
+    "name": "Task list — task two",
     "type": "clickLink",
     "linkSlug": "compound-component-task-page"
   },
@@ -48,10 +51,11 @@
     }
   },
   {
-    "slug": "tasks",
-    "name": "Task list — section two task two",
-    "type": "clickLink",
-    "linkSlug": "example-task-with-guidance"
+    "slug": "select-land-parcel",
+    "name": "Select land parcel",
+    "type": "checkboxes",
+    "fieldName": "landParcels",
+    "selectAll": true
   },
   {
     "slug": "example-task-with-guidance",
@@ -60,7 +64,8 @@
     "fieldName": "exampleNumberField",
     "value": "42"
   },
-  { "slug": "tasks", "name": "Task list — declaration", "type": "clickLink", "linkSlug": "declaration" },
-  { "slug": "declaration", "name": "Confirm and send", "type": "submitOnly" },
-  { "slug": "confirmation", "name": "Confirmation", "type": "submitOnly" }
+
+  { "slug": "tasks", "name": "Task list — submit", "type": "clickLink", "linkSlug": "summary" },
+  { "slug": "summary", "name": "Check your answers", "type": "submitOnly" },
+  { "slug": "declaration", "name": "Confirm and send", "type": "submitOnly" }
 ]

--- a/src/server/dev-tools/journey-runner/journeys/farm-payments.json
+++ b/src/server/dev-tools/journey-runner/journeys/farm-payments.json
@@ -2,11 +2,11 @@
   { "slug": "confirm-farm-details", "name": "Confirm your details", "type": "submitOnly" },
   { "slug": "confirm-you-will-be-eligible", "name": "Confirm eligibility", "type": "submitOnly" },
   { "slug": "confirm-your-land-details-are-up-to-date", "name": "Confirm land details", "type": "submitOnly" },
-  { "slug": "select-land-parcel", "name": "Select land parcel", "type": "radios", "fieldName": "selectedLandParcel" },
+  { "slug": "select-land-parcel", "name": "Select land parcel", "type": "radios", "fieldName": "landParcels" },
   {
     "slug": "select-actions-for-land-parcel",
     "name": "Select actions",
-    "type": "checkboxes",
+    "type": "landActions",
     "fieldName": "landAction_1"
   },
   {
@@ -17,6 +17,5 @@
     "value": "false"
   },
   { "slug": "you-must-have-consent", "name": "Consent", "type": "submitOnly" },
-  { "slug": "submit-your-application", "name": "Submit application", "type": "submitOnly" },
-  { "slug": "confirmation", "name": "Confirmation", "type": "submitOnly" }
+  { "slug": "submit-your-application", "name": "Submit application", "type": "submitOnly" }
 ]

--- a/src/server/dev-tools/journey-runner/journeys/woodland.json
+++ b/src/server/dev-tools/journey-runner/journeys/woodland.json
@@ -1,12 +1,10 @@
 [
-  { "slug": "start", "name": "Start", "type": "submitOnly", "section": "start" },
   {
     "slug": "check-details",
     "name": "Check details — Yes",
     "type": "yesNo",
     "fieldName": "businessDetailsUpToDate",
-    "value": "true",
-    "section": "start"
+    "value": "true"
   },
 
   {
@@ -110,5 +108,16 @@
     "type": "radios",
     "fieldName": "fcTeamCode",
     "section": "about-woodland"
-  }
+  },
+
+  {
+    "slug": "tasks",
+    "name": "Task list — check and submit",
+    "type": "clickLink",
+    "linkSlug": "summary",
+    "section": "check-and-submit"
+  },
+  { "slug": "summary", "name": "Check your answers", "type": "submitOnly", "section": "check-and-submit" },
+  { "slug": "potential-funding", "name": "Potential funding", "type": "submitOnly", "section": "check-and-submit" },
+  { "slug": "declaration", "name": "Confirm and send", "type": "submitOnly", "section": "check-and-submit" }
 ]

--- a/src/server/dev-tools/journey-runner/runner-engine.js
+++ b/src/server/dev-tools/journey-runner/runner-engine.js
@@ -130,9 +130,15 @@
     },
 
     radios(step) {
-      const radio = document.querySelector(inputSelector(step.fieldName))
+      // With `value`, pick that specific option (e.g. a particular land parcel);
+      // otherwise take the first radio in the group.
+      const selector = step.value
+        ? `input[name="${step.fieldName}"][value="${step.value}"]`
+        : inputSelector(step.fieldName)
+      const radio = document.querySelector(selector)
       if (!radio) {
-        throw new Error(`${step.fieldName} radio not found`)
+        const valueSuffix = step.value ? ` with value "${step.value}"` : ''
+        throw new Error(`${step.fieldName} radio${valueSuffix} not found`)
       }
       radio.click()
       submitForm()
@@ -145,6 +151,23 @@
       }
       const toClick = step.selectAll ? Array.from(all) : [all[0]]
       toClick.forEach((cb) => cb.click())
+      submitForm()
+    },
+
+    landActions(step) {
+      // Land-grants "select actions" pages tick an action checkbox, which reveals
+      // a required quantity input named `landActionQuantity_<actionCode>` where the
+      // action code is the checkbox's value. Tick the first action, then fill its
+      // revealed quantity before submitting.
+      const checkbox = document.querySelector(inputSelector(step.fieldName))
+      if (!checkbox) {
+        throw new Error(`${step.fieldName} action checkbox not found`)
+      }
+      checkbox.click()
+      const quantityField = document.querySelector(`input[name="landActionQuantity_${checkbox.value}"]`)
+      if (quantityField) {
+        setInputValue(quantityField, step.value ?? '1')
+      }
       submitForm()
     },
 
@@ -369,6 +392,15 @@
     const stuckIdx = findStuckStep(state.lastCompleted ?? -1, state.section)
     if (stuckIdx !== -1) {
       console.error(`${LOG_PREFIX} ${buildStuckErrorReport(steps[stuckIdx], stuckIdx)}`)
+      return
+    }
+    // A section run that completed no steps never started: the current page is
+    // not one of the section's pages (e.g. a cold run entered on the grant's
+    // first page, before the section is reachable). Report failure rather than a
+    // spurious "journey complete", whose wording would otherwise be picked up as
+    // a success by the CLI driver's SUCCESS_MARKERS.
+    if (state.section && (state.lastCompleted ?? -1) < 0) {
+      console.error(`${LOG_PREFIX} No steps found for section "${state.section}" on ${globalThis.location.pathname}`)
       return
     }
     console.log(`${LOG_PREFIX} Reached ${globalThis.location.pathname} - not a known step, journey complete`)

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,6 +2,12 @@
 
 Utility scripts for the grants-ui project.
 
+## grants-tui.js (`gt`)
+
+Interactive TUI / CLI wrapper for the local dev stack (compose up/down, tests, journeys, sonar, snyk). Run `gt --help` for the full flag list.
+
+See [docs/DEV-TOOLS.md](../docs/DEV-TOOLS.md) for the dev-tooling reference, including the headless Journey Runner (`gt journey <slug>`).
+
 ## unseal-cookie.js
 
 Unseal encrypted Hapi session cookies for debugging.

--- a/tools/grants-tui.js
+++ b/tools/grants-tui.js
@@ -88,6 +88,7 @@ import {
 import { pauseStdin, promptScale, radioMenu, releaseStdin, resumeStdin, toggleMenu } from './grants-tui/tui.js'
 import { cmdTest, testLogPath } from './grants-tui/tests.js'
 import { cmdSonar } from './grants-tui/sonar.js'
+import { cmdJourney, journeyCrnOptions, journeySteps, listJourneys, wontCompleteReason } from './grants-tui/journey.js'
 
 // Sweep of stale tool logs from tmpdir. macOS auto-clears windows tmpdir
 // after ~3 days
@@ -311,6 +312,17 @@ function getRunningComposeFiles() {
     .trim()
     .split(',')
     .map((f) => f.trim())
+}
+
+/**
+ * Base URL for the running app: the HA addon fronts it with an HTTPS nginx proxy
+ * on 4000, every other stack serves plain HTTP on 3000. Used to default
+ * `gt journey`'s target so it works without a manual --base-url.
+ * @returns {string}
+ */
+function journeyBaseUrl() {
+  const runningFiles = getRunningComposeFiles()
+  return runningFiles?.some((f) => f.endsWith('compose.ha.yml')) ? 'https://localhost:4000' : 'http://localhost:3000'
 }
 
 /** Returns the list of running compose service names for the grants-ui project */
@@ -754,6 +766,7 @@ ${BOLD}Commands:${RESET_COLOR}
   debug   Restart grants-ui in debug mode (detached, port 9229)
   restart Restart running containers (selectable; uses --no-deps)
   test    Run tests: ${TEST_TARGETS.map((t) => t.key).join(' | ')} (default: ${TEST_TARGETS[0].key})
+  journey Run a Journey Runner journey headlessly (${listJourneys().join(' | ')})
   sonar   Run SonarQube analysis against a local server (--changed scopes to PR files; --down stops it)
   snyk    Run Snyk dependency vulnerability scan (same as CI; needs a Snyk login — see below)
   check   Pre-PR full check: all test suites + snyk + PR-scoped sonar (runs every step, summarises)
@@ -767,6 +780,15 @@ ${BOLD}Other flags:${RESET_COLOR}
   --dry-run      Print commands without running them
   --help         Show this help
   --version      Show version number
+
+${BOLD}Journey flags (for 'journey'):${RESET_COLOR}
+  --crn <crn>      DefraID CRN to sign in as (default: the journey's allowlisted CRN, e.g. woodland → 1100943757)
+  --stop <n|sect>  Stop before step <n> (1-indexed) or run only section <sect>
+  --headed         Watch it run in your installed Google Chrome (headless uses bundled Chromium)
+  --clear          Flush saved application state first (so --stop starts at step 1)
+  --base-url <url> App base URL (auto: https://localhost:4000 on --ha, else http://localhost:3000)
+  --skip-install   Skip 'playwright install chromium'
+  ${DIM}Full journey/section reference: docs/DEV-TOOLS.md ("Run from the CLI")${RESET_COLOR}
 
 ${BOLD}Snyk auth (for 'snyk'):${RESET_COLOR}
   One-time login — no org/paid token needed, a FREE personal Snyk account works:
@@ -787,6 +809,8 @@ ${BOLD}Examples:${RESET_COLOR}
   gt restart
   gt test                            # unit tests (default)
   gt test acceptance                 # docker-based acceptance journeys
+  gt journey woodland                # walk the woodland journey headlessly
+  gt journey example-grant-with-auth --stop 8 --headed   # watch it, stop before step 8
   gt sonar                           # local SonarQube scan of src/
   gt sonar --changed                 # scope scan to src files changed vs main (approx. CI PR view)
   gt sonar --down                    # stop the local SonarQube server
@@ -819,9 +843,11 @@ async function main() {
 
   // Validate args before doing anything else — catch unrecognised flags/commands early
   {
-    const knownCmds = ['up', 'down', 'debug', 'restart', 'reset', 'test', 'sonar', 'snyk', 'check']
+    const knownCmds = ['up', 'down', 'debug', 'restart', 'reset', 'test', 'sonar', 'snyk', 'check', 'journey']
     // Test targets are valid positionals only after the `test` command
     const testTargetKeys = argv.includes('test') ? TEST_TARGETS.map((t) => t.key) : []
+    // The journey slug is a free positional straight after the `journey` command.
+    const journeyIdx = argv.indexOf('journey')
     const knownFlags = [
       '--dry-run',
       '--help',
@@ -835,15 +861,28 @@ async function main() {
       '--down',
       '--skip-tests',
       '--changed',
+      '--crn',
+      '--stop',
+      '--headed',
+      '--clear',
+      '--base-url',
+      '--skip-install',
       ...LOCAL_SERVICES.map((s) => `--local-${s.key}`)
     ]
-    const scaleValIdx = argv.indexOf('--scale')
+    // Flags that consume the following positional as their value — so it isn't
+    // mistaken for an unknown command.
+    const valueFlagIdxs = ['--scale', '--crn', '--stop', '--base-url']
+      .map((f) => argv.indexOf(f))
+      .filter((i) => i !== -1)
+      .map((i) => i + 1)
     const unknownCmd = argv.find(
       (a, i) =>
         !a.startsWith('-') &&
         !knownCmds.includes(a) &&
         !testTargetKeys.includes(a) &&
-        !(scaleValIdx !== -1 && i === scaleValIdx + 1)
+        !valueFlagIdxs.includes(i) &&
+        // the journey slug positional (immediately after `journey`) is allowed
+        !(journeyIdx !== -1 && i === journeyIdx + 1)
     )
     const unknownFlag = argv.filter((a) => a.startsWith('-')).find((a) => !knownFlags.includes(a))
     if (unknownCmd) {
@@ -866,10 +905,13 @@ async function main() {
     : []
   const testNeedsDocker = testTargets.some((k) => TEST_TARGETS.find((t) => t.key === k)?.needsDocker)
   const snykInvoked = argv.includes('snyk')
+  // `journey` drives a browser against localhost:3000, which may be a plain
+  // `npm run dev` rather than the Docker stack — don't force a Docker check.
+  const journeyInvoked = argv.includes('journey')
 
   // Preflight: ensure Docker is available and running (skipped for --dry-run so
-  // offline/CI usage works, and for test/snyk runs that don't drive containers)
-  if (!dryRun && !(testInvoked && !testNeedsDocker) && !snykInvoked) {
+  // offline/CI usage works, and for test/snyk/journey runs that don't drive containers)
+  if (!dryRun && !(testInvoked && !testNeedsDocker) && !snykInvoked && !journeyInvoked) {
     const dockerCheck = spawnSync('docker', ['info'], { encoding: 'utf8', stdio: 'pipe' })
     if (dockerCheck.status !== 0 || dockerCheck.error) {
       console.error(
@@ -926,6 +968,28 @@ async function main() {
   if (argv.includes('check')) {
     releaseStdin()
     process.exit(await cmdCheck(dryRun))
+  }
+  if (argv.includes('journey')) {
+    releaseStdin()
+    const journeyIdx = argv.indexOf('journey')
+    const slug = argv[journeyIdx + 1] && !argv[journeyIdx + 1].startsWith('-') ? argv[journeyIdx + 1] : ''
+    const valueOf = (flag) => {
+      const i = argv.indexOf(flag)
+      return i !== -1 ? argv[i + 1] : undefined
+    }
+    // Default the base URL to match the running stack: the HA addon fronts the
+    // app with an HTTPS nginx proxy on 4000, everything else serves plain HTTP on
+    // 3000. An explicit --base-url always wins.
+    const baseUrl = valueOf('--base-url') ?? journeyBaseUrl()
+    const opts = {
+      crn: valueOf('--crn'),
+      stop: valueOf('--stop'),
+      baseUrl,
+      headed: argv.includes('--headed'),
+      clear: argv.includes('--clear'),
+      skipInstall: argv.includes('--skip-install')
+    }
+    process.exit(cmdJourney(slug, opts, dryRun))
   }
   if (argv.includes('up')) {
     const flaggedAddons = ADDONS.filter((a) => argv.includes(`--${a.key}`)).map((a) => a.key)
@@ -1020,6 +1084,12 @@ async function main() {
           ]
         : []),
       { key: 'test', label: 'test ⇢', description: 'Run unit / contract / acceptance tests' },
+      {
+        key: 'journey',
+        label: 'journey ⇢',
+        description: 'Walk a Journey Runner journey headlessly',
+        disabled: !containersRunning
+      },
       {
         key: 'sonar',
         label: 'sonar',
@@ -1275,6 +1345,141 @@ async function main() {
         const outputs = !dryRun && passed.length ? ` — output: ${passed.map((k) => testLogPath(k)).join(', ')}` : ''
         statusLine = `${PURPLE}✔  Passed: ${passed.join(', ')}${RESET_COLOR}${outputs}`
       }
+      continue
+    }
+
+    if (command === 'journey') {
+      const journeys = listJourneys()
+      if (!journeys.length) {
+        statusLine = `${DIM}No journey definitions found${RESET_COLOR}`
+        continue
+      }
+      const SELECT_HINT = '↑ ↓  navigate    enter → select    esc → cancel'
+      // Annotate each journey with the CRN it needs (or a warning if it can't complete).
+      const journeyItems = journeys.map((slug) => {
+        const crns = journeyCrnOptions(slug)
+        const description = wontCompleteReason(slug)
+          ? `${YELLOW}⚠ may not complete${RESET_COLOR}`
+          : `${DIM}CRN ${crns[0]?.crn ?? '—'}${RESET_COLOR}`
+        return { key: slug, label: slug, description }
+      })
+      const chosen = await radioMenu(journeyItems, 'Select a journey to run', { hint: SELECT_HINT })
+      if (chosen === '__quit__') {
+        statusLine = ''
+        continue
+      }
+
+      // Pick the CRN to sign in as. Journeys with more than one known-good CRN
+      // prompt; a single option is used automatically (methane has none — the
+      // won't-complete acknowledgement below covers it).
+      const crnOptions = journeyCrnOptions(chosen)
+      let crn = crnOptions[0]?.crn
+      if (crnOptions.length > 1) {
+        const crnItems = crnOptions.map((o) => ({ key: o.crn, label: o.crn, description: o.note }))
+        const pickedCrn = await radioMenu(crnItems, `Select a CRN for '${chosen}'`, { hint: SELECT_HINT })
+        if (pickedCrn === '__quit__') {
+          statusLine = ''
+          continue
+        }
+        crn = pickedCrn
+      }
+
+      // Then pick how to run it — headless (bundled Chromium) or headed (your Chrome).
+      const modeItems = [
+        { key: 'headless', label: 'headless', description: 'Run in the background (bundled Chromium)' },
+        { key: 'headed', label: 'headed', description: 'Watch it in your installed Google Chrome' }
+      ]
+      const mode = await radioMenu(modeItems, `Run '${chosen}' — headed or headless?`, { hint: SELECT_HINT })
+      if (mode === '__quit__') {
+        statusLine = ''
+        continue
+      }
+
+      // Then choose whether to flush saved application state first — the same
+      // reset the "Clear application state" footer link performs — so the run
+      // starts from step 1 rather than resuming the furthest-reached page.
+      const clearItems = [
+        { key: 'keep', label: 'keep state', description: 'Resume from where this application left off' },
+        {
+          key: 'clear',
+          label: 'clear state',
+          description: 'Reset to step 1 (like the footer "Clear application state" link)'
+        }
+      ]
+      const clearChoice = await radioMenu(clearItems, `Clear application state for '${chosen}' before running?`, {
+        hint: '↑ ↓  navigate    enter → run    esc → cancel'
+      })
+      if (clearChoice === '__quit__') {
+        statusLine = ''
+        continue
+      }
+
+      // For journeys known not to complete (e.g. farm-payments), make the user
+      // acknowledge why before running — a selectable confirm, not just a keypress.
+      const wontComplete = wontCompleteReason(chosen)
+      if (wontComplete) {
+        const ackItems = [
+          {
+            key: 'cancel',
+            label: 'Cancel',
+            description: 'Back to the menu'
+          },
+          {
+            key: 'run',
+            label: 'Run anyway',
+            description: wontComplete.join(' ')
+          }
+        ]
+        const ack = await radioMenu(ackItems, `${YELLOW}⚠  '${chosen}' will NOT complete — run anyway?${RESET_COLOR}`, {
+          hint: SELECT_HINT
+        })
+        if (ack !== 'run') {
+          statusLine = ack === '__quit__' ? '' : `${DIM}Journey '${chosen}' cancelled${RESET_COLOR}`
+          continue
+        }
+      }
+
+      // Headed only: let the user stop the browser on a chosen page. Lists every
+      // page in the journey; picking one passes it as --stop so the run halts
+      // there (on the page, before filling it) for inspection.
+      let stop
+      if (mode === 'headed') {
+        const steps = journeySteps(chosen)
+        const stopItems = [
+          { key: '__end__', label: 'Run to the end', description: 'Complete the whole journey' },
+          ...steps.map((s, i) => ({
+            key: String(i + 1),
+            label: `${i + 1}. ${s.slug}`,
+            description: s.name === s.slug ? '' : s.name
+          }))
+        ]
+        const pickedStop = await radioMenu(stopItems, `Stop '${chosen}' on which page?`, { hint: SELECT_HINT })
+        if (pickedStop === '__quit__') {
+          statusLine = ''
+          continue
+        }
+        if (pickedStop !== '__end__') stop = pickedStop
+      }
+
+      pauseStdin()
+      const code = cmdJourney(
+        chosen,
+        {
+          crn,
+          stop,
+          baseUrl: journeyBaseUrl(),
+          headed: mode === 'headed',
+          clear: clearChoice === 'clear',
+          acknowledged: true
+        },
+        dryRun
+      )
+      resumeStdin()
+
+      statusLine =
+        code === 0
+          ? `${PURPLE}✔  Journey '${chosen}' completed${RESET_COLOR}`
+          : `${RED}✖${RESET_COLOR}  Journey '${chosen}' did not complete (exit ${code}) — check output above`
       continue
     }
 

--- a/tools/grants-tui/constants.js
+++ b/tools/grants-tui/constants.js
@@ -17,6 +17,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 export const ROOT = resolve(__dirname, '..', '..')
 export const STATE_FILE = resolve(ROOT, '.grants-ui-cli-state.json')
 
+// The acceptance suite owns the Playwright install + chromium binary; the
+// `gt journey` CLI driver (acceptance/journey-cli.js) reuses them.
+export const ACCEPTANCE_DIR = resolve(ROOT, 'acceptance')
+export const JOURNEY_CLI_SCRIPT = resolve(ACCEPTANCE_DIR, 'journey-cli.js')
+// Journey definitions the runner steps through — one JSON per grant slug.
+export const JOURNEYS_DIR = resolve(ROOT, 'src/server/dev-tools/journey-runner/journeys')
+
 // Folder holding developer-private form-definition overrides, mirroring the
 // config repo layout `<grant>/<service>/<file>`. A single toggle enables/disables
 // all overrides found here.

--- a/tools/grants-tui/journey.js
+++ b/tools/grants-tui/journey.js
@@ -1,0 +1,236 @@
+/* eslint-disable no-console, curly */
+
+import { spawnSync } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, readSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import {
+  ACCEPTANCE_DIR,
+  BOLD,
+  CYAN,
+  DIM,
+  JOURNEY_CLI_SCRIPT,
+  JOURNEYS_DIR,
+  RED,
+  RESET_COLOR,
+  YELLOW
+} from './constants.js'
+
+const SLUG_PATTERN = /^[a-z0-9-]+$/
+
+// Generic CRN for the many grants whose allowlist is `allowAll: true`.
+export const DEFAULT_CRN = '1102838829'
+
+/**
+ * CRNs known to work for a journey, most-suitable first. Only journeys that need
+ * a *specific* CRN are listed; anything absent uses DEFAULT_CRN (its allowlist is
+ * `allowAll`). Sourced from localstack/config-broker/local-allowlists/*.yaml.
+ * @type {Record<string, {crn: string, note: string}[]>}
+ */
+const JOURNEY_CRNS = {
+  woodland: [
+    { crn: '1100943757', note: 'woodland allowlist (SBI 113593357)' },
+    { crn: '1100943838', note: 'woodland allowlist (SBI 107173507)' }
+  ],
+  'farm-payments': [{ crn: '1102838829', note: 'farm-payments allowlist + seeded land parcels' }]
+  // methane is `allowAll` once seeded (see SELF_SEED_GRANTS), so it uses DEFAULT_CRN.
+}
+
+/**
+ * CRN options for a journey (most-suitable first). Journeys not in JOURNEY_CRNS
+ * are `allowAll`, so any CRN works and DEFAULT_CRN is offered.
+ * @param {string} slug
+ * @returns {{crn: string, note: string}[]}
+ */
+export function journeyCrnOptions(slug) {
+  if (slug in JOURNEY_CRNS) return JOURNEY_CRNS[slug]
+  return [{ crn: DEFAULT_CRN, note: 'allowlisted for all CRNs' }]
+}
+
+/**
+ * The default CRN to sign in with for a journey when none is given explicitly.
+ * @param {string} slug
+ * @returns {string}
+ */
+export function defaultCrn(slug) {
+  return journeyCrnOptions(slug)[0]?.crn ?? DEFAULT_CRN
+}
+
+/**
+ * Journeys that are known not to complete on a standard local stack, with the
+ * reason (one array entry per printed line). Shown as a blocking warning the user
+ * must acknowledge before the run.
+ * @type {Record<string, string[]>}
+ */
+const WONT_COMPLETE = {
+  'farm-payments': [
+    'It stops at "select-actions-for-land-parcel": the offered actions (CMOR1, UPL1–UPL3) are',
+    'moorland-only, and the local land-grants seed has no majority-moorland parcel, so every',
+    'parcel is rejected with "This parcel is not majority on the moorland".',
+    'This is backend seed data, not a journey bug.'
+  ],
+  methane: [
+    'Every CRN is turned away at /auth/journey-unauthorised. methane is a frontend-code-only grant',
+    'not known to grants-ui-backend, whose allowlist only governs config-broker grants — so it has',
+    'no way to authorise methane (seeding config__allowlist_entries is ignored). This needs an',
+    'architecture change (skip the backend allowlist for local grants, or onboard methane), not a seed.'
+  ]
+}
+
+/**
+ * The reason a journey is known not to complete, as printable lines — or null if
+ * it should run normally. Lets the interactive menu show its own acknowledgement.
+ * @param {string} slug
+ * @returns {string[] | null}
+ */
+export function wontCompleteReason(slug) {
+  return WONT_COMPLETE[slug] ?? null
+}
+
+/**
+ * If the chosen journey is known not to complete, print why and block until the
+ * user presses Enter (or Ctrl+C). No-op for a dry run or a non-interactive stdin.
+ * Uses a synchronous fd-0 read so it works from the plain `gt journey <slug>`
+ * path, where stdin has already left raw mode.
+ * @param {string} slug
+ * @param {boolean} dryRun
+ * @returns {void}
+ */
+function acknowledgeIfWontComplete(slug, dryRun) {
+  const reason = WONT_COMPLETE[slug]
+  if (!reason || dryRun || !process.stdin.isTTY) return
+  console.log(`\n  ${YELLOW}⚠  '${slug}' will NOT complete.${RESET_COLOR}`)
+  for (const line of reason) console.log(`     ${line}`)
+  process.stdout.write(`\n  Press ${BOLD}Enter${RESET_COLOR} to run anyway ${DIM}(Ctrl+C to cancel)${RESET_COLOR}… `)
+  try {
+    readSync(0, Buffer.alloc(8), 0, 8, null)
+  } catch {
+    // stdin not readable (piped/CI) — proceed without blocking
+  }
+  console.log('')
+}
+
+/**
+ * List the journey slugs that have a definition file, for validation and
+ * for the "unknown journey" hint.
+ * @returns {string[]}
+ */
+export function listJourneys() {
+  try {
+    return readdirSync(JOURNEYS_DIR)
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => f.replace(/\.json$/, ''))
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Read and parse a journey's step definition file. Returns [] if the file is
+ * missing or unparseable — the single source of truth for the readers below.
+ * @param {string} slug  grant URL slug
+ * @returns {{name?: string, slug: string}[]}
+ */
+function loadJourney(slug) {
+  try {
+    const steps = JSON.parse(readFileSync(resolve(JOURNEYS_DIR, `${slug}.json`), 'utf8'))
+    return Array.isArray(steps) ? steps : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * The slug of a journey's first step — the page the runner must enter on. Not
+ * every grant starts at `/start` (farm-payments begins at /confirm-farm-details).
+ * @param {string} slug  grant URL slug
+ * @returns {string | null}  first step's page slug, or null if unreadable
+ */
+export function firstStepSlug(slug) {
+  return loadJourney(slug)[0]?.slug ?? null
+}
+
+/**
+ * The ordered steps of a journey, for building a "stop at page" picker. Each
+ * entry's 1-based position is the number `runJourney`/`--stop` expects.
+ * @param {string} slug
+ * @returns {{name: string, slug: string}[]}
+ */
+export function journeySteps(slug) {
+  return loadJourney(slug).map((s) => ({ name: s.name ?? s.slug, slug: s.slug }))
+}
+
+/**
+ * Run a journey headlessly by shelling into the acceptance Playwright driver
+ * (`acceptance/journey-cli.js`). Streams the driver's output and returns its
+ * exit code (0 = journey completed).
+ * @param {string} slug  grant URL slug with a matching journeys/<slug>.json
+ * @param {{crn?: string, stop?: string, headed?: boolean, clear?: boolean, acknowledged?: boolean, baseUrl?: string, skipInstall?: boolean}} [opts]
+ * @param {boolean} [dryRun]  print the command without running it
+ * @returns {number}  child exit code
+ */
+export function cmdJourney(slug, opts = {}, dryRun = false) {
+  if (!slug || !SLUG_PATTERN.test(slug) || !existsSync(resolve(JOURNEYS_DIR, `${slug}.json`))) {
+    const available = listJourneys()
+    console.error(`\n  ${RED}✖${RESET_COLOR}  Unknown journey: '${slug ?? ''}'.`)
+    if (available.length) {
+      console.error(`  ${DIM}Available:${RESET_COLOR} ${available.join(', ')}\n`)
+    } else {
+      console.error(`  ${DIM}No journey definitions found in ${JOURNEYS_DIR}${RESET_COLOR}\n`)
+    }
+    return 1
+  }
+
+  // Warn (and block for acknowledgement) if this journey is known not to finish.
+  // Skipped when the caller (the interactive menu) already got acknowledgement.
+  if (!opts.acknowledged) acknowledgeIfWontComplete(slug, dryRun)
+
+  // chromium is installed on demand (idempotent — mirrors acceptance/run-local.sh).
+  if (!opts.skipInstall) {
+    console.log(`\n  ${DIM}▶${RESET_COLOR}  npx playwright install chromium  ${DIM}(acceptance/)${RESET_COLOR}\n`)
+    if (!dryRun) {
+      const install = spawnSync('npx', ['playwright', 'install', 'chromium'], {
+        cwd: ACCEPTANCE_DIR,
+        stdio: 'inherit',
+        encoding: 'utf8'
+      })
+      if (install.status !== 0) {
+        console.error(`\n  ${RED}✖${RESET_COLOR}  Could not install chromium — is the acceptance package installed?\n`)
+        return install.status ?? 1
+      }
+    }
+  }
+
+  // The runner enters at the journey's first step, not always a `/start` page
+  // (e.g. farm-payments begins at /confirm-farm-details).
+  const startPage = firstStepSlug(slug)
+
+  // Use the journey's known-good CRN unless the caller picked one — the global
+  // default only works for allowAll grants (e.g. woodland needs its own CRN).
+  const crn = opts.crn || defaultCrn(slug)
+
+  const driverArgs = [JOURNEY_CLI_SCRIPT, slug]
+  if (startPage && startPage !== 'start') driverArgs.push('--start', startPage)
+  driverArgs.push('--crn', crn)
+  if (opts.stop) driverArgs.push('--stop', opts.stop)
+  if (opts.headed) driverArgs.push('--headed')
+  if (opts.clear) driverArgs.push('--clear')
+  if (opts.baseUrl) driverArgs.push('--base-url', opts.baseUrl)
+
+  console.log(
+    `  ${DIM}▶${RESET_COLOR}  node acceptance/journey-cli.js ${driverArgs.slice(1).join(' ')}  ` +
+      `${DIM}(journey: ${CYAN}${slug}${RESET_COLOR}${DIM})${RESET_COLOR}\n`
+  )
+  if (dryRun) return 0
+
+  // Default the stub password to the same value acceptance/run-local.sh uses.
+  const env = { ...process.env, DEFRA_ID_USER_PASSWORD: process.env.DEFRA_ID_USER_PASSWORD ?? 'x' }
+  const result = spawnSync(process.execPath, driverArgs, {
+    cwd: ACCEPTANCE_DIR,
+    stdio: 'inherit',
+    encoding: 'utf8',
+    env
+  })
+  return result.status ?? 1
+}


### PR DESCRIPTION
Add `gt journey <slug>` and an interactive TUI menu that drive the DOM-bound Journey Runner headlessly via a Playwright driver (acceptance/journey-cli.js), signing in through the DefraID stub and streaming engine output. Adds a `landActions` step type and value-targeted `radios`, refreshes the woodland/farm-payments/example journey definitions, and fixes the engine so a section run that never starts reports failure instead of a spurious "journey complete".