### PR TITLE
Fix claim amount, payment total and error link defects surfaced by exactOptionalPropertyTypes

### DIFF
--- a/src/__mocks__/index.js
+++ b/src/__mocks__/index.js
@@ -25,4 +25,6 @@ export {
 
 export { setupControllerMocks } from './controller-mocks.js'
 
+export { mockParcelsResponse, mockUserContext } from './land-grants-mocks.js'
+
 export { mockFilters } from './filters-mocks.js'

--- a/src/__mocks__/land-grants-mocks.js
+++ b/src/__mocks__/land-grants-mocks.js
@@ -1,0 +1,19 @@
+/**
+ * Shared fixtures for the land-grants controller tests. The two-parcel response
+ * is what fetchParcels() resolves to; tests needing a single parcel take the
+ * first entry rather than redeclaring it.
+ */
+export const mockParcelsResponse = [
+  {
+    parcelId: '0155',
+    sheetId: 'SD7946',
+    area: { unit: 'ha', value: 4.0383 }
+  },
+  {
+    parcelId: '4509',
+    sheetId: 'SD7846',
+    area: { unit: 'sqm', value: 0.0633 }
+  }
+]
+
+export const mockUserContext = { defraIdToken: 'defra-id-access-token', sbi: '106284736' }

--- a/src/server/claims/services/claim-state.js
+++ b/src/server/claims/services/claim-state.js
@@ -80,7 +80,12 @@ export function upsertCurrentClaim(state, { referenceNumber, totalEligibleArea, 
   const currentIndex = claims.findIndex((claim) => claim?.status !== ClaimStatus.SUBMITTED)
 
   if (currentIndex >= 0) {
-    claims[currentIndex] = { ...claims[currentIndex], totalEligibleArea, unit, totalClaimAmountPence }
+    claims[currentIndex] = {
+      ...claims[currentIndex],
+      ...(totalEligibleArea !== undefined && { totalEligibleArea }),
+      ...(unit !== undefined && { unit }),
+      ...(totalClaimAmountPence !== undefined && { totalClaimAmountPence })
+    }
     return { claims, currentClaim: claims[currentIndex] }
   }
 

--- a/src/server/claims/services/claim-state.test.js
+++ b/src/server/claims/services/claim-state.test.js
@@ -104,6 +104,26 @@ describe('claim-state', () => {
       expect(claims).toHaveLength(2)
     })
 
+    test('keeps stored amounts when the refreshed values are omitted', () => {
+      const state = {
+        claims: [
+          {
+            claimNumber: 'WMP-A1B2-C3D4-C0001',
+            status: ClaimStatus.IN_PROGRESS,
+            totalEligibleArea: 24.95,
+            unit: 'ha',
+            totalClaimAmountPence: 150000
+          }
+        ]
+      }
+
+      const { currentClaim } = upsertCurrentClaim(state, { referenceNumber: 'WMP-A1B2-C3D4' })
+
+      expect(currentClaim.totalClaimAmountPence).toBe(150000)
+      expect(currentClaim.totalEligibleArea).toBe(24.95)
+      expect(currentClaim.unit).toBe('ha')
+    })
+
     test('refreshes amounts on the existing current claim instead of creating a new one', () => {
       const state = {
         claims: [
@@ -164,6 +184,14 @@ describe('claim-state', () => {
         { claimNumber: 'WMP-A1B2-C3D4-C0001', status: ClaimStatus.SUBMITTED },
         { claimNumber: 'WMP-A1B2-C3D4-C0002', status: ClaimStatus.SUBMITTED, submittedAt: '2025-01-01T00:00:00.000Z' }
       ])
+    })
+
+    test('leaves every claim untouched when no claim number matches', () => {
+      const state = { claims: [{ claimNumber: 'WMP-A1B2-C3D4-C0001', status: ClaimStatus.IN_PROGRESS }] }
+
+      const result = markClaimSubmitted(state, 'WMP-A1B2-C3D4-C0999', '2025-01-01T00:00:00.000Z')
+
+      expect(result).toEqual([{ claimNumber: 'WMP-A1B2-C3D4-C0001', status: ClaimStatus.IN_PROGRESS }])
     })
 
     test('does not mutate the original state claims', () => {

--- a/src/server/land-grants/controllers/select-actions-base-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-actions-base-page.controller.test.js
@@ -1,6 +1,7 @@
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
+import { mockParcelsResponse as allParcels } from '~/src/__mocks__/land-grants-mocks.js'
 import {
   fetchGroupedActionsForParcel,
   fetchParcels,
@@ -91,7 +92,7 @@ class StubSelectActionsController extends SelectActionsBasePageController {
   }
 }
 
-const mockParcelsResponse = [{ parcelId: '0155', sheetId: 'SD7946', area: { unit: 'ha', value: 4.0383 } }]
+const mockParcelsResponse = [allParcels[0]]
 
 const mockGroupedActions = [
   {

--- a/src/server/land-grants/controllers/select-actions-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-actions-page.controller.test.js
@@ -1,6 +1,7 @@
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
+import { mockParcelsResponse as allParcels, mockUserContext } from '~/src/__mocks__/land-grants-mocks.js'
 import {
   fetchActionsForParcel,
   fetchActionsWithPlannedActions,
@@ -55,14 +56,8 @@ vi.mock('~/src/config/config.js', async () => {
 vi.mock('~/src/server/land-grants/services/land-grants.service.js')
 vi.mock('~/src/shared/format-parcel.js')
 
-const mockParcelsResponse = [
-  {
-    parcelId: '0155',
-    sheetId: 'SD7946',
-    area: { unit: 'ha', value: 4.0383 }
-  }
-]
-const userContext = { defraIdToken: 'defra-id-access-token', sbi: '106284736' }
+const mockParcelsResponse = [allParcels[0]]
+const userContext = mockUserContext
 
 describe('SelectActionsPageController', () => {
   let controller

--- a/src/server/land-grants/controllers/select-grouped-actions-page.controller.js
+++ b/src/server/land-grants/controllers/select-grouped-actions-page.controller.js
@@ -45,10 +45,13 @@ export default class SelectGroupedActionsPageController extends SelectActionsBas
    */
   buildValidationErrors(payload, failedMessages) {
     const landActionFields = extractLandActionFields(payload, this.actionFieldPrefix)
-    return failedMessages.map((e) => ({
-      text: `${e.description}${e.code ? ': ' + e.code : ''}`,
-      href: e.code ? `#${landActionFields.find((field) => payload[field] === e.code)}` : undefined
-    }))
+    return failedMessages.map((e) => {
+      const field = e.code ? landActionFields.find((f) => payload[f] === e.code) : undefined
+      return {
+        text: `${e.description}${e.code ? ': ' + e.code : ''}`,
+        href: field ? `#${field}` : undefined
+      }
+    })
   }
 
   /**

--- a/src/server/land-grants/controllers/select-grouped-actions-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-grouped-actions-page.controller.test.js
@@ -1,6 +1,7 @@
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
+import { mockParcelsResponse, mockUserContext } from '~/src/__mocks__/land-grants-mocks.js'
 import {
   fetchGroupedActionsForParcel,
   fetchParcels,
@@ -53,19 +54,7 @@ vi.mock('~/src/config/config.js', async () => {
 vi.mock('~/src/server/land-grants/services/land-grants.service.js')
 vi.mock('~/src/shared/format-parcel.js')
 
-const mockParcelsResponse = [
-  {
-    parcelId: '0155',
-    sheetId: 'SD7946',
-    area: { unit: 'ha', value: 4.0383 }
-  },
-  {
-    parcelId: '4509',
-    sheetId: 'SD7846',
-    area: { unit: 'sqm', value: 0.0633 }
-  }
-]
-const userContext = { defraIdToken: 'defra-id-access-token', sbi: '106284736' }
+const userContext = mockUserContext
 
 describe('SelectGroupedActionsPageController', () => {
   let controller
@@ -175,6 +164,15 @@ describe('SelectGroupedActionsPageController', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+  })
+
+  describe('buildValidationErrors', () => {
+    test('omits the href when no field carries the action code', () => {
+      const payload = { landAction_1: 'UPL1' }
+      const errors = controller.buildValidationErrors(payload, [{ code: 'UPL2', description: 'Enter a quantity' }])
+
+      expect(errors).toEqual([{ text: 'Enter a quantity: UPL2', href: undefined }])
+    })
   })
 
   describe('singleParcelSubmission (grant-level config)', () => {

--- a/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
@@ -1,6 +1,7 @@
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { vi } from 'vitest'
 import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
+import { mockParcelsResponse } from '~/src/__mocks__/land-grants-mocks.js'
 import { debug } from '~/src/server/common/helpers/logging/log.js'
 import { setupControllerMocks } from '~/src/__mocks__/controller-mocks.js'
 import { fetchParcels } from '~/src/server/land-grants/services/land-grants.service.js'
@@ -40,19 +41,6 @@ vi.mock('~/src/server/land-grants/services/land-grants.service.js', () => ({
 vi.mock('~/src/shared/format-parcel.js', () => ({
   stringifyParcel: ({ parcelId, sheetId }) => `${sheetId}-${parcelId}`
 }))
-
-const mockParcelsResponse = [
-  {
-    parcelId: '0155',
-    sheetId: 'SD7946',
-    area: { unit: 'ha', value: 4.0383 }
-  },
-  {
-    parcelId: '4509',
-    sheetId: 'SD7846',
-    area: { unit: 'sqm', value: 0.0633 }
-  }
-]
 
 const controllerParcelsResponse = [
   {

--- a/src/server/land-grants/services/land-grants.service.js
+++ b/src/server/land-grants/services/land-grants.service.js
@@ -48,7 +48,7 @@ const buildParcelActionsCacheKey = (parcelKey, enabledLandActions) =>
  * Calculates grant payment for land actions.
  * @param {object} state
  * @param {LandGrantsUserContext} userContext
- * @returns {Promise<{payment: PaymentCalculation, errorMessage?: string, paymentTotal: string}>} - Payment calculation result
+ * @returns {Promise<{payment: PaymentCalculation, errorMessage?: string, paymentTotal?: string}>} - Payment calculation result
  * @throws {Error}
  */
 export async function calculateLandActionsPayment(state, userContext) {
@@ -56,13 +56,13 @@ export async function calculateLandActionsPayment(state, userContext) {
     parcel: stateToLandActionsMapper(state)
   }
   const { payment } = await calculate(payload, LAND_GRANTS_API_URL, userContext)
-  const paymentTotal = formatCurrency(payment?.annualTotalPence / 100)
+  const annualTotalPence = payment?.annualTotalPence
 
-  return {
-    payment,
-    errorMessage: paymentTotal == null ? 'Error calculating payment. Please try again later.' : undefined,
-    paymentTotal
+  if (annualTotalPence == null) {
+    return { payment, errorMessage: 'Error calculating payment. Please try again later.' }
   }
+
+  return { payment, paymentTotal: formatCurrency(annualTotalPence / 100) }
 }
 
 /**

--- a/src/server/land-grants/services/land-grants.service.test.js
+++ b/src/server/land-grants/services/land-grants.service.test.js
@@ -88,6 +88,8 @@ describe('land-grants service', () => {
   })
 
   describe('calculateLandActionsPayment', () => {
+    const PAYMENT_ERROR = 'Error calculating payment. Please try again later.'
+
     it('should calculate payment and format amount', async () => {
       const mockCalculateResponse = {
         payment: { annualTotalPence: 123456 }
@@ -123,42 +125,25 @@ describe('land-grants service', () => {
       expect(formatCurrency).toHaveBeenCalledWith(1234.56)
       expect(result).toEqual({
         payment: { annualTotalPence: 123456 },
-        paymentTotal: '£1,234.56',
-        errorMessage: undefined
+        paymentTotal: '£1,234.56'
       })
     })
 
-    it('should handle zero payment amount', async () => {
-      const mockCalculateResponse = { payment: { total: 0 } }
-      calculate.mockResolvedValueOnce(mockCalculateResponse)
+    it.each([
+      ['a zero annual total', { payment: { annualTotalPence: 0 } }, '£0.00', undefined],
+      ['no payment object', {}, undefined, PAYMENT_ERROR],
+      ['a payment with no annual total', { payment: { total: 0 } }, undefined, PAYMENT_ERROR]
+    ])('handles %s', async (_, response, expectedTotal, expectedError) => {
+      calculate.mockResolvedValueOnce(response)
       formatCurrency.mockReturnValue('£0.00')
 
-      const result = await calculateLandActionsPayment({
-        landParcels: {
-          'SHEET123-PARCEL456': {
-            actionsObj: { CMOR1: { value: 0 } }
-          }
-        }
-      })
+      const result = await calculateLandActionsPayment({ landParcels: { 'SHEET123-PARCEL456': {} } })
 
-      expect(result.paymentTotal).toBe('£0.00')
-      expect(result.errorMessage).toBeUndefined()
-    })
-
-    it('should handle missing payment data with error message', async () => {
-      const mockCalculateResponse = {/* no payment property */}
-      calculate.mockResolvedValueOnce(mockCalculateResponse)
-
-      formatCurrency.mockReturnValue(null)
-
-      const result = await calculateLandActionsPayment({
-        landParcels: {
-          'SHEET123-PARCEL456': {}
-        }
-      })
-
-      expect(result.paymentTotal).toBeNull()
-      expect(result.errorMessage).toBe('Error calculating payment. Please try again later.')
+      expect(result.paymentTotal).toBe(expectedTotal)
+      expect(result.errorMessage).toBe(expectedError)
+      // A missing amount must never reach formatCurrency: it would format NaN
+      // and render "£NaN" to the user instead of the error message.
+      expect(formatCurrency).toHaveBeenCalledTimes(expectedTotal ? 1 : 0)
     })
 
     it('should propagate API errors', async () => {


### PR DESCRIPTION
Three defects found by running tsc with exactOptionalPropertyTypes and verifying each finding against its consumer. upsertCurrentClaim spread omitted values over stored ones, so a revisit where the payment calculation returned nothing wiped the claim amount the declaration reads back from state. calculateLandActionsPayment guarded on the formatted string, but formatCurrency always returns a string, so its error message could never display and a missing amount rendered as "£NaN". buildValidationErrors interpolated an unmatched find() result into the error-summary link, producing href="#undefined". Each fix has a regression test verified to fail without it; the payment outcome tests are consolidated into it.each and the duplicated parcels fixture moved to src/mocks/land-grants-mocks.js.