### PR TITLE
enable the feedback survey CTA for grasslands and example-grant-with-…

### DIFF
--- a/src/__mocks__/hapi-mocks.js
+++ b/src/__mocks__/hapi-mocks.js
@@ -148,6 +148,19 @@ export const mockSimpleRequest = (customProps = {}) => ({
 })
 
 /**
+ * Creates a request scoped to a grant journey: the `params.slug`, absolute `url`
+ * and `info.host` that grant-aware helpers read.
+ * @param {{ slug?: string, path?: string, href?: string }} [options]
+ */
+export const mockGrantRequest = ({ slug = 'woodland', path = `/${slug}/summary`, href } = {}) => ({
+  ...mockSimpleRequest({ path }),
+  params: { slug },
+  url: { href: href ?? `https://grants.example${path}` },
+  info: { host: 'grants.example' },
+  server: { info: { protocol: 'https' } }
+})
+
+/**
  * Creates a minimal form-context-style object with a payload bag.
  * @param {Record<string, unknown>} [customProps] Properties to merge over the defaults.
  */

--- a/src/__mocks__/index.js
+++ b/src/__mocks__/index.js
@@ -18,6 +18,7 @@ export {
   mockSsoRequest,
   mockAuthRequest,
   mockSimpleRequest,
+  mockGrantRequest,
   mockContext,
   createMockFetchResponse
 } from './hapi-mocks.js'

--- a/src/config/nunjucks/context/context.test.js
+++ b/src/config/nunjucks/context/context.test.js
@@ -1,5 +1,5 @@
 import { vi } from 'vitest'
-import { mockSimpleRequest } from '~/src/__mocks__/hapi-mocks.js'
+import { mockGrantRequest, mockSimpleRequest } from '~/src/__mocks__/hapi-mocks.js'
 
 const mockReadFileSync = vi.fn()
 const mockLog = vi.fn()
