### PR TITLE
WIP - add a remove land parcel confirmation page and clear map selection state when a parcel is removed.

### DIFF
--- a/src/__mocks__/controller-mocks.js
+++ b/src/__mocks__/controller-mocks.js
@@ -2,7 +2,7 @@ import { vi } from 'vitest'
 
 /**
  * Replace a controller's interaction methods with vitest spies for tests.
- * @param {QuestionPageController} controller
+ * @param {QuestionPageController & { performAuthCheck?: (...args: unknown[]) => unknown }} controller
  * @param {SetupControllerMocksOptions} [options]
  * @returns {void}
  */
@@ -11,6 +11,7 @@ export const setupControllerMocks = (controller, { proceed = 'redirected', nextP
   controller.getNextPath = vi.fn().mockReturnValue(nextPath)
   controller.setState = vi.fn()
   controller.getState = vi.fn().mockResolvedValue({})
+  controller.performAuthCheck = vi.fn().mockResolvedValue(null)
 }
 
 /**

--- a/src/server/dev-tools/journey-runner/runner-engine.js
+++ b/src/server/dev-tools/journey-runner/runner-engine.js
@@ -283,10 +283,18 @@
       submitForm()
     },
 
+    /**
+     * Links into direct-only utility pages carry a query string
+     * (`remove-parcel?parcelId=SD1234-5678`), so the `/slug`-suffix match never
+     * sees them. Such steps set `linkHrefContains` instead.
+     * @param {JourneyStep} step
+     * @returns {void}
+     */
     clickLink(step) {
-      const link = document.querySelector(`a[href$="/${step.linkSlug}"]`)
+      const selector = step.linkHrefContains ? `a[href*="${step.linkHrefContains}"]` : `a[href$="/${step.linkSlug}"]`
+      const link = document.querySelector(selector)
       if (!link) {
-        throw new Error(`Link to /${step.linkSlug} not found`)
+        throw new Error(`No link matching ${selector}`)
       }
       link.click()
     },
@@ -672,6 +680,7 @@
  * @property {boolean} [selectAll]         Tick every checkbox (or select every land parcel) instead of just the first.
  * @property {number} [offsetDays]         Days to add to "today" for date-parts steps.
  * @property {string} [linkSlug]           Slug to match against an `<a href>` for clickLink.
+ * @property {string} [linkHrefContains]   Substring to match an `<a href>` on instead of `linkSlug`, for links carrying a query string.
  * @property {'prefix'} [matchMode]        Match `/slug/{uuid}` instead of exact `/slug`.
  * @property {Record<string, string>} [fields] Multiple field name → value pairs.
  */

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -41,6 +41,7 @@ import SubmissionPageController from '~/src/server/land-grants/controllers/submi
 import LandGrantsGenericPageController from '~/src/server/land-grants/controllers/land-grants-generic-page.controller.js'
 import ConsentPageController from '~/src/server/land-grants/controllers/consent-page.controller.js'
 import RemoveActionPageController from '~/src/server/land-grants/controllers/remove-action-page.controller.js'
+import RemoveLandParcelPageController from '~/src/server/land-grants/controllers/remove-land-parcel-page.controller.js'
 import { PotentialFundingController } from '~/src/server/non-land-grants/pigs-might-fly/controllers/potential-funding.controller.js'
 import { formatCurrency } from '../config/nunjucks/filters/format-currency.js'
 import { gridColumnClass } from '../config/nunjucks/grid-column.js'
@@ -153,6 +154,7 @@ const registerFormsPlugin = async (server, prefix = '') => {
         SelectActionsPageController,
         PaymentPageController,
         RemoveActionPageController,
+        RemoveLandParcelPageController,
         ConsentPageController,
         PotentialFundingController,
         SummaryPageController,

--- a/src/server/land-grants/controllers/remove-action-page.controller.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.js
@@ -5,6 +5,7 @@ import {
   deleteActionFromState
 } from '~/src/server/land-grants/view-state/land-parcel.view-state.js'
 import { resolvePageConfig } from '~/src/config/nunjucks/page-config.js'
+import { formatParcelForDisplay } from '~/src/shared/format-parcel.js'
 import { getParcelIdFromQuery } from '../utils/parcel-request.utils.js'
 
 /**
@@ -34,12 +35,12 @@ export default class RemoveActionPageController extends QuestionPageWithParcelCh
 
   /**
    * Direct-only utility page: force the Back link to the configured list
-   * destination instead of inheriting one based on YAML page order.
-   * @param {{ serviceUrl?: string }} viewModel
+   * destination instead of inheriting one based on YAML page order. Subclasses
+   * reuse the href for their cancel links so the two always agree.
    * @returns {{ text: string, href: string }}
    */
-  buildBackLink(viewModel) {
-    return { text: 'Back', href: `${viewModel.serviceUrl}${this.redirects.list}` }
+  buildBackLink() {
+    return { text: 'Back', href: this.getHref(this.redirects.list) }
   }
 
   resolveParcelIds(request) {
@@ -105,7 +106,7 @@ export default class RemoveActionPageController extends QuestionPageWithParcelCh
 
     return h.view(this.viewName, {
       ...viewModel,
-      backLink: this.buildBackLink(viewModel),
+      backLink: this.buildBackLink(),
       parcelId,
       ...pageHeadingAndHint,
       errors: errorMessage
@@ -143,7 +144,7 @@ export default class RemoveActionPageController extends QuestionPageWithParcelCh
 
     return {
       ...viewModel,
-      backLink: this.buildBackLink(viewModel),
+      backLink: this.buildBackLink(),
       parcelId,
       pageHeading,
       hint
@@ -165,8 +166,8 @@ export default class RemoveActionPageController extends QuestionPageWithParcelCh
 
     return {
       pageHeading: actionInfo?.description
-        ? `Do you want to remove ${actionInfo.description} from land parcel ${parcelId.replaceAll('-', ' ')}?`
-        : `Do you want to remove land parcel ${parcelId.replaceAll('-', ' ')} from this application?`,
+        ? `Do you want to remove ${actionInfo.description} from land parcel ${formatParcelForDisplay(parcelId)}?`
+        : `Do you want to remove land parcel ${formatParcelForDisplay(parcelId)} from this application?`,
       hint
     }
   }

--- a/src/server/land-grants/controllers/remove-action-page.controller.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.js
@@ -4,14 +4,43 @@ import {
   deleteParcelFromState,
   deleteActionFromState
 } from '~/src/server/land-grants/view-state/land-parcel.view-state.js'
+import { resolvePageConfig } from '~/src/config/nunjucks/page-config.js'
 import { getParcelIdFromQuery } from '../utils/parcel-request.utils.js'
 
-const checkSelectedLandActionsPath = '/check-selected-land-actions'
-const selectActionsForParcelPath = '/select-actions-for-land-parcel'
-const selectLandParcelPath = '/select-land-parcel'
+/**
+ * Where the user goes after a removal.
+ */
+const defaultRedirects = {
+  list: '/check-selected-land-actions',
+  noActionsRemain: '/select-actions-for-land-parcel',
+  noParcelsRemain: '/select-land-parcel'
+}
 
 export default class RemoveActionPageController extends QuestionPageWithParcelCheckController {
   viewName = 'remove-action'
+
+  /**
+   * @param {FormModel} model
+   * @param {import('@defra/forms-model').Page} pageDef
+   */
+  constructor(model, pageDef) {
+    super(model, pageDef)
+
+    const { redirects } = /** @type {{ redirects?: Partial<typeof defaultRedirects> }} */ (
+      resolvePageConfig({ path: pageDef?.path, def: model?.def })
+    )
+    this.redirects = { ...defaultRedirects, ...(redirects ?? {}) }
+  }
+
+  /**
+   * Direct-only utility page: force the Back link to the configured list
+   * destination instead of inheriting one based on YAML page order.
+   * @param {{ serviceUrl?: string }} viewModel
+   * @returns {{ text: string, href: string }}
+   */
+  buildBackLink(viewModel) {
+    return { text: 'Back', href: `${viewModel.serviceUrl}${this.redirects.list}` }
+  }
 
   resolveParcelIds(request) {
     return getParcelIdFromQuery(request)
@@ -21,7 +50,7 @@ export default class RemoveActionPageController extends QuestionPageWithParcelCh
    * Determine next path after action removal
    * @param {object} newState - Updated state after removal
    * @param {string} parcel - Parcel key
-   * @param {string} action - Action code (optional)
+   * @param {string} [action] - Action code, absent when removing a whole parcel
    * @returns {string} - Next path to navigate to
    */
   getNextPathAfterRemoval(newState, parcel, action) {
@@ -30,15 +59,15 @@ export default class RemoveActionPageController extends QuestionPageWithParcelCh
 
     // remove the only action
     if (!hasRemainingActions && action) {
-      return `${selectActionsForParcelPath}?parcelId=${parcel}`
+      return `${this.redirects.noActionsRemain}?parcelId=${parcel}`
     }
 
     // remove the only parcel
     if (!hasRemainingParcels) {
-      return selectLandParcelPath
+      return this.redirects.noParcelsRemain
     }
 
-    return checkSelectedLandActionsPath
+    return this.redirects.list
   }
 
   /**
@@ -72,8 +101,11 @@ export default class RemoveActionPageController extends QuestionPageWithParcelCh
    * @returns {object} - Error view response
    */
   renderPostErrorView(h, request, context, errorMessage, parcelId, pageHeadingAndHint) {
+    const viewModel = this.getViewModel(request, context)
+
     return h.view(this.viewName, {
-      ...this.getViewModel(request, context),
+      ...viewModel,
+      backLink: this.buildBackLink(viewModel),
       parcelId,
       ...pageHeadingAndHint,
       errors: errorMessage
@@ -86,7 +118,7 @@ export default class RemoveActionPageController extends QuestionPageWithParcelCh
    * @param {object} state - Current state
    * @param {object} h - Response toolkit
    * @param {string} parcel - Parcel key
-   * @param {string} action - Action code (optional)
+   * @param {string} [action] - Action code, absent when removing a whole parcel
    * @returns {Promise<object>} - Response object
    */
   async processRemoval(request, state, h, parcel, action) {
@@ -107,8 +139,11 @@ export default class RemoveActionPageController extends QuestionPageWithParcelCh
    * @returns {object} - Complete view model
    */
   buildGetViewModel(request, context, parcelId, pageHeading, hint) {
+    const viewModel = this.getViewModel(request, context)
+
     return {
-      ...this.getViewModel(request, context),
+      ...viewModel,
+      backLink: this.buildBackLink(viewModel),
       parcelId,
       pageHeading,
       hint
@@ -144,8 +179,8 @@ export default class RemoveActionPageController extends QuestionPageWithParcelCh
     const landParcels = context.state?.landParcels
     const { action, parcelId } = request.query
 
-    if (!parcelId || !landParcels[parcelId]) {
-      return this.proceed(request, h, checkSelectedLandActionsPath)
+    if (!parcelId || !landParcels?.[parcelId]) {
+      return this.proceed(request, h, this.redirects.list)
     }
 
     const actionInfo = findActionInfoFromState(landParcels, parcelId, action)
@@ -181,11 +216,12 @@ export default class RemoveActionPageController extends QuestionPageWithParcelCh
       return this.processRemoval(request, state, h, parcelId, action)
     }
 
-    return this.proceed(request, h, checkSelectedLandActionsPath)
+    return this.proceed(request, h, this.redirects.list)
   }
 }
 
 /**
  * @import { FormContext, AnyFormRequest } from '@defra/forms-engine-plugin/engine/types.js'
+ * @import { FormModel } from '@defra/forms-engine-plugin/engine/models/index.js'
  * @import { ResponseObject, ResponseToolkit } from '@hapi/hapi'
  */

--- a/src/server/land-grants/controllers/remove-action-page.controller.test.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.test.js
@@ -40,7 +40,8 @@ describe('RemoveActionPageController', () => {
     controller.proceed = vi.fn().mockReturnValue('redirected')
     controller.performAuthCheck = vi.fn().mockResolvedValue(null)
     controller.getViewModel = vi.fn().mockReturnValue({
-      pageTitle: 'Remove action'
+      pageTitle: 'Remove action',
+      serviceUrl: '/test-grant'
     })
 
     mockRequest = {
@@ -189,6 +190,8 @@ describe('RemoveActionPageController', () => {
       expect(controller.getViewModel).toHaveBeenCalledWith(mockRequest, mockContext)
       expect(mockH.view).toHaveBeenCalledWith('remove-action', {
         pageTitle: 'Remove action',
+        serviceUrl: '/test-grant',
+        backLink: { text: 'Back', href: '/test-grant/check-selected-land-actions' },
         parcelId: 'SD6743-8083',
         ...pageHeadingAndHint,
         errors: 'Test error message'
@@ -283,10 +286,111 @@ describe('RemoveActionPageController', () => {
       expect(controller.getViewModel).toHaveBeenCalledWith(mockRequest, mockContext)
       expect(result).toEqual({
         pageTitle: 'Remove action',
+        serviceUrl: '/test-grant',
+        backLink: { text: 'Back', href: '/test-grant/check-selected-land-actions' },
         parcelId: 'SD6743-8083',
         pageHeading,
         hint
       })
+    })
+  })
+
+  describe('buildBackLink', () => {
+    test('points at the default list page when no config is given', () => {
+      expect(controller.buildBackLink({ serviceUrl: '/farm-payments' })).toEqual({
+        text: 'Back',
+        href: '/farm-payments/check-selected-land-actions'
+      })
+    })
+
+    test('points at the configured list page', () => {
+      const configured = new RemoveActionPageController(
+        {
+          def: { metadata: { tasklist: {}, pageConfig: { '/remove-action': { redirects: { list: '/your-land' } } } } },
+          getSection: vi.fn()
+        },
+        { path: '/remove-action' }
+      )
+
+      expect(configured.buildBackLink({ serviceUrl: '/example-grant' })).toEqual({
+        text: 'Back',
+        href: '/example-grant/your-land'
+      })
+    })
+  })
+
+  describe('redirects', () => {
+    const withRedirects = (redirects) => {
+      const configured = new RemoveActionPageController(
+        {
+          def: { metadata: { tasklist: {}, pageConfig: { '/remove-action': { redirects } } } },
+          getSection: vi.fn()
+        },
+        { path: '/remove-action' }
+      )
+      configured.setState = vi.fn().mockResolvedValue(true)
+      configured.proceed = vi.fn().mockReturnValue('redirected')
+      configured.performAuthCheck = vi.fn().mockResolvedValue(null)
+      configured.getViewModel = vi.fn().mockReturnValue({ pageTitle: 'Remove action', serviceUrl: '/test-grant' })
+      return configured
+    }
+
+    test('defaults every destination when no config is given', () => {
+      expect(controller.redirects).toEqual({
+        list: '/check-selected-land-actions',
+        noActionsRemain: '/select-actions-for-land-parcel',
+        noParcelsRemain: '/select-land-parcel'
+      })
+    })
+
+    test('sends the user to the configured list page when parcels remain', () => {
+      const configured = withRedirects({ list: '/confirm-land-and-actions' })
+      const newState = {
+        landParcels: {
+          'SD6743-8083': { actionsObj: { UPL1: { description: 'x' } } }
+        }
+      }
+
+      expect(configured.getNextPathAfterRemoval(newState, 'SD6743-8083', 'CMOR1')).toBe('/confirm-land-and-actions')
+    })
+
+    test('keeps the last-action and last-parcel destinations when only list is configured', () => {
+      const configured = withRedirects({ list: '/confirm-land-and-actions' })
+
+      expect(configured.getNextPathAfterRemoval({ landParcels: {} }, 'SD6743-8083', 'CMOR1')).toBe(
+        '/select-actions-for-land-parcel?parcelId=SD6743-8083'
+      )
+      expect(configured.getNextPathAfterRemoval({ landParcels: {} }, 'SD6743-8083', undefined)).toBe(
+        '/select-land-parcel'
+      )
+    })
+
+    test('honours configured noActionsRemain and noParcelsRemain', () => {
+      const configured = withRedirects({ noActionsRemain: '/pick-actions', noParcelsRemain: '/pick-parcel' })
+
+      expect(configured.getNextPathAfterRemoval({ landParcels: {} }, 'SD6743-8083', 'CMOR1')).toBe(
+        '/pick-actions?parcelId=SD6743-8083'
+      )
+      expect(configured.getNextPathAfterRemoval({ landParcels: {} }, 'SD6743-8083', undefined)).toBe('/pick-parcel')
+    })
+
+    test('GET redirects to the configured list page when the parcel is not in state', async () => {
+      const configured = withRedirects({ list: '/confirm-land-and-actions' })
+      mockRequest.query = {}
+
+      await configured.makeGetRouteHandler()(mockRequest, mockContext, mockH)
+
+      expect(configured.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/confirm-land-and-actions')
+    })
+
+    test('POST returns to the configured list page when the user declines removal', async () => {
+      const configured = withRedirects({ list: '/confirm-land-and-actions' })
+      mockRequest.payload = { remove: 'false' }
+
+      await configured.makePostRouteHandler()(mockRequest, mockContext, mockH)
+
+      expect(configured.setState).not.toHaveBeenCalled()
+      expect(configured.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/confirm-land-and-actions')
     })
   })
 
@@ -299,6 +403,8 @@ describe('RemoveActionPageController', () => {
       expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, [mockRequest.query.parcelId])
       expect(mockH.view).toHaveBeenCalledWith('remove-action', {
         pageTitle: 'Remove action',
+        serviceUrl: '/test-grant',
+        backLink: { text: 'Back', href: '/test-grant/check-selected-land-actions' },
         parcelId: 'SD6743-8083',
         pageHeading: `Do you want to remove Assess moorland and produce a written record: CMOR1 from land parcel SD6743 8083?`,
         hint: 'Select yes to remove this action from this land parcel. You can add a different action to the same parcel.'
@@ -314,6 +420,8 @@ describe('RemoveActionPageController', () => {
 
       expect(mockH.view).toHaveBeenCalledWith('remove-action', {
         pageTitle: 'Remove action',
+        serviceUrl: '/test-grant',
+        backLink: { text: 'Back', href: '/test-grant/check-selected-land-actions' },
         parcelId: 'SD6743-8083',
         pageHeading: 'Do you want to remove land parcel SD6743 8083 from this application?',
         hint: 'If you remove this land parcel you will also remove all the actions added to this parcel.'
@@ -367,6 +475,8 @@ describe('RemoveActionPageController', () => {
 
       expect(mockH.view).toHaveBeenCalledWith('remove-action', {
         pageTitle: 'Remove action',
+        serviceUrl: '/test-grant',
+        backLink: { text: 'Back', href: '/test-grant/check-selected-land-actions' },
         parcelId: 'SD6743-8083',
         pageHeading:
           'Do you want to remove Assess moorland and produce a written record: CMOR1 from land parcel SD6743 8083?',
@@ -386,6 +496,8 @@ describe('RemoveActionPageController', () => {
 
       expect(mockH.view).toHaveBeenCalledWith('remove-action', {
         pageTitle: 'Remove action',
+        serviceUrl: '/test-grant',
+        backLink: { text: 'Back', href: '/test-grant/check-selected-land-actions' },
         parcelId: 'SD6743-8083',
         hint: 'If you remove this land parcel you will also remove all the actions added to this parcel.',
         pageHeading: 'Do you want to remove land parcel SD6743 8083 from this application?',

--- a/src/server/land-grants/controllers/remove-action-page.controller.test.js
+++ b/src/server/land-grants/controllers/remove-action-page.controller.test.js
@@ -43,6 +43,7 @@ describe('RemoveActionPageController', () => {
       pageTitle: 'Remove action',
       serviceUrl: '/test-grant'
     })
+    controller.getHref = vi.fn().mockImplementation((path) => `/test-grant${path}`)
 
     mockRequest = {
       query: {
@@ -295,30 +296,6 @@ describe('RemoveActionPageController', () => {
     })
   })
 
-  describe('buildBackLink', () => {
-    test('points at the default list page when no config is given', () => {
-      expect(controller.buildBackLink({ serviceUrl: '/farm-payments' })).toEqual({
-        text: 'Back',
-        href: '/farm-payments/check-selected-land-actions'
-      })
-    })
-
-    test('points at the configured list page', () => {
-      const configured = new RemoveActionPageController(
-        {
-          def: { metadata: { tasklist: {}, pageConfig: { '/remove-action': { redirects: { list: '/your-land' } } } } },
-          getSection: vi.fn()
-        },
-        { path: '/remove-action' }
-      )
-
-      expect(configured.buildBackLink({ serviceUrl: '/example-grant' })).toEqual({
-        text: 'Back',
-        href: '/example-grant/your-land'
-      })
-    })
-  })
-
   describe('redirects', () => {
     const withRedirects = (redirects) => {
       const configured = new RemoveActionPageController(
@@ -332,8 +309,15 @@ describe('RemoveActionPageController', () => {
       configured.proceed = vi.fn().mockReturnValue('redirected')
       configured.performAuthCheck = vi.fn().mockResolvedValue(null)
       configured.getViewModel = vi.fn().mockReturnValue({ pageTitle: 'Remove action', serviceUrl: '/test-grant' })
+      configured.getHref = vi.fn().mockImplementation((path) => `/test-grant${path}`)
       return configured
     }
+
+    test('the Back link follows the configured list page', () => {
+      const configured = withRedirects({ list: '/your-land' })
+
+      expect(configured.buildBackLink()).toEqual({ text: 'Back', href: '/test-grant/your-land' })
+    })
 
     test('defaults every destination when no config is given', () => {
       expect(controller.redirects).toEqual({

--- a/src/server/land-grants/controllers/remove-land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/remove-land-parcel-page.controller.js
@@ -1,0 +1,57 @@
+import RemoveActionPageController from '~/src/server/land-grants/controllers/remove-action-page.controller.js'
+import { formatParcelForDisplay } from '~/src/shared/format-parcel.js'
+
+/**
+ * "Remove this land parcel?" - a confirm button and a cancel link rather than
+ * the yes/no radios of the action-removal page it extends.
+ */
+export default class RemoveLandParcelPageController extends RemoveActionPageController {
+  viewName = 'remove-land-parcel'
+
+  /**
+   * @param {AnyFormRequest} request
+   * @param {FormContext} context
+   * @param {Pick<ResponseToolkit, 'redirect' | 'view'>} h
+   * @returns {Promise<ResponseObject>}
+   */
+  async handleGet(request, context, h) {
+    const { parcelId } = /** @type {{ parcelId?: string }} */ (request.query ?? {})
+    const landParcels = context.state?.landParcels
+
+    if (!parcelId || !landParcels?.[parcelId]) {
+      return this.proceed(request, h, this.redirects.list)
+    }
+
+    const viewModel = this.getViewModel(request, context)
+
+    return h.view(this.viewName, {
+      ...viewModel,
+      backLink: this.buildBackLink(viewModel),
+      parcelId,
+      parcelReference: formatParcelForDisplay(parcelId),
+      cancelPath: this.getHref(this.redirects.list)
+    })
+  }
+
+  /**
+   * @param {AnyFormRequest} request
+   * @param {FormContext} context
+   * @param {Pick<ResponseToolkit, 'redirect' | 'view'>} h
+   * @returns {Promise<ResponseObject>}
+   */
+  async handlePost(request, context, h) {
+    const { state } = context
+    const { parcelId } = /** @type {{ parcelId?: string }} */ (request.query ?? {})
+
+    if (!parcelId || !state.landParcels?.[parcelId]) {
+      return this.proceed(request, h, this.redirects.list)
+    }
+
+    return this.processRemoval(request, state, h, parcelId, undefined)
+  }
+}
+
+/**
+ * @import { FormContext, AnyFormRequest } from '@defra/forms-engine-plugin/engine/types.js'
+ * @import { ResponseObject, ResponseToolkit } from '@hapi/hapi'
+ */

--- a/src/server/land-grants/controllers/remove-land-parcel-page.controller.js
+++ b/src/server/land-grants/controllers/remove-land-parcel-page.controller.js
@@ -23,13 +23,14 @@ export default class RemoveLandParcelPageController extends RemoveActionPageCont
     }
 
     const viewModel = this.getViewModel(request, context)
+    const backLink = this.buildBackLink()
 
     return h.view(this.viewName, {
       ...viewModel,
-      backLink: this.buildBackLink(viewModel),
+      backLink,
       parcelId,
       parcelReference: formatParcelForDisplay(parcelId),
-      cancelPath: this.getHref(this.redirects.list)
+      cancelPath: backLink.href
     })
   }
 

--- a/src/server/land-grants/controllers/remove-land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/remove-land-parcel-page.controller.test.js
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { setupControllerMocks } from '~/src/__mocks__/controller-mocks.js'
+import RemoveLandParcelPageController from './remove-land-parcel-page.controller.js'
+
+describe('RemoveLandParcelPageController', () => {
+  let controller
+  let mockRequest
+  let mockContext
+  let mockH
+
+  const mockLandParcels = {
+    'SO3757-3192': {
+      actionsObj: {
+        GRH8: { description: 'Haymaking supplement (late cut): GRH8', value: '78.56', unit: 'ha' }
+      }
+    },
+    'SD6944-0085': {
+      actionsObj: {
+        CMOR1: { description: 'Assess moorland and produce a written record: CMOR1', value: '1.0', unit: 'ha' }
+      }
+    }
+  }
+
+  const buildController = (config = {}) => {
+    const mockModel = {
+      def: { metadata: { tasklist: {}, pageConfig: { '/remove-land-parcel': config } } },
+      getSection: vi.fn()
+    }
+    const instance = new RemoveLandParcelPageController(mockModel, { path: '/remove-land-parcel' })
+    setupControllerMocks(instance)
+    instance.getViewModel = vi
+      .fn()
+      .mockReturnValue({ pageTitle: 'Remove this land parcel?', serviceUrl: '/grasslands' })
+    instance.getHref = vi.fn().mockImplementation((path) => `/grasslands${path}`)
+    return instance
+  }
+
+  beforeEach(() => {
+    controller = buildController({
+      redirects: { list: '/your-land-and-actions', noParcelsRemain: '/your-land-and-actions' }
+    })
+
+    mockRequest = {
+      query: { parcelId: 'SO3757-3192' },
+      payload: {}
+    }
+
+    mockContext = { state: { landParcels: structuredClone(mockLandParcels) } }
+
+    mockH = { view: vi.fn().mockReturnValue('view rendered'), redirect: vi.fn() }
+  })
+
+  describe('handleGet', () => {
+    test('renders the confirmation view with the parcel reference, cancel link and back link', async () => {
+      const result = await controller.handleGet(mockRequest, mockContext, mockH)
+
+      expect(mockH.view).toHaveBeenCalledWith(
+        'remove-land-parcel',
+        expect.objectContaining({
+          parcelId: 'SO3757-3192',
+          parcelReference: 'SO3757 3192',
+          cancelPath: '/grasslands/your-land-and-actions',
+          backLink: { text: 'Back', href: '/grasslands/your-land-and-actions' }
+        })
+      )
+      expect(result).toBe('view rendered')
+    })
+
+    test.each([
+      ['no parcelId is given', {}],
+      ['the parcelId is blank', { parcelId: '' }],
+      ['the parcel is not in state', { parcelId: 'ZZ0000-0000' }]
+    ])('redirects to the list page when %s', async (_name, query) => {
+      mockRequest.query = query
+
+      await controller.handleGet(mockRequest, mockContext, mockH)
+
+      expect(mockH.view).not.toHaveBeenCalled()
+      expect(controller.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/your-land-and-actions')
+    })
+  })
+
+  describe('handlePost', () => {
+    test('removes the parcel and returns to the list', async () => {
+      await controller.handlePost(mockRequest, mockContext, mockH)
+
+      const [, newState] = controller.setState.mock.calls[0]
+      expect(newState.landParcels).not.toHaveProperty('SO3757-3192')
+      expect(newState.landParcels).toHaveProperty('SD6944-0085')
+      expect(controller.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/your-land-and-actions')
+    })
+
+    test('returns to the list page when the last parcel is removed', async () => {
+      mockContext.state = { landParcels: { 'SO3757-3192': structuredClone(mockLandParcels['SO3757-3192']) } }
+
+      await controller.handlePost(mockRequest, mockContext, mockH)
+
+      const [, newState] = controller.setState.mock.calls[0]
+      expect(newState).not.toHaveProperty('landParcels')
+      expect(controller.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/your-land-and-actions')
+    })
+
+    test('does not remove anything when the parcel is not in state', async () => {
+      mockRequest.query = { parcelId: 'ZZ0000-0000' }
+
+      await controller.handlePost(mockRequest, mockContext, mockH)
+
+      expect(controller.setState).not.toHaveBeenCalled()
+      expect(controller.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/your-land-and-actions')
+    })
+  })
+
+  describe('redirect defaults', () => {
+    test('falls back to the farm payments paths when no config is given', async () => {
+      const defaulted = buildController()
+      mockRequest.query = {}
+
+      await defaulted.handleGet(mockRequest, mockContext, mockH)
+
+      expect(defaulted.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/check-selected-land-actions')
+    })
+  })
+})

--- a/src/server/land-grants/controllers/select-actions-base-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-actions-base-page.controller.test.js
@@ -1,6 +1,7 @@
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
+import { setupControllerMocks } from '~/src/__mocks__/controller-mocks.js'
 import {
   fetchGroupedActionsForParcel,
   fetchParcels,
@@ -112,10 +113,7 @@ describe('SelectActionsBasePageController', () => {
     const mockModel = { def: { metadata: {} }, getSection: vi.fn(), pages: [] }
     controller = new StubSelectActionsController(mockModel, {})
     controller.collection = { getErrors: vi.fn().mockReturnValue([]) }
-    controller.setState = vi.fn().mockResolvedValue(true)
-    controller.proceed = vi.fn().mockReturnValue('redirected')
-    controller.getNextPath = vi.fn().mockReturnValue('/next-path')
-    controller.performAuthCheck = vi.fn().mockResolvedValue(null)
+    setupControllerMocks(controller)
 
     fetchParcels.mockResolvedValue(mockParcelsResponse)
 

--- a/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
@@ -122,7 +122,6 @@ describe('SelectLandParcelPageController', () => {
     const mockPageDef = {}
     controller = new SelectLandParcelPageController(mockModel, mockPageDef)
     setupControllerMocks(controller, { proceed: 'next', nextPath: '/next-page' })
-    controller.performAuthCheck = vi.fn().mockResolvedValue(null)
 
     fetchParcels.mockResolvedValue(mockParcelsResponse)
 

--- a/src/server/land-grants/view-state/land-parcel.view-state.js
+++ b/src/server/land-grants/view-state/land-parcel.view-state.js
@@ -233,6 +233,41 @@ export function getAddedActionsForStateParcel(state, selectedLandParcel) {
 }
 
 /**
+ * Drops a parcel from the map's own record of what is selected, which
+ * MapSelectPageController keeps separately from `landParcels`. Without this a
+ * removed parcel stays highlighted on the map and keeps appearing on Check
+ * your answers via the `selectedParcelsDisplay` hidden field. Journeys that
+ * pick parcels from a list rather than the map have none of these keys, so
+ * this is a no-op for them.
+ * @param {object} newState - State being built, mutated in place
+ * @param {string} parcel - Parcel key (format: "sheetId-parcelId")
+ * @returns {void}
+ */
+function pruneMapSelection(newState, parcel) {
+  if (Array.isArray(newState.selectedParcelIds)) {
+    newState.selectedParcelIds = newState.selectedParcelIds.filter((id) => id !== parcel)
+
+    if (newState.selectedParcelIds.length === 0) {
+      delete newState.selectedParcelIds
+    }
+  }
+
+  if (newState.selectedParcelId === parcel) {
+    delete newState.selectedParcelId
+  }
+
+  if (newState.selectedParcelsDisplay !== undefined) {
+    const remaining = Array.isArray(newState.selectedParcelIds) ? newState.selectedParcelIds : []
+
+    if (remaining.length === 0) {
+      delete newState.selectedParcelsDisplay
+    } else {
+      newState.selectedParcelsDisplay = remaining.join(', ')
+    }
+  }
+}
+
+/**
  * Delete an entire parcel from state and clean up related data
  * @param {object} state - Current state
  * @param {string} parcel - Parcel key (format: "sheetId-parcelId")
@@ -241,6 +276,7 @@ export function getAddedActionsForStateParcel(state, selectedLandParcel) {
 export function deleteParcelFromState(state, parcel) {
   const newState = structuredClone(state)
   delete newState.landParcels[parcel]
+  pruneMapSelection(newState, parcel)
 
   // Remove the land parcels key if it is empty
   if (Object.keys(newState.landParcels || {}).length === 0) {
@@ -269,6 +305,7 @@ export function deleteActionFromState(state, parcel, action) {
     // Remove parcel if no actions remain
     if (Object.keys(newState.landParcels[parcel].actionsObj).length === 0) {
       delete newState.landParcels[parcel]
+      pruneMapSelection(newState, parcel)
     }
 
     // Remove the land parcels key if it is empty

--- a/src/server/land-grants/view-state/land-parcel.view-state.test.js
+++ b/src/server/land-grants/view-state/land-parcel.view-state.test.js
@@ -549,6 +549,100 @@ describe('land-parcel-state.manager', () => {
 
       expect(state.landParcels).toHaveProperty('AB1234-5678')
     })
+
+    it('should drop the parcel from the map selection and rebuild the display value', () => {
+      const state = {
+        landParcels: {
+          'AB1234-5678': { actionsObj: { SAM1: {} } },
+          'CD9999-1111': { actionsObj: { SAM2: {} } }
+        },
+        selectedParcelIds: ['AB1234-5678', 'CD9999-1111'],
+        selectedParcelsDisplay: 'AB1234-5678, CD9999-1111'
+      }
+
+      const result = deleteParcelFromState(state, 'AB1234-5678')
+
+      expect(result.selectedParcelIds).toEqual(['CD9999-1111'])
+      expect(result.selectedParcelsDisplay).toBe('CD9999-1111')
+    })
+
+    it('should clear the map selection keys when deleting the last parcel', () => {
+      const state = {
+        landParcels: {
+          'AB1234-5678': { actionsObj: { SAM1: {} } }
+        },
+        selectedParcelId: 'AB1234-5678',
+        selectedParcelIds: ['AB1234-5678'],
+        selectedParcelsDisplay: 'AB1234-5678'
+      }
+
+      const result = deleteParcelFromState(state, 'AB1234-5678')
+
+      expect(result).not.toHaveProperty('selectedParcelId')
+      expect(result).not.toHaveProperty('selectedParcelIds')
+      expect(result).not.toHaveProperty('selectedParcelsDisplay')
+    })
+
+    it('should keep a single-select parcel id belonging to a parcel that was not removed', () => {
+      const state = {
+        landParcels: {
+          'AB1234-5678': { actionsObj: { SAM1: {} } },
+          'CD9999-1111': { actionsObj: { SAM2: {} } }
+        },
+        selectedParcelId: 'CD9999-1111',
+        selectedParcelIds: ['CD9999-1111']
+      }
+
+      const result = deleteParcelFromState(state, 'AB1234-5678')
+
+      expect(result.selectedParcelId).toBe('CD9999-1111')
+      expect(result.selectedParcelIds).toEqual(['CD9999-1111'])
+    })
+
+    it('should rebuild the display value when only the id list is an array', () => {
+      const state = {
+        landParcels: {
+          'AB1234-5678': { actionsObj: { SAM1: {} } },
+          'CD9999-1111': { actionsObj: { SAM2: {} } }
+        },
+        selectedParcelIds: 'AB1234-5678, CD9999-1111',
+        selectedParcelsDisplay: 'AB1234-5678, CD9999-1111'
+      }
+
+      const result = deleteParcelFromState(state, 'AB1234-5678')
+
+      expect(result.selectedParcelIds).toBe('AB1234-5678, CD9999-1111')
+      expect(result).not.toHaveProperty('selectedParcelsDisplay')
+    })
+
+    it('should prune the id list when there is no display value to rebuild', () => {
+      const state = {
+        landParcels: {
+          'AB1234-5678': { actionsObj: { SAM1: {} } },
+          'CD9999-1111': { actionsObj: { SAM2: {} } }
+        },
+        selectedParcelIds: ['AB1234-5678', 'CD9999-1111']
+      }
+
+      const result = deleteParcelFromState(state, 'AB1234-5678')
+
+      expect(result.selectedParcelIds).toEqual(['CD9999-1111'])
+      expect(result).not.toHaveProperty('selectedParcelsDisplay')
+    })
+
+    it('should leave journeys that do not use the map untouched', () => {
+      const state = {
+        landParcels: {
+          'AB1234-5678': { actionsObj: { SAM1: {} } },
+          'CD9999-1111': { actionsObj: { SAM2: {} } }
+        }
+      }
+
+      const result = deleteParcelFromState(state, 'AB1234-5678')
+
+      expect(result).not.toHaveProperty('selectedParcelIds')
+      expect(result).not.toHaveProperty('selectedParcelsDisplay')
+    })
   })
 
   describe('deleteActionFromState', () => {
@@ -600,6 +694,37 @@ describe('land-parcel-state.manager', () => {
       expect(result).not.toHaveProperty('payment')
       expect(result).not.toHaveProperty('totalPence')
       expect(result).not.toHaveProperty('totalPayment')
+    })
+
+    it('should drop the parcel from the map selection when its last action goes', () => {
+      const state = {
+        landParcels: {
+          'AB1234-5678': { actionsObj: { SAM1: {} } },
+          'CD9999-1111': { actionsObj: { SAM2: {} } }
+        },
+        selectedParcelIds: ['AB1234-5678', 'CD9999-1111'],
+        selectedParcelsDisplay: 'AB1234-5678, CD9999-1111'
+      }
+
+      const result = deleteActionFromState(state, 'AB1234-5678', 'SAM1')
+
+      expect(result.selectedParcelIds).toEqual(['CD9999-1111'])
+      expect(result.selectedParcelsDisplay).toBe('CD9999-1111')
+    })
+
+    it('should keep the map selection when the parcel still has other actions', () => {
+      const state = {
+        landParcels: {
+          'AB1234-5678': { actionsObj: { SAM1: {}, SAM2: {} } }
+        },
+        selectedParcelIds: ['AB1234-5678'],
+        selectedParcelsDisplay: 'AB1234-5678'
+      }
+
+      const result = deleteActionFromState(state, 'AB1234-5678', 'SAM1')
+
+      expect(result.selectedParcelIds).toEqual(['AB1234-5678'])
+      expect(result.selectedParcelsDisplay).toBe('AB1234-5678')
     })
 
     it('should handle deleting non-existent action gracefully', () => {

--- a/src/server/land-grants/views/remove-land-parcel.html
+++ b/src/server/land-grants/views/remove-land-parcel.html
@@ -1,0 +1,37 @@
+{% extends baseLayoutPath %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitle = "Remove this land parcel?" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="{{ gridColumnClass(page, 'govuk-grid-column-two-thirds-from-desktop') }}">
+      {% if sectionTitle and sectionTitle.length and (sectionTitle !== pageTitle) %}
+        <h2 class="govuk-caption-l govuk-!-margin-top-0" id="section-title">
+          {{- sectionTitle -}}
+        </h2>
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+
+      <p class="govuk-body">
+        This will remove land parcel {{ parcelReference }} and all actions added to it from your application.
+      </p>
+
+      <form method="post" novalidate="novalidate">
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Remove this land parcel",
+            classes: "govuk-button--warning",
+            preventDoubleClick: true
+          }) }}
+
+          <a class="govuk-link" href="{{ cancelPath }}">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/src/shared/format-parcel.js
+++ b/src/shared/format-parcel.js
@@ -25,3 +25,11 @@ export const parseLandParcel = (landParcel) => {
  * @returns {string}
  */
 export const stringifyParcel = ({ parcelId, sheetId }) => `${sheetId}-${parcelId}`
+
+/**
+ * The compound id as it is shown to the user - space separated rather than
+ * hyphenated, e.g. "SO3757-3192" reads as "SO3757 3192" on screen.
+ * @param {string} landParcel - The land parcel identifier
+ * @returns {string}
+ */
+export const formatParcelForDisplay = (landParcel) => (landParcel || '').replaceAll('-', ' ')


### PR DESCRIPTION
Adds a "Remove this land parcel?" confirmation page for grasslands (confirm button plus cancel link, rather than the yes/no radios used for action removal) and flashes the removed parcel reference so the "Your land and actions" page can show a success banner. Makes RemoveActionPageController's previously hardcoded redirect paths configurable per grant via YAML page config, defaulting to the existing farm payments paths so that journey is unchanged. Also clears the map's separate selection keys when a parcel leaves state, which previously left a removed parcel highlighted on the map and listed on Check your answers.