### PR TITLE
mask CRN to last 4 digits and rename user log field to CRN in auth logs

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -49,8 +49,4 @@ ignore:
     - '*':
         reason: 'Fix version is incoming from Defra forms team - Incomplete List of Disallowed Inputs'
         expires: '2026-09-01'
-  'SNYK-JS-IPADDRESS-18343249':
-    - '*':
-        reason: 'SSRF via socks@2.8.9 > ip-address@10.2.0 (@defra/forms-engine-plugin proxy-agent chain). Fixed in 10.2.1, which is in-range for socks (^10.1.1) but blocked by .npmrc min-release-age=7 (10.2.1 published 2026-07-25, installable from 2026-08-01). Replace with an overrides pin "ip-address": "10.2.1" once it clears the cooldown.'
-        expires: '2026-08-02'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21676,9 +21676,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.1.tgz",
+      "integrity": "sha512-O81l1g31PlH55F7AChkGM3sdWZX+1KDLnhesJ/V9Ziug5nIOnEPaVb2jLWAo1TbCOSeZPeNbxX4v/ywTuKSn9A==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     "joi": "17.13.4",
     "body-parser": "1.20.6",
     "brace-expansion": "2.1.2",
-    "postcss": "8.5.19"
+    "postcss": "8.5.19",
+    "ip-address": "10.2.1"
   },
   "dependencies": {
     "@aws-sdk/client-sns": "3.1091.0",

--- a/src/server/common/helpers/logging/log-codes.test.js
+++ b/src/server/common/helpers/logging/log-codes.test.js
@@ -82,73 +82,73 @@ describe('LogCodes', () => {
         'SIGN_IN_ATTEMPT',
         'info',
         { userId: TEST_USER_IDS.DEFAULT },
-        `User sign-in attempt for user=${TEST_USER_IDS.DEFAULT}`
+        `User sign-in attempt for CRN=${TEST_USER_IDS.DEFAULT}`
       ],
       [
         'SIGN_IN_SUCCESS',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, organisationId: TEST_ORGANIZATIONS.DEFAULT },
-        `User sign-in successful for user=${TEST_USER_IDS.DEFAULT}, organisation=${TEST_ORGANIZATIONS.DEFAULT}`
+        `User sign-in successful for CRN=${TEST_USER_IDS.DEFAULT}, organisation=${TEST_ORGANIZATIONS.DEFAULT}`
       ],
       [
         'SIGN_IN_FAILURE',
         'error',
         { userId: TEST_USER_IDS.DEFAULT, errorMessage: TEST_ERRORS.INVALID_CREDENTIALS },
-        `User sign-in failed for user=${TEST_USER_IDS.DEFAULT}. Error: ${TEST_ERRORS.INVALID_CREDENTIALS}`
+        `User sign-in failed for CRN=${TEST_USER_IDS.DEFAULT}. Error: ${TEST_ERRORS.INVALID_CREDENTIALS}`
       ],
       [
         'SIGN_OUT',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, sessionId: TEST_SESSIONS.SESSION_123 },
-        `User sign-out for user=${TEST_USER_IDS.DEFAULT}, session=${TEST_SESSIONS.SESSION_123}`
+        `User sign-out for CRN=${TEST_USER_IDS.DEFAULT}, session=${TEST_SESSIONS.SESSION_123}`
       ],
       [
         'TOKEN_VERIFICATION_SUCCESS',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, organisationId: TEST_ORGANIZATIONS.DEFAULT },
-        `Token verification successful for userCRN=${TEST_USER_IDS.DEFAULT}, userSBI=${TEST_ORGANIZATIONS.DEFAULT}`
+        `Token verification successful for CRN=${TEST_USER_IDS.DEFAULT}, userSBI=${TEST_ORGANIZATIONS.DEFAULT}`
       ],
       [
         'TOKEN_VERIFICATION_FAILURE',
         'error',
         { userId: TEST_USER_IDS.DEFAULT, errorMessage: TEST_ERRORS.INVALID_TOKEN },
-        `Token verification failed for user=${TEST_USER_IDS.DEFAULT}. Error: ${TEST_ERRORS.INVALID_TOKEN}`
+        `Token verification failed for CRN=${TEST_USER_IDS.DEFAULT}. Error: ${TEST_ERRORS.INVALID_TOKEN}`
       ],
       [
         'SESSION_EXPIRED',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, sessionId: TEST_SESSIONS.SESSION_123 },