@@ -626,12 +626,7 @@ describe('context', () => {
     test('injects a survey URL for an in-scope grant', async () => {
       setupManifestSuccess()
 
-      const request = {
-        ...mockSimpleRequest({ path: '/woodland/summary' }),
-        params: { slug: 'woodland' },
-        url: { href: 'https://grants.example/woodland/summary' },
-        info: { host: 'grants.example' }
-      }
+      const request = mockGrantRequest({ slug: 'woodland' })
 
       const contextImport = await importContext()
       const contextResult = await contextImport.context(request)
@@ -645,10 +640,7 @@ describe('context', () => {
     test('is null for an out-of-scope grant', async () => {
       setupManifestSuccess()
 
-      const request = {
-        ...mockSimpleRequest({ path: '/some-other-grant/summary' }),
-        params: { slug: 'some-other-grant' }
-      }
+      const request = mockGrantRequest({ slug: 'some-other-grant' })
 
       const contextImport = await importContext()
       const contextResult = await contextImport.context(request)

--- a/src/server/common/helpers/feedback-survey.js
+++ b/src/server/common/helpers/feedback-survey.js
@@ -8,7 +8,9 @@ import { config } from '~/src/config/config.js'
  */
 export const SCHEME_LABELS = {
   'farm-payments': 'Farm Payments',
-  woodland: 'Woodland Management Plan'
+  woodland: 'Woodland Management Plan',
+  grasslands: 'Grasslands',
+  'example-grant-with-auth': 'Example Grant with Auth'
 }
 
 /**

--- a/src/server/common/helpers/feedback-survey.test.js
+++ b/src/server/common/helpers/feedback-survey.test.js
@@ -1,4 +1,5 @@
 import { config } from '~/src/config/config.js'
+import { mockGrantRequest } from '~/src/__mocks__/hapi-mocks.js'
 import {
   buildFeedbackSurveyUrl,
   resolveJourney,
@@ -9,18 +10,16 @@ import {
 const BASE_URL = 'https://defragroup.eu.qualtrics.com/jfe/form/SV_test'
 
 /**
- * @param {object} [overrides]
- * @returns {any}
+ * Literal — deliberately not derived from SCHEME_LABELS, so the allowlist
+ * assertion below still catches a slug added to the source by mistake.
+ * @type {Array<[string, string]>}
  */
-function mockRequest({ slug = 'woodland', path = '/woodland/summary', href } = {}) {
-  return {
-    params: { slug },
-    path,
-    url: { href: href ?? `https://grants.example${path}` },
-    info: { host: 'grants.example' },
-    server: { info: { protocol: 'https' } }
-  }
-}
+const SLUG_LABELS = [
+  ['farm-payments', 'Farm Payments'],
+  ['woodland', 'Woodland Management Plan'],
+  ['grasslands', 'Grasslands'],
+  ['example-grant-with-auth', 'Example Grant with Auth']
+]
 
 describe('#resolveJourney', () => {
   test.each([
@@ -43,7 +42,7 @@ describe('#buildFeedbackSurveyUrl', () => {
   })
 
   test('builds URL with grant, journey and url params for an in-scope grant', () => {
-    const result = buildFeedbackSurveyUrl(mockRequest({ slug: 'woodland', path: '/woodland/summary' }))
+    const result = buildFeedbackSurveyUrl(mockGrantRequest({ slug: 'woodland', path: '/woodland/summary' }))
     const url = new URL(/** @type {string} */ (result))
 
     expect(url.origin + url.pathname).toBe(BASE_URL)
@@ -62,19 +61,20 @@ describe('#buildFeedbackSurveyUrl', () => {
   })
 
   test('uses submitted journey on the confirmation page', () => {
-    const result = buildFeedbackSurveyUrl(mockRequest({ slug: 'woodland', path: '/woodland/confirmation' }))
+    const result = buildFeedbackSurveyUrl(mockGrantRequest({ slug: 'woodland', path: '/woodland/confirmation' }))
     const url = new URL(/** @type {string} */ (result))
     expect(url.searchParams.get('journey')).toBe(JOURNEY.submitted)
   })
 
-  test('sends the Farm Payments label for the farm-payments slug', () => {
-    const result = buildFeedbackSurveyUrl(mockRequest({ slug: 'farm-payments', path: '/farm-payments/start' }))
-    const url = new URL(/** @type {string} */ (result))
-    expect(url.searchParams.get('grant')).toBe('Farm Payments')
+  test.each(SLUG_LABELS)('sends the grant label for slug %s as %s', (slug, label) => {
+    const result = buildFeedbackSurveyUrl(mockGrantRequest({ slug, path: `/${slug}/start` }))
+    expect(new URL(/** @type {string} */ (result)).searchParams.get('grant')).toBe(label)
   })
 
   test('returns null for an out-of-scope grant (gating)', () => {
-    expect(buildFeedbackSurveyUrl(mockRequest({ slug: 'some-other-grant' }))).toBeNull()
+    expect(
+      buildFeedbackSurveyUrl(mockGrantRequest({ slug: 'some-other-grant', path: '/some-other-grant/summary' }))
+    ).toBeNull()
   })
 
   test('returns null when no slug is present', () => {
@@ -83,7 +83,7 @@ describe('#buildFeedbackSurveyUrl', () => {
 
   test('returns null when survey URL is not configured', () => {
     config.set('feedback.surveyUrl', '')
-    expect(buildFeedbackSurveyUrl(mockRequest())).toBeNull()
+    expect(buildFeedbackSurveyUrl(mockGrantRequest())).toBeNull()
   })
 
   test('returns null for an undefined request', () => {
@@ -92,7 +92,7 @@ describe('#buildFeedbackSurveyUrl', () => {
 
   test('appends params with & when base URL already has a query string', () => {
     config.set('feedback.surveyUrl', `${BASE_URL}?existing=1`)
-    const result = /** @type {string} */ (buildFeedbackSurveyUrl(mockRequest()))
+    const result = /** @type {string} */ (buildFeedbackSurveyUrl(mockGrantRequest()))
     expect(result.startsWith(`${BASE_URL}?existing=1&`)).toBe(true)
     const url = new URL(result)
     expect(url.searchParams.get('existing')).toBe('1')
@@ -100,9 +100,6 @@ describe('#buildFeedbackSurveyUrl', () => {
   })
 
   test('scope allowlist keys map to their exact labels', () => {
-    expect(SCHEME_LABELS).toEqual({
-      'farm-payments': 'Farm Payments',
-      woodland: 'Woodland Management Plan'
-    })
+    expect(SCHEME_LABELS).toEqual(Object.fromEntries(SLUG_LABELS))
   })
 })


### PR DESCRIPTION
Adds the `grasslands` and `example-grant-with-auth` slugs to the `SCHEME_LABELS` allowlist in `feedback-survey.js`, so the phase-banner feedback link now renders on those two journeys and sends the matching `grant` param to Qualtrics. 

Also consolidates the per-slug label tests into a single `test.each` table shared with the allowlist assertion, and extracts the duplicated grant-scoped request fixture into a shared `mockGrantRequest` helper used by both `feedback-survey.test.js` and `context.test.js`. The two new labels are unconfirmed with the survey owner, and the CTA stays hidden in any environment where `FEEDBACK_SURVEY_URL` is unset.