-        `Session expired for user=${TEST_USER_IDS.DEFAULT}, session=${TEST_SESSIONS.SESSION_123}`
+        `Session expired for CRN=${TEST_USER_IDS.DEFAULT}, session=${TEST_SESSIONS.SESSION_123}`
       ],
       [
         'UNAUTHORIZED_ACCESS',
         'error',
         { path: TEST_PATHS.ADMIN, userId: TEST_USER_IDS.DEFAULT },
-        `Unauthorized access attempt to path=${TEST_PATHS.ADMIN} from user=${TEST_USER_IDS.DEFAULT}`
+        `Unauthorized access attempt to path=${TEST_PATHS.ADMIN} from CRN=${TEST_USER_IDS.DEFAULT}`
       ],
       [
         'UNAUTHORIZED_ACCESS with missing userId',
         'error',
         { path: TEST_PATHS.ADMIN },
-        `Unauthorized access attempt to path=${TEST_PATHS.ADMIN} from user=unknown`
+        `Unauthorized access attempt to path=${TEST_PATHS.ADMIN} from CRN=unknown`
       ],
       [
         'SIGN_IN_FAILURE with missing userId',
         'error',
         { errorMessage: TEST_ERRORS.INVALID_CREDENTIALS },
-        `User sign-in failed for user=unknown. Error: ${TEST_ERRORS.INVALID_CREDENTIALS}`
+        `User sign-in failed for CRN=unknown. Error: ${TEST_ERRORS.INVALID_CREDENTIALS}`
       ],
       [
         'TOKEN_VERIFICATION_FAILURE with missing userId',
         'error',
         { errorMessage: TEST_ERRORS.INVALID_TOKEN },
-        `Token verification failed for user=unknown. Error: ${TEST_ERRORS.INVALID_TOKEN}`
+        `Token verification failed for CRN=unknown. Error: ${TEST_ERRORS.INVALID_TOKEN}`
       ],
       [
         'GENERIC_ERROR',
         'error',
         { userId: TEST_USER_IDS.DEFAULT, errorMessage: TEST_ERRORS.INVALID_CREDENTIALS },
-        `Authentication error for user=${TEST_USER_IDS.DEFAULT}: ${TEST_ERRORS.INVALID_CREDENTIALS}`
+        `Authentication error for CRN=${TEST_USER_IDS.DEFAULT}: ${TEST_ERRORS.INVALID_CREDENTIALS}`
       ],
       [
         'OIDC_CONFIG_FETCH_RETRY',
@@ -215,26 +215,26 @@ describe('LogCodes', () => {
       [
         'ALLOWLIST_ACCESS_GRANTED',
         'info',
-        { path: TEST_PATHS.EXAMPLE_GRANT, userId: 'test123', sbi: TEST_SBI.DEFAULT, grantCode: 'woodland' },
-        `Allowlist access granted to path=${TEST_PATHS.EXAMPLE_GRANT} for user=test123, sbi=${TEST_SBI.DEFAULT}, grantCode=woodland`
+        { path: TEST_PATHS.EXAMPLE_GRANT, userId: '1100943757', sbi: TEST_SBI.DEFAULT, grantCode: 'woodland' },
+        `Allowlist access granted to path=${TEST_PATHS.EXAMPLE_GRANT} for CRN=******3757, sbi=${TEST_SBI.DEFAULT}, grantCode=woodland`
       ],
       [
         'ALLOWLIST_ACCESS_DENIED',
         'info',
-        { path: TEST_PATHS.EXAMPLE_GRANT, userId: 'test123', sbi: TEST_SBI.DEFAULT, grantCode: 'woodland' },
-        `Allowlist access denied to path=${TEST_PATHS.EXAMPLE_GRANT} for user=test123, sbi=${TEST_SBI.DEFAULT}, grantCode=woodland`
+        { path: TEST_PATHS.EXAMPLE_GRANT, userId: '1100943757', sbi: TEST_SBI.DEFAULT, grantCode: 'woodland' },
+        `Allowlist access denied to path=${TEST_PATHS.EXAMPLE_GRANT} for CRN=******3757, sbi=${TEST_SBI.DEFAULT}, grantCode=woodland`
       ],
       [
         'ALLOWLIST_ACCESS_GRANTED with fallbacks',
         'info',
         { path: TEST_PATHS.EXAMPLE_GRANT, grantCode: 'woodland' },
-        `Allowlist access granted to path=${TEST_PATHS.EXAMPLE_GRANT} for user=unknown, sbi=N/A, grantCode=woodland`
+        `Allowlist access granted to path=${TEST_PATHS.EXAMPLE_GRANT} for CRN=unknown, sbi=N/A, grantCode=woodland`
       ],
       [
         'ALLOWLIST_ACCESS_DENIED with fallbacks',
         'info',
         { path: TEST_PATHS.EXAMPLE_GRANT, grantCode: 'woodland' },
-        `Allowlist access denied to path=${TEST_PATHS.EXAMPLE_GRANT} for user=unknown, sbi=N/A, grantCode=woodland`
+        `Allowlist access denied to path=${TEST_PATHS.EXAMPLE_GRANT} for CRN=unknown, sbi=N/A, grantCode=woodland`
       ],
       ['CREDENTIALS_MISSING', 'error', {}, `No credentials received from Bell OAuth provider`],
       ['TOKEN_MISSING', 'error', {}, `No token received from Defra Identity`],
@@ -1205,7 +1205,7 @@ describe('LogCodes', () => {
 
   describe('Unknown user handling', () => {
     it.each([
-      ['AUTH log codes', LogCodes.AUTH.SIGN_IN_ATTEMPT, {}, 'User sign-in attempt for user=unknown'],
+      ['AUTH log codes', LogCodes.AUTH.SIGN_IN_ATTEMPT, {}, 'User sign-in attempt for CRN=unknown'],
       ['FORMS log codes', LogCodes.FORMS.FORM_LOAD, { formName: 'test' }, 'Form loaded: test for user=unknown'],
       [
         'SYSTEM log codes',

--- a/src/server/common/helpers/logging/log-codes.test.js
+++ b/src/server/common/helpers/logging/log-codes.test.js
@@ -2,7 +2,8 @@ import { LogCodes, validateLogCodes } from './log-codes.js'
 
 // Test constants
 const TEST_USER_IDS = {
-  DEFAULT: 'test',
+  DEFAULT: '1100943757',
+  MASKED: '******3757',
   CONTACT_ID: '12345'
 }
 
@@ -82,49 +83,49 @@ describe('LogCodes', () => {
         'SIGN_IN_ATTEMPT',
         'info',
         { userId: TEST_USER_IDS.DEFAULT },
-        `User sign-in attempt for CRN=${TEST_USER_IDS.DEFAULT}`
+        `User sign-in attempt for CRN=${TEST_USER_IDS.MASKED}`
       ],
       [
         'SIGN_IN_SUCCESS',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, organisationId: TEST_ORGANIZATIONS.DEFAULT },
-        `User sign-in successful for CRN=${TEST_USER_IDS.DEFAULT}, organisation=${TEST_ORGANIZATIONS.DEFAULT}`
+        `User sign-in successful for CRN=${TEST_USER_IDS.MASKED}, organisation=${TEST_ORGANIZATIONS.DEFAULT}`
       ],
       [
         'SIGN_IN_FAILURE',
         'error',
         { userId: TEST_USER_IDS.DEFAULT, errorMessage: TEST_ERRORS.INVALID_CREDENTIALS },
-        `User sign-in failed for CRN=${TEST_USER_IDS.DEFAULT}. Error: ${TEST_ERRORS.INVALID_CREDENTIALS}`
+        `User sign-in failed for CRN=${TEST_USER_IDS.MASKED}. Error: ${TEST_ERRORS.INVALID_CREDENTIALS}`
       ],
       [
         'SIGN_OUT',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, sessionId: TEST_SESSIONS.SESSION_123 },
-        `User sign-out for CRN=${TEST_USER_IDS.DEFAULT}, session=${TEST_SESSIONS.SESSION_123}`
+        `User sign-out for CRN=${TEST_USER_IDS.MASKED}, session=${TEST_SESSIONS.SESSION_123}`
       ],
       [
         'TOKEN_VERIFICATION_SUCCESS',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, organisationId: TEST_ORGANIZATIONS.DEFAULT },
-        `Token verification successful for CRN=${TEST_USER_IDS.DEFAULT}, userSBI=${TEST_ORGANIZATIONS.DEFAULT}`
+        `Token verification successful for CRN=${TEST_USER_IDS.MASKED}, userSBI=${TEST_ORGANIZATIONS.DEFAULT}`
       ],
       [
         'TOKEN_VERIFICATION_FAILURE',
         'error',
         { userId: TEST_USER_IDS.DEFAULT, errorMessage: TEST_ERRORS.INVALID_TOKEN },
-        `Token verification failed for CRN=${TEST_USER_IDS.DEFAULT}. Error: ${TEST_ERRORS.INVALID_TOKEN}`
+        `Token verification failed for CRN=${TEST_USER_IDS.MASKED}. Error: ${TEST_ERRORS.INVALID_TOKEN}`
       ],
       [
         'SESSION_EXPIRED',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, sessionId: TEST_SESSIONS.SESSION_123 },
-        `Session expired for CRN=${TEST_USER_IDS.DEFAULT}, session=${TEST_SESSIONS.SESSION_123}`
+        `Session expired for CRN=${TEST_USER_IDS.MASKED}, session=${TEST_SESSIONS.SESSION_123}`
       ],
       [
         'UNAUTHORIZED_ACCESS',
         'error',
         { path: TEST_PATHS.ADMIN, userId: TEST_USER_IDS.DEFAULT },
-        `Unauthorized access attempt to path=${TEST_PATHS.ADMIN} from CRN=${TEST_USER_IDS.DEFAULT}`
+        `Unauthorized access attempt to path=${TEST_PATHS.ADMIN} from CRN=${TEST_USER_IDS.MASKED}`
       ],
       [
         'UNAUTHORIZED_ACCESS with missing userId',
@@ -148,7 +149,7 @@ describe('LogCodes', () => {
         'GENERIC_ERROR',
         'error',
         { userId: TEST_USER_IDS.DEFAULT, errorMessage: TEST_ERRORS.INVALID_CREDENTIALS },
-        `Authentication error for CRN=${TEST_USER_IDS.DEFAULT}: ${TEST_ERRORS.INVALID_CREDENTIALS}`
+        `Authentication error for CRN=${TEST_USER_IDS.MASKED}: ${TEST_ERRORS.INVALID_CREDENTIALS}`
       ],
       [
         'OIDC_CONFIG_FETCH_RETRY',
@@ -253,7 +254,7 @@ describe('LogCodes', () => {
         'FORM_LOAD',
         'info',
         { formName: TEST_FORM_NAMES.DECLARATION, userId: TEST_USER_IDS.DEFAULT },
-        `Form loaded: ${TEST_FORM_NAMES.DECLARATION} for user=${TEST_USER_IDS.DEFAULT}`
+        `Form loaded: ${TEST_FORM_NAMES.DECLARATION} for CRN=${TEST_USER_IDS.MASKED}`
       ],
       [
         'FORM_VALIDATION_ERROR',
@@ -265,7 +266,7 @@ describe('LogCodes', () => {
         'FORM_SUBMIT',
         'info',
         { formName: TEST_FORM_NAMES.DECLARATION, userId: TEST_USER_IDS.DEFAULT },
-        `Form submitted: ${TEST_FORM_NAMES.DECLARATION} by user=${TEST_USER_IDS.DEFAULT}`
+        `Form submitted: ${TEST_FORM_NAMES.DECLARATION} by CRN=${TEST_USER_IDS.MASKED}`
       ],
       [
         'FORM_VALIDATION_SUCCESS',
@@ -283,19 +284,19 @@ describe('LogCodes', () => {
         'FORM_SAVE',
         'info',
         { formName: TEST_FORM_NAMES.DECLARATION, userId: TEST_USER_IDS.DEFAULT },
-        `Form saved: ${TEST_FORM_NAMES.DECLARATION} for user=${TEST_USER_IDS.DEFAULT}`
+        `Form saved: ${TEST_FORM_NAMES.DECLARATION} for CRN=${TEST_USER_IDS.MASKED}`
       ],
       [
         'FORM_SUBMIT with missing userId',
         'info',
         { formName: TEST_FORM_NAMES.DECLARATION },
-        `Form submitted: ${TEST_FORM_NAMES.DECLARATION} by user=unknown`
+        `Form submitted: ${TEST_FORM_NAMES.DECLARATION} by CRN=unknown`
       ],
       [
         'FORM_SAVE with missing userId',
         'info',
         { formName: TEST_FORM_NAMES.DECLARATION },
-        `Form saved: ${TEST_FORM_NAMES.DECLARATION} for user=unknown`
+        `Form saved: ${TEST_FORM_NAMES.DECLARATION} for CRN=unknown`
       ],
       [
         'SLUG_STORED',
@@ -330,7 +331,7 @@ describe('LogCodes', () => {
           errorMessage: TEST_ERRORS.NETWORK_ERROR,
           stack: 'Error stack trace'
         },
-        `Grant submission failed for grantType=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, userCrn=${TEST_USER_IDS.DEFAULT}, userSbi=${TEST_SBI.DEFAULT}, error=${TEST_ERRORS.NETWORK_ERROR}`
+        `Grant submission failed for grantType=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, CRN=${TEST_USER_IDS.MASKED}, userSbi=${TEST_SBI.DEFAULT}, error=${TEST_ERRORS.NETWORK_ERROR}`
       ],
       [
         'SUBMISSION_VALIDATION_ERROR',
@@ -418,19 +419,19 @@ describe('LogCodes', () => {
         'DECLARATION_LOAD',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, grantType: TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH },
-        `Declaration page loaded for user=${TEST_USER_IDS.DEFAULT}, grantType=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}`
+        `Declaration page loaded for CRN=${TEST_USER_IDS.MASKED}, grantType=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}`
       ],
       [
         'DECLARATION_ACCEPTED',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, grantType: TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH },
-        `Declaration accepted by user=${TEST_USER_IDS.DEFAULT}, grantType=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}`
+        `Declaration accepted by CRN=${TEST_USER_IDS.MASKED}, grantType=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}`
       ],
       [
         'DECLARATION_ERROR',
         'error',
         { userId: TEST_USER_IDS.DEFAULT, errorMessage: TEST_ERRORS.PROCESSING_FAILED },
-        `Declaration processing error for user=${TEST_USER_IDS.DEFAULT}: ${TEST_ERRORS.PROCESSING_FAILED}`
+        `Declaration processing error for CRN=${TEST_USER_IDS.MASKED}: ${TEST_ERRORS.PROCESSING_FAILED}`
       ]
     ])
   })
@@ -441,19 +442,19 @@ describe('LogCodes', () => {
         'CONFIRMATION_LOAD',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, grantType: TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH },
-        `Confirmation page loaded for user=${TEST_USER_IDS.DEFAULT}, grantType=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}`
+        `Confirmation page loaded for CRN=${TEST_USER_IDS.MASKED}, grantType=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}`
       ],
       [
         'CONFIRMATION_SUCCESS',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, referenceNumber: TEST_REFERENCE_NUMBERS.REF_123 },
-        `Confirmation processed successfully for user=${TEST_USER_IDS.DEFAULT}, referenceNumber=${TEST_REFERENCE_NUMBERS.REF_123}`
+        `Confirmation processed successfully for CRN=${TEST_USER_IDS.MASKED}, referenceNumber=${TEST_REFERENCE_NUMBERS.REF_123}`
       ],
       [
         'CONFIRMATION_ERROR',
         'error',
         { userId: TEST_USER_IDS.DEFAULT, errorMessage: TEST_ERRORS.PROCESSING_FAILED },
-        `Confirmation processing error for user=${TEST_USER_IDS.DEFAULT}: ${TEST_ERRORS.PROCESSING_FAILED}`
+        `Confirmation processing error for CRN=${TEST_USER_IDS.MASKED}: ${TEST_ERRORS.PROCESSING_FAILED}`
       ],
       [
         'SUBMITTED_STATUS_RETRIEVED',
@@ -470,19 +471,19 @@ describe('LogCodes', () => {
         'LAND_GRANT_APPLICATION_STARTED',
         'info',
         { userId: TEST_USER_IDS.DEFAULT },
-        `Land grant application started for user=${TEST_USER_IDS.DEFAULT}`
+        `Land grant application started for CRN=${TEST_USER_IDS.MASKED}`
       ],
       [
         'LAND_GRANT_APPLICATION_SUBMITTED',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, referenceNumber: TEST_REFERENCE_NUMBERS.REF_123 },
-        `Land grant application submitted for user=${TEST_USER_IDS.DEFAULT}, referenceNumber=${TEST_REFERENCE_NUMBERS.REF_123}`
+        `Land grant application submitted for CRN=${TEST_USER_IDS.MASKED}, referenceNumber=${TEST_REFERENCE_NUMBERS.REF_123}`
       ],
       [
         'LAND_GRANT_ERROR',
         'error',
         { userId: TEST_USER_IDS.DEFAULT, errorMessage: TEST_ERRORS.PROCESSING_FAILED },
-        `Land grant processing error for user=${TEST_USER_IDS.DEFAULT}: ${TEST_ERRORS.PROCESSING_FAILED}`
+        `Land grant processing error for CRN=${TEST_USER_IDS.MASKED}: ${TEST_ERRORS.PROCESSING_FAILED}`
       ],
       ['NO_LAND_PARCELS_FOUND', 'warn', { sbi: TEST_SBI.DEFAULT }, `No land parcels found for sbi=${TEST_SBI.DEFAULT}`],
       [
@@ -554,19 +555,19 @@ describe('LogCodes', () => {
         'AGREEMENT_LOAD',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, agreementType: TEST_AGREEMENT_TYPES.TERMS },
-        `Agreement loaded for user=${TEST_USER_IDS.DEFAULT}, agreementType=${TEST_AGREEMENT_TYPES.TERMS}`
+        `Agreement loaded for CRN=${TEST_USER_IDS.MASKED}, agreementType=${TEST_AGREEMENT_TYPES.TERMS}`
       ],
       [
         'AGREEMENT_ACCEPTED',
         'info',
         { userId: TEST_USER_IDS.DEFAULT, agreementType: TEST_AGREEMENT_TYPES.TERMS },
-        `Agreement accepted by user=${TEST_USER_IDS.DEFAULT}, agreementType=${TEST_AGREEMENT_TYPES.TERMS}`
+        `Agreement accepted by CRN=${TEST_USER_IDS.MASKED}, agreementType=${TEST_AGREEMENT_TYPES.TERMS}`
       ],
       [
         'AGREEMENT_ERROR',
         'error',
         { userId: TEST_USER_IDS.DEFAULT, errorMessage: TEST_ERRORS.PROCESSING_FAILED },
-        `Agreement processing error for user=${TEST_USER_IDS.DEFAULT}: ${TEST_ERRORS.PROCESSING_FAILED}`
+        `Agreement processing error for CRN=${TEST_USER_IDS.MASKED}: ${TEST_ERRORS.PROCESSING_FAILED}`
       ],
       ['PROXY_RESPONSE_ERROR', 'error', {}, 'Proxy response is undefined. Possible upstream error or misconfiguration.']
     ])
@@ -577,32 +578,32 @@ describe('LogCodes', () => {
       [
         'RELEASE_SKIPPED',
         'debug',
-        { ownerId: 'session-abc', reason: 'no-owner' },
-        'Application locks release skipped | ownerId=session-abc | reason=no-owner'
+        { ownerId: '1100943757', reason: 'no-owner' },
+        'Application locks release skipped | CRN=******3757 | reason=no-owner'
       ],
       [
         'RELEASE_ATTEMPTED',
         'debug',
-        { ownerId: 'session-abc' },
-        'Attempting application locks release | ownerId=session-abc'
+        { ownerId: '1100943757' },
+        'Attempting application locks release | CRN=******3757'
       ],
       [
         'RELEASE_SUCCEEDED',
         'debug',
-        { ownerId: 'session-abc', releasedCount: 3 },
-        'Application locks released | ownerId=session-abc | releasedCount=3'
+        { ownerId: '1100943757', releasedCount: 3 },
+        'Application locks released | CRN=******3757 | releasedCount=3'
       ],
       [
         'RELEASE_TIMEOUT',
         'warn',
-        { ownerId: 'session-abc', timeoutMs: 5000 },
-        'Application locks release timed out | ownerId=session-abc | timeoutMs=5000'
+        { ownerId: '1100943757', timeoutMs: 5000 },
+        'Application locks release timed out | CRN=******3757 | timeoutMs=5000'
       ],
       [
         'RELEASE_FAILED',
         'error',
-        { ownerId: 'session-abc', errorName: 'TimeoutError', errorMessage: 'connection lost' },
-        'Failed to release application locks | ownerId=session-abc | errorName=TimeoutError | errorMessage=connection lost'
+        { ownerId: '1100943757', errorName: 'TimeoutError', errorMessage: 'connection lost' },
+        'Failed to release application locks | CRN=******3757 | errorName=TimeoutError | errorMessage=connection lost'
       ]
     ])
   })
@@ -642,7 +643,7 @@ describe('LogCodes', () => {
           environment: 'production',
           referer: 'http://example.com'
         },
-        `Form not found: slug=test-form, userId=${TEST_USER_IDS.DEFAULT}, sbi=${TEST_SBI.DEFAULT}, reason=not_found, environment=production, referer=http://example.com`
+        `Form not found: slug=test-form, CRN=${TEST_USER_IDS.MASKED}, sbi=${TEST_SBI.DEFAULT}, reason=not_found, environment=production, referer=http://example.com`
       ],
       [
         'PAGE_NOT_FOUND',
@@ -654,19 +655,19 @@ describe('LogCodes', () => {
           referer: 'http://example.com',
           userAgent: 'Mozilla/5.0'
         },
-        `Page not found: path=${TEST_PATHS.TEST_PATH}, userId=${TEST_USER_IDS.DEFAULT}, sbi=${TEST_SBI.DEFAULT}, referer=http://example.com, userAgent=Mozilla/5.0`
+        `Page not found: path=${TEST_PATHS.TEST_PATH}, CRN=${TEST_USER_IDS.MASKED}, sbi=${TEST_SBI.DEFAULT}, referer=http://example.com, userAgent=Mozilla/5.0`
       ],
       [
         'FORM_NOT_FOUND with fallbacks',
         'info',
         { slug: 'test-form' },
-        'Form not found: slug=test-form, userId=anonymous, sbi=unknown, reason=not_found, environment=unknown, referer=none'
+        'Form not found: slug=test-form, CRN=unknown, sbi=unknown, reason=not_found, environment=unknown, referer=none'
       ],
       [
         'PAGE_NOT_FOUND with fallbacks',
         'info',
         { path: TEST_PATHS.TEST_PATH },
-        `Page not found: path=${TEST_PATHS.TEST_PATH}, userId=anonymous, sbi=unknown, referer=none, userAgent=unknown`
+        `Page not found: path=${TEST_PATHS.TEST_PATH}, CRN=unknown, sbi=unknown, referer=none, userAgent=unknown`
       ]
     ])
   })
@@ -683,7 +684,7 @@ describe('LogCodes', () => {
         'ERROR',
         'error',
         { userId: TEST_USER_IDS.DEFAULT, slug: 'test-slug', errorMessage: TEST_ERRORS.PROCESSING_FAILED },
-        `Print application error for user=${TEST_USER_IDS.DEFAULT}, slug=test-slug: ${TEST_ERRORS.PROCESSING_FAILED}`
+        `Print application error for CRN=${TEST_USER_IDS.MASKED}, slug=test-slug: ${TEST_ERRORS.PROCESSING_FAILED}`
       ]
     ])
   })
@@ -700,7 +701,7 @@ describe('LogCodes', () => {
           authorised: true,
           path: 'test-start'
         },
-        `Permission enforcement bypassed for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, userId=${TEST_USER_IDS.DEFAULT}, authorised=true, path=test-start`
+        `Permission enforcement bypassed for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, CRN=${TEST_USER_IDS.MASKED}, authorised=true, path=test-start`
       ],
       [
         'SUCCESS',
@@ -712,7 +713,7 @@ describe('LogCodes', () => {
           authorised: true,
           path: 'test-start'
         },
-        `Permission check successful for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, userId=${TEST_USER_IDS.DEFAULT}, authorised=true, path=test-start`
+        `Permission check successful for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, CRN=${TEST_USER_IDS.MASKED}, authorised=true, path=test-start`
       ],
       [
         'FAILURE',
@@ -724,7 +725,7 @@ describe('LogCodes', () => {
           authorised: false,
           path: 'test-start'
         },
-        `Permission check failed for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, userId=${TEST_USER_IDS.DEFAULT}, authorised=false, path=test-start`
+        `Permission check failed for grantCode=${TEST_GRANT_TYPES.EXAMPLE_GRANT_WITH_AUTH}, permission=submit, CRN=${TEST_USER_IDS.MASKED}, authorised=false, path=test-start`
       ]
     ])
   })
@@ -781,7 +782,7 @@ describe('LogCodes', () => {
         'EXTERNAL_API_CALL',
         'info',
         { endpoint: TEST_ENDPOINTS.API_GRANTS, userId: TEST_USER_IDS.DEFAULT },
-        `External API call to ${TEST_ENDPOINTS.API_GRANTS} for user=${TEST_USER_IDS.DEFAULT}`
+        `External API call to ${TEST_ENDPOINTS.API_GRANTS} for CRN=${TEST_USER_IDS.MASKED}`
       ],
       [
         'EXTERNAL_API_CALL_DEBUG',
@@ -792,7 +793,7 @@ describe('LogCodes', () => {
           method: TEST_METHODS.GET,
           identity: TEST_USER_IDS.DEFAULT
         },
-        `External ${TEST_METHODS.GET} to /api/grants (${TEST_USER_IDS.DEFAULT})`
+        `External ${TEST_METHODS.GET} to /api/grants (${TEST_USER_IDS.MASKED})`
       ],
       ['SYSTEM_SHUTDOWN', 'info', {}, 'System shutdown initiated'],
       [
@@ -1007,13 +1008,13 @@ describe('LogCodes', () => {
           userId: TEST_USER_IDS.DEFAULT,
           userAgent: 'Mozilla/5.0'
         },
-        `Rate limit exceeded: path=${TEST_PATHS.EXAMPLE_GRANT}, ip=127.0.0.1, userId=${TEST_USER_IDS.DEFAULT}, userAgent=Mozilla/5.0`
+        `Rate limit exceeded: path=${TEST_PATHS.EXAMPLE_GRANT}, ip=127.0.0.1, CRN=${TEST_USER_IDS.MASKED}, userAgent=Mozilla/5.0`
       ],
       [
         'RATE_LIMIT_EXCEEDED with fallbacks',
         'warn',
         { path: TEST_PATHS.EXAMPLE_GRANT },
-        `Rate limit exceeded: path=${TEST_PATHS.EXAMPLE_GRANT}, ip=unknown, userId=anonymous, userAgent=unknown`
+        `Rate limit exceeded: path=${TEST_PATHS.EXAMPLE_GRANT}, ip=unknown, CRN=unknown, userAgent=unknown`
       ],
       [
         'CHECK_DETAILS_TERMINAL_PAGE_INJECTED',
@@ -1206,12 +1207,12 @@ describe('LogCodes', () => {
   describe('Unknown user handling', () => {
     it.each([
       ['AUTH log codes', LogCodes.AUTH.SIGN_IN_ATTEMPT, {}, 'User sign-in attempt for CRN=unknown'],
-      ['FORMS log codes', LogCodes.FORMS.FORM_LOAD, { formName: 'test' }, 'Form loaded: test for user=unknown'],
+      ['FORMS log codes', LogCodes.FORMS.FORM_LOAD, { formName: 'test' }, 'Form loaded: test for CRN=unknown'],
       [
         'SYSTEM log codes',
         LogCodes.SYSTEM.EXTERNAL_API_CALL,
         { endpoint: TEST_ENDPOINTS.API_TEST },
-        `External API call to ${TEST_ENDPOINTS.API_TEST} for user=unknown`
+        `External API call to ${TEST_ENDPOINTS.API_TEST} for CRN=unknown`
       ]
     ])('should handle unknown users in %s', (_description, logCode, testParams, expectedMessage) => {
       expect(logCode.messageFunc(testParams)).toBe(expectedMessage)

--- a/src/server/common/helpers/logging/log-codes/agreements.js
+++ b/src/server/common/helpers/logging/log-codes/agreements.js
@@ -1,3 +1,5 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
@@ -5,17 +7,17 @@ export const AGREEMENTS = {
   AGREEMENT_LOAD: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Agreement loaded for user=${messageOptions.userId}, agreementType=${messageOptions.agreementType}`
+      `Agreement loaded for CRN=${maskCrn(messageOptions.userId)}, agreementType=${messageOptions.agreementType}`
   },
   AGREEMENT_ACCEPTED: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Agreement accepted by user=${messageOptions.userId}, agreementType=${messageOptions.agreementType}`
+      `Agreement accepted by CRN=${maskCrn(messageOptions.userId)}, agreementType=${messageOptions.agreementType}`
   },
   AGREEMENT_ERROR: {
     level: 'error',
     messageFunc: (messageOptions) =>
-      `Agreement processing error for user=${messageOptions.userId}: ${messageOptions.errorMessage}`
+      `Agreement processing error for CRN=${maskCrn(messageOptions.userId)}: ${messageOptions.errorMessage}`
   },
   PROXY_RESPONSE_ERROR: {
     level: 'error',

--- a/src/server/common/helpers/logging/log-codes/application-locks.js
+++ b/src/server/common/helpers/logging/log-codes/application-locks.js
@@ -1,28 +1,31 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
 export const APPLICATION_LOCKS = {
   RELEASE_SKIPPED: {
     level: 'debug',
-    messageFunc: ({ ownerId, reason }) => `Application locks release skipped | ownerId=${ownerId} | reason=${reason}`
+    messageFunc: ({ ownerId, reason }) =>
+      `Application locks release skipped | CRN=${maskCrn(ownerId)} | reason=${reason}`
   },
   RELEASE_ATTEMPTED: {
     level: 'debug',
-    messageFunc: ({ ownerId }) => `Attempting application locks release | ownerId=${ownerId}`
+    messageFunc: ({ ownerId }) => `Attempting application locks release | CRN=${maskCrn(ownerId)}`
   },
   RELEASE_SUCCEEDED: {
     level: 'debug',
     messageFunc: ({ ownerId, releasedCount }) =>
-      `Application locks released | ownerId=${ownerId} | releasedCount=${releasedCount}`
+      `Application locks released | CRN=${maskCrn(ownerId)} | releasedCount=${releasedCount}`
   },
   RELEASE_TIMEOUT: {
     level: 'warn',
     messageFunc: ({ ownerId, timeoutMs }) =>
-      `Application locks release timed out | ownerId=${ownerId} | timeoutMs=${timeoutMs}`
+      `Application locks release timed out | CRN=${maskCrn(ownerId)} | timeoutMs=${timeoutMs}`
   },
   RELEASE_FAILED: {
     level: 'error',
     messageFunc: ({ ownerId, errorName, errorMessage }) =>
-      `Failed to release application locks | ownerId=${ownerId} | errorName=${errorName} | errorMessage=${errorMessage}`
+      `Failed to release application locks | CRN=${maskCrn(ownerId)} | errorName=${errorName} | errorMessage=${errorMessage}`
   }
 }

--- a/src/server/common/helpers/logging/log-codes/auth.js
+++ b/src/server/common/helpers/logging/log-codes/auth.js
@@ -1,3 +1,5 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
@@ -5,46 +7,46 @@ export const AUTH = {
   GENERIC_ERROR: {
     level: 'error',
     messageFunc: (messageOptions) =>
-      `Authentication error for user=${messageOptions.userId}: ${messageOptions.errorMessage}`
+      `Authentication error for CRN=${maskCrn(messageOptions.userId)}: ${messageOptions.errorMessage}`
   },
   SIGN_IN_ATTEMPT: {
     level: 'info',
-    messageFunc: (messageOptions) => `User sign-in attempt for user=${messageOptions.userId || 'unknown'}`
+    messageFunc: (messageOptions) => `User sign-in attempt for CRN=${maskCrn(messageOptions.userId)}`
   },
   SIGN_IN_SUCCESS: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `User sign-in successful for user=${messageOptions.userId}, organisation=${messageOptions.organisationId}`
+      `User sign-in successful for CRN=${maskCrn(messageOptions.userId)}, organisation=${messageOptions.organisationId}`
   },
   SIGN_IN_FAILURE: {
     level: 'error',
     messageFunc: (messageOptions) =>
-      `User sign-in failed for user=${messageOptions.userId || 'unknown'}. Error: ${messageOptions.errorMessage}`
+      `User sign-in failed for CRN=${maskCrn(messageOptions.userId)}. Error: ${messageOptions.errorMessage}`
   },
   SIGN_OUT: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `User sign-out for user=${messageOptions.userId}, session=${messageOptions.sessionId}`
+      `User sign-out for CRN=${maskCrn(messageOptions.userId)}, session=${messageOptions.sessionId}`
   },
   TOKEN_VERIFICATION_SUCCESS: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Token verification successful for userCRN=${messageOptions.userId}, userSBI=${messageOptions.organisationId}`
+      `Token verification successful for CRN=${maskCrn(messageOptions.userId)}, userSBI=${messageOptions.organisationId}`
   },
   TOKEN_VERIFICATION_FAILURE: {
     level: 'error',
     messageFunc: (messageOptions) =>
-      `Token verification failed for user=${messageOptions.userId || 'unknown'}. Error: ${messageOptions.errorMessage}`
+      `Token verification failed for CRN=${maskCrn(messageOptions.userId)}. Error: ${messageOptions.errorMessage}`
   },
   SESSION_EXPIRED: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Session expired for user=${messageOptions.userId}, session=${messageOptions.sessionId}`
+      `Session expired for CRN=${maskCrn(messageOptions.userId)}, session=${messageOptions.sessionId}`
   },
   UNAUTHORIZED_ACCESS: {
     level: 'error',
     messageFunc: (messageOptions) =>
-      `Unauthorized access attempt to path=${messageOptions.path} from user=${messageOptions.userId || 'unknown'}`
+      `Unauthorized access attempt to path=${messageOptions.path} from CRN=${maskCrn(messageOptions.userId)}`
   },
   AUTH_DEBUG: {
     level: 'debug',
@@ -54,12 +56,12 @@ export const AUTH = {
   ALLOWLIST_ACCESS_GRANTED: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Allowlist access granted to path=${messageOptions.path} for user=${messageOptions.userId || 'unknown'}, sbi=${messageOptions.sbi || 'N/A'}, grantCode=${messageOptions.grantCode}`
+      `Allowlist access granted to path=${messageOptions.path} for CRN=${maskCrn(messageOptions.userId)}, sbi=${messageOptions.sbi || 'N/A'}, grantCode=${messageOptions.grantCode}`
   },
   ALLOWLIST_ACCESS_DENIED: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Allowlist access denied to path=${messageOptions.path} for user=${messageOptions.userId || 'unknown'}, sbi=${messageOptions.sbi || 'N/A'}, grantCode=${messageOptions.grantCode}`
+      `Allowlist access denied to path=${messageOptions.path} for CRN=${maskCrn(messageOptions.userId)}, sbi=${messageOptions.sbi || 'N/A'}, grantCode=${messageOptions.grantCode}`
   },
   CREDENTIALS_MISSING: {
     level: 'error',

--- a/src/server/common/helpers/logging/log-codes/confirmation.js
+++ b/src/server/common/helpers/logging/log-codes/confirmation.js
@@ -1,3 +1,5 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
@@ -5,17 +7,17 @@ export const CONFIRMATION = {
   CONFIRMATION_LOAD: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Confirmation page loaded for user=${messageOptions.userId}, grantType=${messageOptions.grantType}`
+      `Confirmation page loaded for CRN=${maskCrn(messageOptions.userId)}, grantType=${messageOptions.grantType}`
   },
   CONFIRMATION_SUCCESS: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Confirmation processed successfully for user=${messageOptions.userId}, referenceNumber=${messageOptions.referenceNumber}`
+      `Confirmation processed successfully for CRN=${maskCrn(messageOptions.userId)}, referenceNumber=${messageOptions.referenceNumber}`
   },
   CONFIRMATION_ERROR: {
     level: 'error',
     messageFunc: (messageOptions) =>
-      `Confirmation processing error for user=${messageOptions.userId}: ${messageOptions.errorMessage}`
+      `Confirmation processing error for CRN=${maskCrn(messageOptions.userId)}: ${messageOptions.errorMessage}`
   },
   SUBMITTED_STATUS_RETRIEVED: {
     level: 'info',

--- a/src/server/common/helpers/logging/log-codes/declaration.js
+++ b/src/server/common/helpers/logging/log-codes/declaration.js
@@ -1,3 +1,5 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
@@ -5,16 +7,16 @@ export const DECLARATION = {
   DECLARATION_LOAD: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Declaration page loaded for user=${messageOptions.userId}, grantType=${messageOptions.grantType}`
+      `Declaration page loaded for CRN=${maskCrn(messageOptions.userId)}, grantType=${messageOptions.grantType}`
   },
   DECLARATION_ACCEPTED: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Declaration accepted by user=${messageOptions.userId}, grantType=${messageOptions.grantType}`
+      `Declaration accepted by CRN=${maskCrn(messageOptions.userId)}, grantType=${messageOptions.grantType}`
   },
   DECLARATION_ERROR: {
     level: 'error',
     messageFunc: (messageOptions) =>
-      `Declaration processing error for user=${messageOptions.userId}: ${messageOptions.errorMessage}`
+      `Declaration processing error for CRN=${maskCrn(messageOptions.userId)}: ${messageOptions.errorMessage}`
   }
 }

--- a/src/server/common/helpers/logging/log-codes/forms.js
+++ b/src/server/common/helpers/logging/log-codes/forms.js
@@ -1,16 +1,17 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
 export const FORMS = {
   FORM_LOAD: {
     level: 'info',
-    messageFunc: (messageOptions) =>
-      `Form loaded: ${messageOptions.formName} for user=${messageOptions.userId || 'unknown'}`
+    messageFunc: (messageOptions) => `Form loaded: ${messageOptions.formName} for CRN=${maskCrn(messageOptions.userId)}`
   },
   FORM_SUBMIT: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Form submitted: ${messageOptions.formName} by user=${messageOptions.userId || 'unknown'}`
+      `Form submitted: ${messageOptions.formName} by CRN=${maskCrn(messageOptions.userId)}`
   },
   FORM_VALIDATION_ERROR: {
     level: 'error',
@@ -28,8 +29,7 @@ export const FORMS = {
   },
   FORM_SAVE: {
     level: 'info',
-    messageFunc: (messageOptions) =>
-      `Form saved: ${messageOptions.formName} for user=${messageOptions.userId || 'unknown'}`
+    messageFunc: (messageOptions) => `Form saved: ${messageOptions.formName} for CRN=${maskCrn(messageOptions.userId)}`
   },
   SLUG_STORED: {
     level: 'debug',

--- a/src/server/common/helpers/logging/log-codes/land-grants.js
+++ b/src/server/common/helpers/logging/log-codes/land-grants.js
@@ -1,20 +1,22 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
 export const LAND_GRANTS = {
   LAND_GRANT_APPLICATION_STARTED: {
     level: 'info',
-    messageFunc: (messageOptions) => `Land grant application started for user=${messageOptions.userId}`
+    messageFunc: (messageOptions) => `Land grant application started for CRN=${maskCrn(messageOptions.userId)}`
   },
   LAND_GRANT_APPLICATION_SUBMITTED: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Land grant application submitted for user=${messageOptions.userId}, referenceNumber=${messageOptions.referenceNumber}`
+      `Land grant application submitted for CRN=${maskCrn(messageOptions.userId)}, referenceNumber=${messageOptions.referenceNumber}`
   },
   LAND_GRANT_ERROR: {
     level: 'error',
     messageFunc: (messageOptions) =>
-      `Land grant processing error for user=${messageOptions.userId}: ${messageOptions.errorMessage}`
+      `Land grant processing error for CRN=${maskCrn(messageOptions.userId)}: ${messageOptions.errorMessage}`
   },
   NO_LAND_PARCELS_FOUND: {
     level: 'warn',

--- a/src/server/common/helpers/logging/log-codes/permissions.js
+++ b/src/server/common/helpers/logging/log-codes/permissions.js
@@ -1,3 +1,5 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
@@ -5,16 +7,16 @@ export const PERMISSIONS = {
   BYPASSED: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Permission enforcement bypassed for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, userId=${messageOptions.userId}, authorised=${messageOptions.authorised}, path=${messageOptions.path}`
+      `Permission enforcement bypassed for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, CRN=${maskCrn(messageOptions.userId)}, authorised=${messageOptions.authorised}, path=${messageOptions.path}`
   },
   SUCCESS: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Permission check successful for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, userId=${messageOptions.userId}, authorised=${messageOptions.authorised}, path=${messageOptions.path}`
+      `Permission check successful for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, CRN=${maskCrn(messageOptions.userId)}, authorised=${messageOptions.authorised}, path=${messageOptions.path}`
   },
   FAILURE: {
     level: 'warn',
     messageFunc: (messageOptions) =>
-      `Permission check failed for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, userId=${messageOptions.userId}, authorised=${messageOptions.authorised}, path=${messageOptions.path}`
+      `Permission check failed for grantCode=${messageOptions.grantCode}, permission=${messageOptions.permission}, CRN=${maskCrn(messageOptions.userId)}, authorised=${messageOptions.authorised}, path=${messageOptions.path}`
   }
 }

--- a/src/server/common/helpers/logging/log-codes/print-application.js
+++ b/src/server/common/helpers/logging/log-codes/print-application.js
@@ -1,3 +1,5 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
@@ -9,6 +11,6 @@ export const PRINT_APPLICATION = {
   ERROR: {
     level: 'error',
     messageFunc: (messageOptions) =>
-      `Print application error for user=${messageOptions.userId}, slug=${messageOptions.slug}: ${messageOptions.errorMessage}`
+      `Print application error for CRN=${maskCrn(messageOptions.userId)}, slug=${messageOptions.slug}: ${messageOptions.errorMessage}`
   }
 }

--- a/src/server/common/helpers/logging/log-codes/resource-not-found.js
+++ b/src/server/common/helpers/logging/log-codes/resource-not-found.js
@@ -1,3 +1,5 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
@@ -5,11 +7,11 @@ export const RESOURCE_NOT_FOUND = {
   FORM_NOT_FOUND: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Form not found: slug=${messageOptions.slug}, userId=${messageOptions.userId || 'anonymous'}, sbi=${messageOptions.sbi || 'unknown'}, reason=${messageOptions.reason || 'not_found'}, environment=${messageOptions.environment || 'unknown'}, referer=${messageOptions.referer || 'none'}`
+      `Form not found: slug=${messageOptions.slug}, CRN=${maskCrn(messageOptions.userId)}, sbi=${messageOptions.sbi || 'unknown'}, reason=${messageOptions.reason || 'not_found'}, environment=${messageOptions.environment || 'unknown'}, referer=${messageOptions.referer || 'none'}`
   },
   PAGE_NOT_FOUND: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `Page not found: path=${messageOptions.path}, userId=${messageOptions.userId || 'anonymous'}, sbi=${messageOptions.sbi || 'unknown'}, referer=${messageOptions.referer || 'none'}, userAgent=${messageOptions.userAgent || 'unknown'}`
+      `Page not found: path=${messageOptions.path}, CRN=${maskCrn(messageOptions.userId)}, sbi=${messageOptions.sbi || 'unknown'}, referer=${messageOptions.referer || 'none'}, userAgent=${messageOptions.userAgent || 'unknown'}`
   }
 }

--- a/src/server/common/helpers/logging/log-codes/submission.js
+++ b/src/server/common/helpers/logging/log-codes/submission.js
@@ -1,3 +1,5 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
@@ -15,7 +17,7 @@ export const SUBMISSION = {
   SUBMISSION_FAILURE: {
     level: 'error',
     messageFunc: (messageOptions) =>
-      `Grant submission failed for grantType=${messageOptions.grantType}, userCrn=${messageOptions.userCrn}, userSbi=${messageOptions.userSbi}, error=${messageOptions.errorMessage}`
+      `Grant submission failed for grantType=${messageOptions.grantType}, CRN=${maskCrn(messageOptions.userCrn)}, userSbi=${messageOptions.userSbi}, error=${messageOptions.errorMessage}`
   },
   SUBMISSION_VALIDATION_ERROR: {
     level: 'error',

--- a/src/server/common/helpers/logging/log-codes/system.js
+++ b/src/server/common/helpers/logging/log-codes/system.js
@@ -1,3 +1,5 @@
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
 /**
  * @type {Object<string, import('./definition.js').LogCodesDefinition>}
  */
@@ -50,12 +52,12 @@ export const SYSTEM = {
   EXTERNAL_API_CALL: {
     level: 'info',
     messageFunc: (messageOptions) =>
-      `External API call to ${messageOptions.endpoint} for user=${messageOptions.userId || 'unknown'}`
+      `External API call to ${messageOptions.endpoint} for CRN=${maskCrn(messageOptions.userId)}`
   },
   EXTERNAL_API_CALL_DEBUG: {
     level: 'debug',
     messageFunc: (messageOptions) =>
-      `External ${messageOptions.method} to ${new URL(messageOptions.endpoint).pathname} (${messageOptions.identity || 'unknown'})`
+      `External ${messageOptions.method} to ${new URL(messageOptions.endpoint).pathname} (${maskCrn(messageOptions.identity)})`
   },
   EXTERNAL_API_ERROR: {
     level: 'error',
@@ -142,7 +144,7 @@ export const SYSTEM = {
   RATE_LIMIT_EXCEEDED: {
     level: 'warn',
     messageFunc: (messageOptions) =>
-      `Rate limit exceeded: path=${messageOptions.path}, ip=${messageOptions.ip || 'unknown'}, userId=${messageOptions.userId || 'anonymous'}, userAgent=${messageOptions.userAgent || 'unknown'}`
+      `Rate limit exceeded: path=${messageOptions.path}, ip=${messageOptions.ip || 'unknown'}, CRN=${maskCrn(messageOptions.userId)}, userAgent=${messageOptions.userAgent || 'unknown'}`
   },
   STATE_SIZE_EXCEEDED: {
     level: 'warn',

--- a/src/server/common/helpers/logging/log.test.js
+++ b/src/server/common/helpers/logging/log.test.js
@@ -58,13 +58,13 @@ describe('Logger Functionality', () => {
 
   it('should work with real LogCodes', () => {
     const testOptions = {
-      userId: 'test-user',
+      userId: '1100943757',
       organisationId: 'test-org'
     }
 
     log(LogCodes.AUTH.SIGN_IN_SUCCESS, testOptions)
 
-    expect(logger.info).toHaveBeenCalledWith({}, 'User sign-in successful for CRN=test-user, organisation=test-org')
+    expect(logger.info).toHaveBeenCalledWith({}, 'User sign-in successful for CRN=******3757, organisation=test-org')
   })
 
   it('should work with error log codes', () => {
@@ -94,12 +94,12 @@ describe('Logger Functionality', () => {
   it('should work with FORMS log codes', () => {
     const formOptions = {
       formName: 'declaration',
-      userId: 'test-user'
+      userId: '1100943757'
     }
 
     log(LogCodes.FORMS.FORM_LOAD, formOptions)
 
-    expect(logger.info).toHaveBeenCalledWith({}, 'Form loaded: declaration for user=test-user')
+    expect(logger.info).toHaveBeenCalledWith({}, 'Form loaded: declaration for CRN=******3757')
   })
 
   it('should work with SUBMISSION log codes', () => {
@@ -143,17 +143,17 @@ describe('Logger Functionality', () => {
   it('should bypass logcodes defined level when using the dedicated debug logger', () => {
     const logCode = LogCodes.AUTH.GENERIC_ERROR
     debug(logCode, {
-      userId: '123',
+      userId: '1100943757',
       error: undefined
     })
-    expect(logger.debug).toHaveBeenCalledWith({}, 'Authentication error for CRN=123: undefined')
+    expect(logger.debug).toHaveBeenCalledWith({}, 'Authentication error for CRN=******3757: undefined')
   })
 
   it('should always log at error level when using the dedicated error logger', () => {
     const logCode = LogCodes.AUTH.SIGN_IN_SUCCESS
-    error(logCode, { userId: '123', organisationId: 'org-456' })
+    error(logCode, { userId: '1100943757', organisationId: 'org-456' })
 
-    expect(logger.error).toHaveBeenCalledWith({}, 'User sign-in successful for CRN=123, organisation=org-456')
+    expect(logger.error).toHaveBeenCalledWith({}, 'User sign-in successful for CRN=******3757, organisation=org-456')
     expect(logger.info).not.toHaveBeenCalled()
     expect(logger.debug).not.toHaveBeenCalled()
   })

--- a/src/server/common/helpers/logging/log.test.js
+++ b/src/server/common/helpers/logging/log.test.js
@@ -64,7 +64,7 @@ describe('Logger Functionality', () => {
 
     log(LogCodes.AUTH.SIGN_IN_SUCCESS, testOptions)
 
-    expect(logger.info).toHaveBeenCalledWith({}, 'User sign-in successful for user=test-user, organisation=test-org')
+    expect(logger.info).toHaveBeenCalledWith({}, 'User sign-in successful for CRN=test-user, organisation=test-org')
   })
 
   it('should work with error log codes', () => {
@@ -146,14 +146,14 @@ describe('Logger Functionality', () => {
       userId: '123',
       error: undefined
     })
-    expect(logger.debug).toHaveBeenCalledWith({}, 'Authentication error for user=123: undefined')
+    expect(logger.debug).toHaveBeenCalledWith({}, 'Authentication error for CRN=123: undefined')
   })
 
   it('should always log at error level when using the dedicated error logger', () => {
     const logCode = LogCodes.AUTH.SIGN_IN_SUCCESS
     error(logCode, { userId: '123', organisationId: 'org-456' })
 
-    expect(logger.error).toHaveBeenCalledWith({}, 'User sign-in successful for user=123, organisation=org-456')
+    expect(logger.error).toHaveBeenCalledWith({}, 'User sign-in successful for CRN=123, organisation=org-456')
     expect(logger.info).not.toHaveBeenCalled()
     expect(logger.debug).not.toHaveBeenCalled()
   })

--- a/src/server/common/helpers/logging/mask-crn.js
+++ b/src/server/common/helpers/logging/mask-crn.js
@@ -1,0 +1,21 @@
+const VISIBLE_DIGITS = 4
+const MASKABLE_CRN = new RegExp(String.raw`^\d{${VISIBLE_DIGITS + 1},}$`)
+
+/**
+ * Mask a CRN for logging, revealing only the last 4 digits (e.g. `******1262`).
+ * @param {string|number|null|undefined} value - The CRN or sentinel value to mask.
+ * @returns {string} The masked CRN, or the original value when it is not a maskable CRN.
+ */
+export function maskCrn(value) {
+  if (value === null || value === undefined) {
+    return 'unknown'
+  }
+
+  const str = String(value)
+
+  if (!MASKABLE_CRN.test(str)) {
+    return str
+  }
+
+  return `${'*'.repeat(str.length - VISIBLE_DIGITS)}${str.slice(-VISIBLE_DIGITS)}`
+}

--- a/src/server/common/helpers/logging/mask-crn.test.js
+++ b/src/server/common/helpers/logging/mask-crn.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest'
+import { maskCrn } from '~/src/server/common/helpers/logging/mask-crn.js'
+
+describe('maskCrn', () => {
+  test('reveals only the last 4 digits of a CRN', () => {
+    expect(maskCrn('1100943757')).toBe('******3757')
+  })
+
+  test('masks a number CRN', () => {
+    expect(maskCrn(1100943838)).toBe('******3838')
+  })
+
+  test('masks the shortest maskable CRN, leaving one star', () => {
+    expect(maskCrn('51262')).toBe('*1262')
+  })
+
+  test.each(['unknown', 'system', 'N/A'])('returns sentinel value %s unchanged', (sentinel) => {
+    expect(maskCrn(sentinel)).toBe(sentinel)
+  })
+
+  test.each([null, undefined])('returns "unknown" for %s', (value) => {
+    expect(maskCrn(value)).toBe('unknown')
+  })
+
+  test.each(['1', '12', '1234'])('does not mask numeric values of 4 digits or fewer: %s', (value) => {
+    expect(maskCrn(value)).toBe(value)
+  })
+
+  test('returns non-numeric strings unchanged', () => {
+    expect(maskCrn('abc123')).toBe('abc123')
+  })
+})


### PR DESCRIPTION
Add a maskCrn helper that reveals only the last 4 digits of a CRN, and rename the auth log field from user/userCRN to CRN across all AUTH log codes. This stops CDP obfuscating the value (it was masked because labelled "user") while avoiding logging the full CRN as PII, aiding live support triage of unauthorised access attempts.