### PR TITLE
 Handle land parcels with no eligible actions

### DIFF
--- a/acceptance/journey-cli.js
+++ b/acceptance/journey-cli.js
@@ -17,6 +17,7 @@
  *
  * Usage:
  *   node journey-cli.js <slug> [--crn <crn>] [--stop <n|section>] [--headed]
+ *                              [--parcel <ref>] [--mock-no-actions]
  *                              [--base-url <url>] [--timeout <ms>]
  *
  * Invoked by `gt journey <slug>` (tools/grants-tui/journey.js).
@@ -50,6 +51,8 @@ function parseArgs(argv) {
     crn: DEFAULT_CRN,
     stop: undefined,
     start: 'start',
+    parcel: undefined,
+    mockNoActions: false,
     headed: false,
     clear: false,
     baseUrl: DEFAULT_BASE_URL,
@@ -59,6 +62,8 @@ function parseArgs(argv) {
     const arg = argv[i]
     if (arg === '--headed') {
       opts.headed = true
+    } else if (arg === '--mock-no-actions') {
+      opts.mockNoActions = true
     } else if (arg === '--clear') {
       opts.clear = true
     } else if (arg === '--crn') {
@@ -67,6 +72,8 @@ function parseArgs(argv) {
       opts.stop = argv[++i]
     } else if (arg === '--start') {
       opts.start = argv[++i]
+    } else if (arg === '--parcel') {
+      opts.parcel = argv[++i]
     } else if (arg === '--base-url') {
       opts.baseUrl = argv[++i]
     } else if (arg === '--timeout') {
@@ -131,7 +138,7 @@ async function main() {
   const opts = parseArgs(process.argv.slice(2))
   if (!opts.slug) {
     console.error(
-      'Usage: node journey-cli.js <slug> [--crn <crn>] [--stop <n|section>] [--start <page>] [--headed] [--clear] [--base-url <url>]'
+      'Usage: node journey-cli.js <slug> [--crn <crn>] [--stop <n|section>] [--start <page>] [--parcel <ref>] [--mock-no-actions] [--headed] [--clear] [--base-url <url>]'
     )
     process.exit(2)
   }
@@ -158,7 +165,14 @@ async function main() {
   // <form> otherwise sits above the page form and the engine submits it by
   // mistake (getting stuck on the start page). 'false' = reject analytics, which
   // also keeps Google Analytics from adding network noise.
-  await context.addCookies([{ name: 'cookie_consent', value: 'false', url: opts.baseUrl }])
+  const cookies = [{ name: 'cookie_consent', value: 'false', url: opts.baseUrl }]
+  // Dev-tools override: makes the app report the selected land parcel as having
+  // no eligible actions, so the map page's error can be reached on any stack.
+  if (opts.mockNoActions) {
+    cookies.push({ name: 'dev_mock_no_actions', value: '1', url: opts.baseUrl })
+    console.log(`${LOG_PREFIX} Mock enabled: land parcels report no eligible actions`)
+  }
+  await context.addCookies(cookies)
   const page = await context.newPage()
   page.setDefaultTimeout(opts.timeout)
   page.setDefaultNavigationTimeout(opts.timeout)
@@ -203,7 +217,12 @@ async function main() {
     const stopArg = normaliseStop(opts.stop)
     // The first step submits and navigates, which can tear down the evaluate
     // context — that's expected, not an error.
-    await page.evaluate((arg) => globalThis.runJourney(arg), stopArg ?? null).catch(() => {})
+    await page
+      .evaluate(({ stop, parcel }) => globalThis.runJourney(stop, parcel ? { parcel } : undefined), {
+        stop: stopArg ?? null,
+        parcel: opts.parcel ?? null
+      })
+      .catch(() => {})
 
     const timer = new Promise((resolve) => setTimeout(() => resolve('timeout'), opts.timeout))
     result = await Promise.race([outcome, timer])

--- a/docs/DEV-TOOLS.md
+++ b/docs/DEV-TOOLS.md
@@ -112,6 +112,7 @@ Open the browser console and run:
 runJourney() // Run through all steps
 runJourney(5) // Stop before step 5
 runJourney('sectionName') // Run only the named section
+runJourney(null, { parcel: 'SD6843-7039' }) // Drive the mapParcel step to a specific parcel
 stopJourney() // Cancel a running journey
 ```
 
@@ -136,26 +137,56 @@ Prefer not to remember slugs and flags? Run `gt` with no arguments to open the i
 2. **CRN** — only asked when a journey has more than one known-good CRN (e.g. woodland); otherwise the right CRN is chosen automatically.
 3. **Headed or headless** — headless runs in the background (bundled Chromium); headed watches it in your installed Google Chrome.
 4. **Clear state?** — keep the saved application state (resume where it left off) or reset to step 1, matching the footer "Clear application state" link.
-5. **Stop on which page?** — headed runs only: halt the browser on a chosen page for inspection, or run to the end.
+5. **Land parcel actions?** — only asked for journeys with a map step: **API Data**, or **Mock no eligible actions** (see [below](#land-parcels-with-no-eligible-actions)).
+6. **Stop on which page?** — headed runs only: halt the browser on a chosen page for inspection, or run to the end.
 
 Journeys flagged as won't-complete (e.g. **farm-payments**, **methane**) make you acknowledge why before running. The `journey ⇢` item is disabled until the Docker stack is up; for a plain `npm run dev` server use the `gt journey <slug>` form above instead.
 
 Under the hood this launches a Chromium browser (reusing the acceptance suite's Playwright install in `acceptance/`), signs in through the DefraID stub, then calls `runJourney()` on the page and streams the `[journey-runner]` console output to your terminal. It exits non-zero if the journey gets stuck, and prints the final page heading and any error summary to help diagnose the stall.
 
-| Flag               | Default                   | Purpose                                                                                                                                                                                                                                                                                              |
-| ------------------ | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--crn <crn>`      | journey's allowlisted CRN | DefraID CRN to sign in as. Defaults per journey to a CRN on that grant's allowlist — most grants are `allowAll` (uses `1102838829`), but **woodland** needs `1100943757`/`1100943838`, and **farm-payments** uses `1102838829`. The interactive menu lets you pick when a journey has more than one. |
-| `--stop <n\|sect>` | run to the end            | Stop before step `n` (1-indexed), or run only section `sect`                                                                                                                                                                                                                                         |
-| `--headed`         | headless                  | Watch the run in your installed Google Chrome (headless uses bundled Chromium)                                                                                                                                                                                                                       |
-| `--clear`          | keeps state               | Flush saved application state first, so `--stop` starts from step 1                                                                                                                                                                                                                                  |
-| `--base-url <url>` | auto-detected             | App base URL — defaults to `https://localhost:4000` when the HA addon is running, otherwise `http://localhost:3000`                                                                                                                                                                                  |
-| `--skip-install`   | installs chromium         | Skip `playwright install chromium`                                                                                                                                                                                                                                                                   |
+| Flag                | Default                   | Purpose                                                                                                                                                                                                                                                                                                                                           |
+| ------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--parcel <ref>`    | first available parcel    | Land parcel the `mapParcel` step selects, e.g. `SD6843-7039`. Overrides the step's `value` without editing the journey file. The ref must be one `/api/map/parcels` returns, or the step fails listing what was available — note that with `MAP_MOCK_DATA_ENABLED=true` (the default) that list is truncated to the embedded mock geometry count. |
+| `--mock-no-actions` | off                       | Makes land parcels report **no eligible actions**, so the map page's "There are no eligible actions for this parcel" error can be reached. See [Land parcels with no eligible actions](#land-parcels-with-no-eligible-actions) below.                                                                                                             |
+| `--crn <crn>`       | journey's allowlisted CRN | DefraID CRN to sign in as. Defaults per journey to a CRN on that grant's allowlist — most grants are `allowAll` (uses `1102838829`), but **woodland** needs `1100943757`/`1100943838`, and **farm-payments** uses `1102838829`. The interactive menu lets you pick when a journey has more than one.                                              |
+| `--stop <n\|sect>`  | run to the end            | Stop before step `n` (1-indexed), or run only section `sect`                                                                                                                                                                                                                                                                                      |
+| `--headed`          | headless                  | Watch the run in your installed Google Chrome (headless uses bundled Chromium)                                                                                                                                                                                                                                                                    |
+| `--clear`           | keeps state               | Flush saved application state first, so `--stop` starts from step 1                                                                                                                                                                                                                                                                               |
+| `--base-url <url>`  | auto-detected             | App base URL — defaults to `https://localhost:4000` when the HA addon is running, otherwise `http://localhost:3000`                                                                                                                                                                                                                               |
+| `--skip-install`    | installs chromium         | Skip `playwright install chromium`                                                                                                                                                                                                                                                                                                                |
 
 The app must already be running (`gt up` or `npm run dev`), and the same land-grants/mockserver setup described below is needed for journeys that reach `/select-land-parcel` or `/total-area-of-woodland`. The stub password comes from `DEFRA_ID_USER_PASSWORD` (defaults to `x`, matching `acceptance/run-local.sh`).
 
 The base URL is auto-detected from the running stack: `http://localhost:3000` normally, or `https://localhost:4000` when the **High Availability** addon (`gt up --ha`) fronts the app with its HTTPS nginx proxy (the self-signed cert is accepted automatically). Override with `--base-url` for a non-standard setup.
 
 The journey must be allowlisted for the signed-in user, or the app redirects to `/auth/journey-unauthorised` and the run reports as stuck. Locally the allowlist lives in the `config__allowlist_entries` collection in the `grants-ui-backend` Mongo database; `example-grant-with-auth` is seeded `allowAll`, so it's the most reliable journey to smoke-test with.
+
+### Land parcels with no eligible actions
+
+The Grasslands map page rejects Continue when the selected parcel has no eligible action, showing:
+
+> There are no eligible actions for this parcel. Change the parcel land cover or choose a different parcel to view eligible actions.
+
+The wording deliberately matches the select-actions page's own empty state (`src/server/land-grants/views/select-actions.html`) — one condition, one message, whichever page the user reaches first.
+
+**That state cannot be reached from local data.** Every parcel the DAL stub returns for CRN `1102838829` comes back from the local `land-grants-backend` seed with at least one action, so no `--parcel` value produces it. Hence the mock:
+
+```sh
+gt journey grasslands --mock-no-actions --headed    # or pick "Mock no eligible actions" in the TUI
+```
+
+It sets a `dev_mock_no_actions=1` cookie, which `MapSelectPageController` honours by treating every selected parcel as having no eligible actions. Because it is request-scoped it needs no restart and works on either land-grants stack. It is read through `isNoActionsMockEnabled()` (`src/server/dev-tools/mock-overrides.js`), which returns `false` whenever `devTools.enabled` is off — so the cookie is inert in a deployed environment.
+
+The run is _expected_ to stop on `/select-land-parcel`; the driver prints the error summary and exits non-zero, which is the check.
+
+To poke at it by hand, set the cookie in devtools and click Continue. It is a session cookie and nothing in the app clears it, so unset it when you're done or every later local run will show the error:
+
+```js
+document.cookie = 'dev_mock_no_actions=1' // on
+document.cookie = 'dev_mock_no_actions=; Max-Age=0; path=/' // off
+```
+
+The `gt journey --mock-no-actions` path needs no cleanup — it sets the cookie on a throwaway Playwright context that is discarded when the run ends.
 
 ### Adding a new journey
 

--- a/src/server/common/map/map-select-page.controller.js
+++ b/src/server/common/map/map-select-page.controller.js
@@ -1,6 +1,17 @@
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { withTaskContext } from '~/src/server/task-list/task-list.helper.js'
 import { getParcelIdsFromPayload } from '~/src/server/land-grants/utils/parcel-request.utils.js'
+import { fetchActionsForParcel } from '~/src/server/land-grants/services/land-grants.service.js'
+import { getLandGrantsUserContext } from '~/src/server/land-grants/services/land-grants-user-context.js'
+import { parseLandParcel } from '~/src/shared/format-parcel.js'
+import { log, error, LogCodes } from '~/src/server/common/helpers/logging/log.js'
+import { isNoActionsMockEnabled } from '~/src/server/dev-tools/mock-overrides.js'
+
+// Must match the no-eligible-actions copy in
+// src/server/land-grants/views/select-actions.html
+const NO_ELIGIBLE_ACTIONS_ERROR =
+  'There are no eligible actions for this parcel.<br>' +
+  'Change the parcel land cover or choose a different parcel to view eligible actions.'
 
 export default class MapSelectPageController extends withTaskContext(QuestionPageController) {
   viewName = 'map-select-parcel'
@@ -10,6 +21,9 @@ export default class MapSelectPageController extends withTaskContext(QuestionPag
 
   /** @type {boolean} */
   singleParcelSubmission = false
+
+  /** @type {string[]} */
+  enabledLandActions = []
 
   /**
    * @param {FormModel} model
@@ -26,6 +40,8 @@ export default class MapSelectPageController extends withTaskContext(QuestionPag
     // Grant-level config: when only a single land parcel is allowed in state, multiple selection is always disabled.
     this.singleParcelSubmission = metadata.singleParcelSubmission === true
     this.multiSelect = !this.singleParcelSubmission && Boolean(config.multiSelect)
+
+    this.enabledLandActions = Array.isArray(metadata.enabledLandActions) ? metadata.enabledLandActions : []
   }
 
   makeGetRouteHandler() {
@@ -63,6 +79,93 @@ export default class MapSelectPageController extends withTaskContext(QuestionPag
   }
 
   /**
+   * One parcel's eligible actions, or null when the fetch failed.
+   *
+   * Mirrors SelectActionsBasePageController.fetchActions: the catch is per
+   * parcel, so one failing fetch cannot decide the outcome for the rest of the
+   * selection.
+   * @param {FormRequestPayload} request
+   * @param {LandGrantsUserContext} userContext
+   * @param {{ sheetId: string, parcelId: string }} parcel
+   * @returns {Promise<ActionOption[] | null>}
+   */
+  async fetchActionsOrNull(request, userContext, { sheetId, parcelId }) {
+    try {
+      const { actions } = await fetchActionsForParcel(
+        { sheetId, parcelId, enabledLandActions: this.enabledLandActions },
+        userContext
+      )
+      return actions
+    } catch (err) {
+      const { message: errorMessage, status: statusCode } = /** @type {Error & {status?: number}} */ (err)
+      error(
+        LogCodes.LAND_GRANTS.FETCH_ACTIONS_ERROR,
+        { sbi: userContext.sbi, sheetId, parcelId, errorMessage, statusCode },
+        request
+      )
+      return null
+    }
+  }
+
+  /**
+   * The selected parcels that have no action the user could go on to choose, so
+   * that Continue can be rejected here rather than sending the user to the
+   * select-actions page only to be told to come back.
+   *
+   * Uses the flat fetchActionsForParcel, matching SelectActionsPageController. A
+   * journey pairing this map page with SelectGroupedActionsPageController would
+   * need fetchGroupedActionsForParcel, which filters further by group definition
+   * and caches under a different key prefix ('' vs 'flat:').
+   *
+   * Fails open per parcel: a parcel whose fetch failed is treated as eligible,
+   * so an outage lets the user through to the select-actions page (which has its
+   * own fetch-failure message) instead of being reported as "no actions".
+   * @param {FormRequestPayload} request
+   * @param {string[]} selectedParcelIds
+   * @returns {Promise<string[]>}
+   */
+  async findParcelsWithNoActions(request, selectedParcelIds) {
+    if (this.enabledLandActions.length === 0) {
+      return []
+    }
+
+    // Dev-tools escape hatch: the local seed gives every parcel at least one
+    // action, so this is the only way to see the error page locally.
+    if (isNoActionsMockEnabled(request)) {
+      return selectedParcelIds
+    }
+
+    let userContext
+    try {
+      userContext = getLandGrantsUserContext(request)
+    } catch (err) {
+      const { message: errorMessage, status: statusCode } = /** @type {Error & {status?: number}} */ (err)
+      error(
+        LogCodes.LAND_GRANTS.FETCH_ACTIONS_ERROR,
+        { sbi: request.auth?.credentials?.sbi, sheetId: '', parcelId: '', errorMessage, statusCode },
+        request
+      )
+      return []
+    }
+
+    const results = await Promise.all(
+      [...new Set(selectedParcelIds)].map(async (selectedParcelId) => {
+        const [sheetId = '', parcelId = ''] = parseLandParcel(selectedParcelId)
+        const actions = await this.fetchActionsOrNull(request, userContext, { sheetId, parcelId })
+        return { selectedParcelId, sheetId, parcelId, actions }
+      })
+    )
+
+    // A null means the fetch failed — only a resolved empty list is "no actions".
+    const ineligible = results.filter((result) => result.actions?.length === 0)
+    ineligible.forEach(({ sheetId, parcelId }) => {
+      log(LogCodes.LAND_GRANTS.NO_ACTIONS_FOUND, { sheetId, parcelId }, request)
+    })
+
+    return ineligible.map((result) => result.selectedParcelId)
+  }
+
+  /**
    * @param {FormRequestPayload} request
    * @param {FormContext} context
    * @param {FormResponseToolkit} h
@@ -78,8 +181,21 @@ export default class MapSelectPageController extends withTaskContext(QuestionPag
       return h.view(
         this.viewName,
         this.buildViewModel(request, context, {
-          selectedParcelIds: [],
           errors: [{ text: errorText, href: '#parcel-map' }]
+        })
+      )
+    }
+
+    const parcelsWithNoActions = await this.findParcelsWithNoActions(request, selectedParcelIds)
+    if (parcelsWithNoActions.length > 0) {
+      // State is deliberately left untouched: a rejected change must not destroy a
+      // previously completed selection and its actions. The map always re-renders
+      // unselected regardless, because parcel-select-page.js builds its inputs from
+      // map events only — there is no server-side re-hydration of the selection.
+      return h.view(
+        this.viewName,
+        this.buildViewModel(request, context, {
+          errors: [{ html: NO_ELIGIBLE_ACTIONS_ERROR, href: '#parcel-map' }]
         })
       )
     }
@@ -115,4 +231,6 @@ export default class MapSelectPageController extends withTaskContext(QuestionPag
  * @import { FormRequest, FormRequestPayload, FormContext, FormResponseToolkit, FormSubmissionState } from '@defra/forms-engine-plugin/types'
  * @import { FormModel } from '@defra/forms-engine-plugin/engine/models/index.js'
  * @import { PageQuestion as PageDef } from '@defra/forms-model'
+ * @import { ActionOption } from '~/src/server/land-grants/types/land-grants.client.d.js'
+ * @import { LandGrantsUserContext } from '~/src/server/land-grants/services/land-grants-user-context.js'
  */

--- a/src/server/common/map/map-select-page.controller.test.js
+++ b/src/server/common/map/map-select-page.controller.test.js
@@ -2,8 +2,16 @@
 import { vi } from 'vitest'
 import MapSelectPageController from './map-select-page.controller.js'
 import { setupControllerMocks } from '~/src/__mocks__/controller-mocks.js'
+import { fetchActionsForParcel } from '~/src/server/land-grants/services/land-grants.service.js'
+import { isNoActionsMockEnabled } from '~/src/server/dev-tools/mock-overrides.js'
+import { getLandGrantsUserContext } from '~/src/server/land-grants/services/land-grants-user-context.js'
+import { log, error, LogCodes } from '~/src/server/common/helpers/logging/log.js'
 
 const PAGE_PATH = '/select-land-parcel'
+
+const NO_ELIGIBLE_ACTIONS_ERROR =
+  'There are no eligible actions for this parcel.<br>' +
+  'Change the parcel land cover or choose a different parcel to view eligible actions.'
 
 function makePageDef(path = PAGE_PATH) {
   return { path }
@@ -21,6 +29,18 @@ vi.mock('~/src/server/task-list/task-list.helper.js', async (importOriginal) => 
   }
 })
 
+vi.mock('~/src/server/land-grants/services/land-grants.service.js', () => ({
+  fetchActionsForParcel: vi.fn()
+}))
+
+vi.mock('~/src/server/dev-tools/mock-overrides.js', () => ({
+  isNoActionsMockEnabled: vi.fn().mockReturnValue(false)
+}))
+
+vi.mock('~/src/server/land-grants/services/land-grants-user-context.js', () => ({
+  getLandGrantsUserContext: vi.fn().mockReturnValue({ defraIdToken: 'token', sbi: '123456789' })
+}))
+
 function makeController(config = {}, metadata = {}) {
   const controller = new MapSelectPageController(makeModel(config, metadata), makePageDef())
   setupControllerMocks(controller)
@@ -29,7 +49,7 @@ function makeController(config = {}, metadata = {}) {
 }
 
 function makeRequest(payload = {}, path = '/select-land-parcel') {
-  return { payload, path, query: {} }
+  return { payload, path, query: {}, auth: { credentials: { sbi: '123456789', token: 'token' } } }
 }
 
 function makeContext(state = {}) {
@@ -43,111 +63,242 @@ function makeH() {
   }
 }
 
+const expectNoActionsError = (h) =>
+  expect(h.view).toHaveBeenCalledWith(
+    'map-select-parcel',
+    expect.objectContaining({
+      errors: [{ html: NO_ELIGIBLE_ACTIONS_ERROR, href: '#parcel-map' }]
+    })
+  )
+
 describe('MapSelectPageController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isNoActionsMockEnabled.mockReturnValue(false)
+  })
+
   describe('constructor', () => {
-    it('defaults multiSelect to false', () => {
-      const controller = new MapSelectPageController(makeModel(), makePageDef())
-      expect(controller.multiSelect).toBe(false)
+    it.each([
+      ['defaults to false with no page config', {}, {}, false],
+      ['is true when the page config sets it', { multiSelect: true }, {}, true],
+      ['is false when the page config unsets it', { multiSelect: false }, {}, false],
+      [
+        'is forced false by grant-level singleParcelSubmission',
+        { multiSelect: true },
+        { singleParcelSubmission: true },
+        false
+      ],
+      ['stays true when singleParcelSubmission is absent', { multiSelect: true }, {}, true]
+    ])('multiSelect %s', (_name, config, metadata, expected) => {
+      const controller = new MapSelectPageController(makeModel(config, metadata), makePageDef())
+      expect(controller.multiSelect).toBe(expected)
     })
 
-    it('sets multiSelect true from model.def.metadata.pageConfig', () => {
-      const controller = new MapSelectPageController(makeModel({ multiSelect: true }), makePageDef())
-      expect(controller.multiSelect).toBe(true)
-    })
-
-    it('sets multiSelect false when config.multiSelect is falsy', () => {
-      const controller = new MapSelectPageController(makeModel({ multiSelect: false }), makePageDef())
-      expect(controller.multiSelect).toBe(false)
-    })
-
-    it('forces multiSelect false when grant-level singleParcelSubmission is true', () => {
-      const singleParcelModel = makeModel({ multiSelect: true }, { singleParcelSubmission: true })
-      const controller = new MapSelectPageController(singleParcelModel, makePageDef({ multiSelect: true }))
-      expect(controller.multiSelect).toBe(false)
-    })
-
-    it('keeps multiSelect true when singleParcelSubmission is not set', () => {
-      const controller = new MapSelectPageController(makeModel({ multiSelect: true }), makePageDef())
-      expect(controller.multiSelect).toBe(true)
+    it.each([
+      ['defaults to [] when metadata omits it', {}, []],
+      ['is ignored when metadata sets a non-array', { enabledLandActions: 'CLIG3' }, []],
+      ['is taken from metadata', { enabledLandActions: ['CLIG3'] }, ['CLIG3']]
+    ])('enabledLandActions %s', (_name, metadata, expected) => {
+      const controller = new MapSelectPageController(makeModel({}, metadata), makePageDef())
+      expect(controller.enabledLandActions).toEqual(expected)
     })
   })
 
   describe('handleGet', () => {
-    it('renders the map view with multiSelect and formAction', async () => {
-      const controller = makeController()
-      const request = makeRequest({}, '/my-path')
-      const context = makeContext()
+    it.each([
+      ['defaults multiSelect false and sets formAction from the path', {}, { multiSelect: false }],
+      ['passes multiSelect true when the page config sets it', { multiSelect: true }, { multiSelect: true }]
+    ])('renders the map view — %s', (_name, config, expected) => {
       const h = makeH()
 
-      await controller.handleGet(request, context, h)
+      makeController(config).handleGet(makeRequest({}, '/my-path'), makeContext(), h)
 
       expect(h.view).toHaveBeenCalledWith(
         'map-select-parcel',
-        expect.objectContaining({
-          multiSelect: false,
-          formAction: '/my-path'
-        })
-      )
-    })
-
-    it('passes multiSelect: true when configured', async () => {
-      const controller = makeController({ multiSelect: true })
-      const h = makeH()
-
-      await controller.handleGet(makeRequest(), makeContext(), h)
-
-      expect(h.view).toHaveBeenCalledWith(
-        'map-select-parcel',
-        expect.objectContaining({
-          multiSelect: true
-        })
+        expect.objectContaining({ ...expected, formAction: '/my-path' })
       )
     })
   })
 
   describe('handlePost — validation', () => {
-    it('re-renders with error when no parcels submitted (single-select)', async () => {
-      const controller = makeController()
+    it.each([
+      ['no landParcels key', {}, {}, 'Select a land parcel on the map before you continue.'],
+      ['an empty string', { landParcels: '' }, {}, 'Select a land parcel on the map before you continue.'],
+      ['an empty array', { landParcels: [] }, {}, 'Select a land parcel on the map before you continue.'],
+      [
+        'nothing selected in multi-select mode',
+        {},
+        { multiSelect: true },
+        'Select at least one land parcel on the map before you continue.'
+      ]
+    ])('re-renders with an error given %s', async (_name, payload, config, errorText) => {
+      const controller = makeController(config)
       const h = makeH()
 
-      await controller.handlePost(makeRequest({}), makeContext(), h)
+      await controller.handlePost(makeRequest(payload), makeContext(), h)
 
       expect(h.view).toHaveBeenCalledWith(
         'map-select-parcel',
-        expect.objectContaining({
-          errors: [{ text: 'Select a land parcel on the map before you continue.', href: '#parcel-map' }]
-        })
+        expect.objectContaining({ errors: [{ text: errorText, href: '#parcel-map' }] })
       )
-      expect(controller.setState).not.toHaveBeenCalled()
-    })
-
-    it('re-renders with multi-select error message when no parcels submitted', async () => {
-      const controller = makeController({ multiSelect: true })
-      const h = makeH()
-
-      await controller.handlePost(makeRequest({}), makeContext(), h)
-
-      expect(h.view).toHaveBeenCalledWith(
-        'map-select-parcel',
-        expect.objectContaining({
-          errors: [{ text: 'Select at least one land parcel on the map before you continue.', href: '#parcel-map' }]
-        })
-      )
-    })
-
-    it('re-renders when landParcels is empty string', async () => {
-      const controller = makeController()
-      const h = makeH()
-
-      await controller.handlePost(makeRequest({ landParcels: '' }), makeContext(), h)
-
-      expect(h.view).toHaveBeenCalled()
       expect(controller.setState).not.toHaveBeenCalled()
     })
   })
 
+  describe('handlePost — action eligibility', () => {
+    const withActions = { enabledLandActions: ['CLIG3', 'CSAM3'] }
+
+    it('rejects every selected parcel without calling the API when the dev mock is on', async () => {
+      isNoActionsMockEnabled.mockReturnValue(true)
+      const controller = makeController({}, withActions)
+      const h = makeH()
+
+      await controller.handlePost(makeRequest({ landParcels: 'SD7148-9160' }), makeContext(), h)
+
+      expect(fetchActionsForParcel).not.toHaveBeenCalled()
+      expectNoActionsError(h)
+      expect(controller.setState).not.toHaveBeenCalled()
+    })
+
+    it('skips the check entirely for grants without enabledLandActions, dev mock or not', async () => {
+      isNoActionsMockEnabled.mockReturnValue(true)
+      const controller = makeController()
+      const h = makeH()
+
+      await controller.handlePost(makeRequest({ landParcels: 'SD7148-9160' }), makeContext(), h)
+
+      expect(fetchActionsForParcel).not.toHaveBeenCalled()
+      expect(controller.setState).toHaveBeenCalled()
+    })
+
+    it('re-renders with the no-eligible-actions error, and logs it, when the parcel has none', async () => {
+      fetchActionsForParcel.mockResolvedValue({ actions: [] })
+      const controller = makeController({}, withActions)
+      const h = makeH()
+
+      await controller.handlePost(makeRequest({ landParcels: 'SD7148-9160' }), makeContext(), h)
+
+      expect(fetchActionsForParcel).toHaveBeenCalledWith(
+        { sheetId: 'SD7148', parcelId: '9160', enabledLandActions: ['CLIG3', 'CSAM3'] },
+        expect.anything()
+      )
+      expect(log).toHaveBeenCalledWith(
+        LogCodes.LAND_GRANTS.NO_ACTIONS_FOUND,
+        { sheetId: 'SD7148', parcelId: '9160' },
+        expect.anything()
+      )
+      expectNoActionsError(h)
+      expect(controller.setState).not.toHaveBeenCalled()
+      expect(controller.proceed).not.toHaveBeenCalled()
+    })
+
+    it('proceeds when the parcel has eligible actions', async () => {
+      fetchActionsForParcel.mockResolvedValue({ actions: [{ code: 'CLIG3' }] })
+      const controller = makeController({}, withActions)
+      const h = makeH()
+
+      await controller.handlePost(makeRequest({ landParcels: 'SD7148-9160' }), makeContext(), h)
+
+      expect(controller.setState).toHaveBeenCalled()
+      expect(controller.proceed).toHaveBeenCalledWith(expect.anything(), h, '/next-path?parcelId=SD7148-9160')
+    })
+
+    it('fails open, logging the failure, when the actions fetch throws', async () => {
+      fetchActionsForParcel.mockRejectedValue(new Error('Land Grants API unavailable'))
+      const controller = makeController({}, withActions)
+      const h = makeH()
+
+      await controller.handlePost(makeRequest({ landParcels: 'SD7148-9160' }), makeContext(), h)
+
+      expect(error).toHaveBeenCalledWith(
+        LogCodes.LAND_GRANTS.FETCH_ACTIONS_ERROR,
+        expect.objectContaining({
+          sbi: '123456789',
+          sheetId: 'SD7148',
+          parcelId: '9160',
+          errorMessage: 'Land Grants API unavailable'
+        }),
+        expect.anything()
+      )
+      expect(controller.setState).toHaveBeenCalled()
+      expect(controller.proceed).toHaveBeenCalled()
+    })
+
+    it('errors when any one of several multi-selected parcels has no actions', async () => {
+      fetchActionsForParcel
+        .mockResolvedValueOnce({ actions: [{ code: 'CLIG3' }] })
+        .mockResolvedValueOnce({ actions: [] })
+      const controller = makeController({ multiSelect: true }, withActions)
+      const h = makeH()
+
+      await controller.handlePost(makeRequest({ landParcels: ['SD7148-9160', 'SD7148-9161'] }), makeContext(), h)
+
+      expectNoActionsError(h)
+      expect(controller.setState).not.toHaveBeenCalled()
+    })
+
+    it('still rejects a parcel with no actions when a different parcel fetch fails', async () => {
+      fetchActionsForParcel
+        .mockRejectedValueOnce(new Error('Land Grants API unavailable'))
+        .mockResolvedValueOnce({ actions: [] })
+      const controller = makeController({ multiSelect: true }, withActions)
+      const h = makeH()
+
+      await controller.handlePost(makeRequest({ landParcels: ['SD7148-9160', 'SD7148-9161'] }), makeContext(), h)
+
+      // The failure is logged against its own parcel, not the whole selection,
+      // and it does not blanket-pass the parcel that genuinely has no actions.
+      expect(error).toHaveBeenCalledWith(
+        LogCodes.LAND_GRANTS.FETCH_ACTIONS_ERROR,
+        expect.objectContaining({ sheetId: 'SD7148', parcelId: '9160' }),
+        expect.anything()
+      )
+      expect(log).toHaveBeenCalledWith(
+        LogCodes.LAND_GRANTS.NO_ACTIONS_FOUND,
+        { sheetId: 'SD7148', parcelId: '9161' },
+        expect.anything()
+      )
+      expectNoActionsError(h)
+      expect(controller.setState).not.toHaveBeenCalled()
+    })
+
+    it('fails open, without calling the API, when the user context is unavailable', async () => {
+      getLandGrantsUserContext.mockImplementationOnce(() => {
+        throw new Error('Missing SBI in Land Grants user context')
+      })
+      const controller = makeController({}, withActions)
+      const h = makeH()
+
+      await controller.handlePost(makeRequest({ landParcels: 'SD7148-9160' }), makeContext(), h)
+
+      expect(error).toHaveBeenCalledWith(
+        LogCodes.LAND_GRANTS.FETCH_ACTIONS_ERROR,
+        expect.objectContaining({
+          sbi: '123456789',
+          sheetId: '',
+          parcelId: '',
+          errorMessage: 'Missing SBI in Land Grants user context'
+        }),
+        expect.anything()
+      )
+      expect(fetchActionsForParcel).not.toHaveBeenCalled()
+      expect(controller.setState).toHaveBeenCalled()
+    })
+
+    it('fetches each parcel once when the same parcel is submitted twice', async () => {
+      fetchActionsForParcel.mockResolvedValue({ actions: [{ code: 'CLIG3' }] })
+      const controller = makeController({ multiSelect: true }, withActions)
+      const h = makeH()
+
+      await controller.handlePost(makeRequest({ landParcels: ['SD7148-9160', 'SD7148-9160'] }), makeContext(), h)
+
+      expect(fetchActionsForParcel).toHaveBeenCalledTimes(1)
+      expect(controller.setState).toHaveBeenCalled()
+    })
+  })
+
   describe('handlePost — single-select success', () => {
-    it('saves selectedParcelId, selectedParcelIds, selectedParcelsDisplay to state', async () => {
+    it('saves the parcel to state and appends ?parcelId to the redirect', async () => {
       const controller = makeController()
       const h = makeH()
 
@@ -161,26 +312,16 @@ describe('MapSelectPageController', () => {
           selectedParcelsDisplay: 'SD7148-9160'
         })
       )
-    })
-
-    it('appends ?parcelId to the redirect URL', async () => {
-      const controller = makeController()
-      controller.getNextPath = vi.fn().mockReturnValue('/next')
-      const h = makeH()
-
-      await controller.handlePost(makeRequest({ landParcels: 'SD7148-9160' }), makeContext(), h)
-
-      expect(controller.proceed).toHaveBeenCalledWith(expect.anything(), h, '/next?parcelId=SD7148-9160')
+      expect(controller.proceed).toHaveBeenCalledWith(expect.anything(), h, '/next-path?parcelId=SD7148-9160')
     })
 
     it('URL-encodes the parcel ID in the redirect', async () => {
       const controller = makeController()
-      controller.getNextPath = vi.fn().mockReturnValue('/next')
       const h = makeH()
 
       await controller.handlePost(makeRequest({ landParcels: 'SD 71/48' }), makeContext(), h)
 
-      expect(controller.proceed).toHaveBeenCalledWith(expect.anything(), h, '/next?parcelId=SD%2071%2F48')
+      expect(controller.proceed).toHaveBeenCalledWith(expect.anything(), h, '/next-path?parcelId=SD%2071%2F48')
     })
 
     it('handles array payload with one item', async () => {
@@ -197,40 +338,32 @@ describe('MapSelectPageController', () => {
   })
 
   describe('handlePost — single-parcel-submission', () => {
+    const existingParcels = { landParcels: { 'SD0000-0001': { size: {}, actionsObj: {} } } }
+
     it('clears existing landParcels object when a parcel is selected', async () => {
       const controller = makeController({}, { singleParcelSubmission: true })
       const h = makeH()
-      const context = makeContext({ landParcels: { 'SD0000-0001': { size: {}, actionsObj: {} } } })
 
-      await controller.handlePost(makeRequest({ landParcels: 'SD7148-9160' }), context, h)
+      await controller.handlePost(makeRequest({ landParcels: 'SD7148-9160' }), makeContext(existingParcels), h)
 
       expect(controller.setState).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({
-          selectedParcelId: 'SD7148-9160',
-          landParcels: {}
-        })
+        expect.objectContaining({ selectedParcelId: 'SD7148-9160', landParcels: {} })
       )
     })
 
     it('does not clear landParcels when singleParcelSubmission is not set', async () => {
       const controller = makeController()
       const h = makeH()
-      const context = makeContext({ landParcels: { 'SD0000-0001': { size: {}, actionsObj: {} } } })
 
-      await controller.handlePost(makeRequest({ landParcels: 'SD7148-9160' }), context, h)
+      await controller.handlePost(makeRequest({ landParcels: 'SD7148-9160' }), makeContext(existingParcels), h)
 
-      expect(controller.setState).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          landParcels: { 'SD0000-0001': { size: {}, actionsObj: {} } }
-        })
-      )
+      expect(controller.setState).toHaveBeenCalledWith(expect.anything(), expect.objectContaining(existingParcels))
     })
   })
 
   describe('handlePost — multi-select success', () => {
-    it('saves selectedParcelIds and selectedParcelsDisplay, no selectedParcelId', async () => {
+    it('saves every parcel, omits selectedParcelId, and does not append ?parcelId', async () => {
       const controller = makeController({ multiSelect: true })
       const h = makeH()
 
@@ -247,16 +380,7 @@ describe('MapSelectPageController', () => {
         expect.anything(),
         expect.not.objectContaining({ selectedParcelId: expect.anything() })
       )
-    })
-
-    it('does not append parcelId to redirect URL', async () => {
-      const controller = makeController({ multiSelect: true })
-      controller.getNextPath = vi.fn().mockReturnValue('/next')
-      const h = makeH()
-
-      await controller.handlePost(makeRequest({ landParcels: ['SD7148-9160', 'SD7148-9161'] }), makeContext(), h)
-
-      expect(controller.proceed).toHaveBeenCalledWith(expect.anything(), h, '/next')
+      expect(controller.proceed).toHaveBeenCalledWith(expect.anything(), h, '/next-path')
     })
 
     it('filters non-string values from array payload', async () => {
@@ -271,13 +395,14 @@ describe('MapSelectPageController', () => {
 
       expect(controller.setState).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({
-          selectedParcelIds: ['SD7148-9160', 'SD7148-9161']
-        })
+        expect.objectContaining({ selectedParcelIds: ['SD7148-9160', 'SD7148-9161'] })
       )
     })
   })
 
+  // These wrappers override base-class stubs that return a canned view/redirect,
+  // so without this coverage the overrides could be deleted and every other test
+  // here would still pass.
   describe('route handler wrappers', () => {
     it('makeGetRouteHandler delegates to handleGet', async () => {
       const controller = makeController()

--- a/src/server/common/map/views/map-select-parcel.html
+++ b/src/server/common/map/views/map-select-parcel.html
@@ -44,8 +44,12 @@
 
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds-from-desktop">
+            {# tabindex makes the element a focus target: the error-summary links and
+               the "Change" link below all point at #parcel-map, and govuk-frontend
+               cannot move focus to a custom element without it. #}
             <parcel-map
               id="parcel-map"
+              tabindex="-1"
               multi-select="{{ 'true' if multiSelect else 'false' }}"
               aria-label="Land parcel selection map"
               style="display:block;width:100%;height:500px;position:relative"

--- a/src/server/dev-tools/dev-tools-enabled.js
+++ b/src/server/dev-tools/dev-tools-enabled.js
@@ -1,0 +1,14 @@
+import { config } from '~/src/config/config.js'
+
+/**
+ * Whether dev-only behaviour may run. `DEV_TOOLS_ENABLED` can be set
+ * independently of `NODE_ENV`, keeps dev tooling out of a deployed environment.
+ * @returns {boolean}
+ */
+export function isDevToolsEnabled() {
+  return (
+    config.get('devTools.enabled') === true &&
+    process.env.NODE_ENV !== 'production' &&
+    process.env.ENVIRONMENT === 'local'
+  )
+}

--- a/src/server/dev-tools/dev-tools-enabled.test.js
+++ b/src/server/dev-tools/dev-tools-enabled.test.js
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import { vi } from 'vitest'
+import { isDevToolsEnabled } from './dev-tools-enabled.js'
+import { config } from '~/src/config/config.js'
+
+vi.mock('~/src/config/config.js', () => ({ config: { get: vi.fn() } }))
+
+describe('isDevToolsEnabled', () => {
+  const originalEnv = { NODE_ENV: process.env.NODE_ENV, ENVIRONMENT: process.env.ENVIRONMENT }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    config.get.mockReturnValue(true)
+    process.env.NODE_ENV = 'development'
+    process.env.ENVIRONMENT = 'local'
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv.NODE_ENV
+    process.env.ENVIRONMENT = originalEnv.ENVIRONMENT
+  })
+
+  it('is true only when the config flag and both environment checks agree', () => {
+    expect(isDevToolsEnabled()).toBe(true)
+    expect(config.get).toHaveBeenCalledWith('devTools.enabled')
+  })
+
+  it.each([
+    ['the config flag is off', () => config.get.mockReturnValue(false)],
+    ['the config flag is not strictly true', () => config.get.mockReturnValue('yes')],
+    ['NODE_ENV is production', () => (process.env.NODE_ENV = 'production')],
+    ['ENVIRONMENT is not local', () => (process.env.ENVIRONMENT = 'dev')],
+    ['ENVIRONMENT is unset', () => delete process.env.ENVIRONMENT]
+  ])('is false when %s', (_name, arrange) => {
+    arrange()
+
+    expect(isDevToolsEnabled()).toBe(false)
+  })
+})

--- a/src/server/dev-tools/journey-runner/runner-engine.js
+++ b/src/server/dev-tools/journey-runner/runner-engine.js
@@ -12,7 +12,7 @@
  * until we reach the configured stop point or run out of steps.
  *
  * Public API exposed on `globalThis`:
- *   - `runJourney(stopAtPageOrSection?)` - start a run.
+ *   - `runJourney(stopAtPageOrSection?, options?)` - start a run.
  *   - `stopJourney()` - cancel an in-flight run.
  */
 ;(function () {
@@ -36,6 +36,13 @@
   const PARCELS_FIELD_NAME = 'landParcels'
   const WAIT_TIMEOUT_MS = 10000
   const WAIT_POLL_INTERVAL_MS = 100
+
+  /**
+   * Per-run overrides from `runJourney(stop, options)`, rehydrated from
+   * sessionStorage on every page load so they survive the journey's navigations.
+   * @type {{parcel?: string}}
+   */
+  let runOptions = {}
 
   // ---------------------------------------------------------------------------
   // DOM helpers
@@ -299,6 +306,11 @@
      * the API the map itself loads and writes those same inputs, so the POST
      * payload is identical to a human's without waiting on (or depending on)
      * the map rendering.
+     *
+     * A run-level parcel override (`runJourney(stop, { parcel })`, i.e.
+     * `gt journey <slug> --parcel <ref>`) wins over the step's own `value`, so a
+     * journey can be pointed at a specific parcel — e.g. one with no eligible
+     * actions — without editing its definition file.
      * @param {JourneyStep} step
      * @returns {Promise<void>}
      */
@@ -319,12 +331,14 @@
         throw new Error('No land parcels returned for this account')
       }
 
+      const requested = runOptions.parcel ?? step.value
+
       let chosen
-      if (step.value) {
-        if (!available.includes(step.value)) {
-          throw new Error(`Parcel "${step.value}" not available (have: ${available.join(', ')})`)
+      if (requested) {
+        if (!available.includes(requested)) {
+          throw new Error(`Parcel "${requested}" not available (have: ${available.join(', ')})`)
         }
-        chosen = [step.value]
+        chosen = [requested]
       } else if (step.selectAll) {
         chosen = available
       } else {
@@ -564,6 +578,8 @@
 
     /** @type {JourneyState} */
     const state = JSON.parse(raw)
+    // Rehydrate per-run overrides before any handler runs
+    runOptions = state.options ?? {}
     const idx = findCurrentStep(state.lastCompleted ?? -1, state.section)
 
     if (idx === -1) {
@@ -621,9 +637,12 @@
    *   - **Number**: stop when arriving at that step (1-indexed).
    *   - **String**: only run steps whose `section` tag matches.
    *   - **Omitted**: run to the end.
+   * @param {{parcel?: string}} [options]
+   *   - `parcel`: parcel reference (e.g. `SD6843-7039`) the `mapParcel` step
+   *     should select, overriding that step's own `value`.
    * @returns {void}
    */
-  globalThis.runJourney = function (stopAtPageOrSection) {
+  globalThis.runJourney = function (stopAtPageOrSection, options) {
     /** @type {JourneyState} */
     let state
     if (typeof stopAtPageOrSection === 'string') {
@@ -637,6 +656,10 @@
     } else {
       state = { stopAt: stopAtPageOrSection || steps.length + 1 }
       console.log(`${LOG_PREFIX} Starting journey, will stop at step ${state.stopAt}`)
+    }
+    if (options?.parcel) {
+      state.options = { parcel: options.parcel }
+      console.log(`${LOG_PREFIX} Land parcel override: ${options.parcel}`)
     }
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state))
     processCurrentPage()
@@ -681,6 +704,7 @@
  * @property {number} stopAt               Stop when reaching this 1-indexed step.
  * @property {string} [section]            Restrict run to steps with this section tag.
  * @property {number} [lastCompleted]      Index of the last completed step (for resume across page loads).
+ * @property {{parcel?: string}} [options] Per-run overrides from `runJourney`'s second argument.
  */
 
 /**

--- a/src/server/dev-tools/mock-overrides.js
+++ b/src/server/dev-tools/mock-overrides.js
@@ -1,0 +1,19 @@
+import { isDevToolsEnabled } from '~/src/server/dev-tools/dev-tools-enabled.js'
+
+/**
+ * Make the app pretend the selected land parcel has no eligible actions.
+ */
+export const NO_ACTIONS_MOCK_COOKIE = 'dev_mock_no_actions'
+
+/**
+ * Whether this request should treat every selected land parcel as having no
+ * eligible actions.
+ * @param {{ state?: Record<string, unknown> }} [request]
+ * @returns {boolean}
+ */
+export function isNoActionsMockEnabled(request) {
+  if (!isDevToolsEnabled()) {
+    return false
+  }
+  return request?.state?.[NO_ACTIONS_MOCK_COOKIE] === '1'
+}

--- a/src/server/dev-tools/mock-overrides.test.js
+++ b/src/server/dev-tools/mock-overrides.test.js
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import { vi } from 'vitest'
+import { isNoActionsMockEnabled, NO_ACTIONS_MOCK_COOKIE } from './mock-overrides.js'
+import { isDevToolsEnabled } from '~/src/server/dev-tools/dev-tools-enabled.js'
+
+vi.mock('~/src/server/dev-tools/dev-tools-enabled.js', () => ({ isDevToolsEnabled: vi.fn() }))
+
+describe('isNoActionsMockEnabled', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isDevToolsEnabled.mockReturnValue(true)
+  })
+
+  it('is true when dev tools are enabled and the cookie is set', () => {
+    expect(isNoActionsMockEnabled({ state: { [NO_ACTIONS_MOCK_COOKIE]: '1' } })).toBe(true)
+  })
+
+  it('is false when dev tools are disabled, even with the cookie set', () => {
+    isDevToolsEnabled.mockReturnValue(false)
+
+    expect(isNoActionsMockEnabled({ state: { [NO_ACTIONS_MOCK_COOKIE]: '1' } })).toBe(false)
+  })
+
+  it('is false when the cookie is absent, any other value, or there is no request', () => {
+    expect(isNoActionsMockEnabled({ state: {} })).toBe(false)
+    expect(isNoActionsMockEnabled({ state: { [NO_ACTIONS_MOCK_COOKIE]: '0' } })).toBe(false)
+    expect(isNoActionsMockEnabled({})).toBe(false)
+    expect(isNoActionsMockEnabled()).toBe(false)
+  })
+})

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -6,6 +6,7 @@ import { health } from '~/src/server/health/index.js'
 import { home } from '~/src/server/home/index.js'
 import { agreements } from '~/src/server/agreements/index.js'
 import { devTools } from '~/src/server/dev-tools/index.js'
+import { isDevToolsEnabled } from '~/src/server/dev-tools/dev-tools-enabled.js'
 import { journeyRunnerPlugin } from '~/src/server/dev-tools/journey-runner/journey-runner-plugin.js'
 import { clearApplicationState } from './dev-tools/clear-application-state.js'
 import { cookies } from '~/src/server/cookies/index.js'
@@ -37,11 +38,7 @@ export const router = {
       await server.register([mapPlugin, landGrantsActionsPlugin])
 
       // Development tools (only available in development mode)
-      if (
-        config.get('devTools.enabled') &&
-        process.env.NODE_ENV !== 'production' &&
-        process.env.ENVIRONMENT === 'local'
-      ) {
+      if (isDevToolsEnabled()) {
         await server.register([devTools, journeyRunnerPlugin])
       }
 

--- a/tools/grants-tui.js
+++ b/tools/grants-tui.js
@@ -800,6 +800,8 @@ ${BOLD}Other flags:${RESET_COLOR}
 ${BOLD}Journey flags (for 'journey'):${RESET_COLOR}
   --crn <crn>      DefraID CRN to sign in as (default: the journey's allowlisted CRN, e.g. woodland → 1100943757)
   --stop <n|sect>  Stop before step <n> (1-indexed) or run only section <sect>
+  --parcel <ref>   Land parcel the map step selects, e.g. SD6843-7039 (overrides the step's own value)
+  --mock-no-actions  Make land parcels report no eligible actions (shows the map page's error)
   --headed         Watch it run in your installed Google Chrome (headless uses bundled Chromium)
   --clear          Flush saved application state first (so --stop starts at step 1)
   --base-url <url> App base URL (auto: https://localhost:4000 on --ha, else http://localhost:3000)
@@ -827,6 +829,8 @@ ${BOLD}Examples:${RESET_COLOR}
   gt test acceptance                 # docker-based acceptance journeys
   gt journey woodland                # walk the woodland journey headlessly
   gt journey example-grant-with-auth --stop 8 --headed   # watch it, stop before step 8
+  gt journey grasslands --parcel SD6843-7039             # drive the map step to a specific parcel
+  gt journey grasslands --mock-no-actions --headed       # see the "no actions available" error on the map page
   gt sonar                           # local SonarQube scan of src/
   gt sonar --changed                 # scope scan to src files changed vs main (approx. CI PR view)
   gt sonar --down                    # stop the local SonarQube server
@@ -879,6 +883,8 @@ async function main() {
       '--changed',
       '--crn',
       '--stop',
+      '--parcel',
+      '--mock-no-actions',
       '--headed',
       '--clear',
       '--base-url',
@@ -887,7 +893,7 @@ async function main() {
     ]
     // Flags that consume the following positional as their value — so it isn't
     // mistaken for an unknown command.
-    const valueFlagIdxs = ['--scale', '--crn', '--stop', '--base-url']
+    const valueFlagIdxs = ['--scale', '--crn', '--stop', '--parcel', '--base-url']
       .map((f) => argv.indexOf(f))
       .filter((i) => i !== -1)
       .map((i) => i + 1)
@@ -1000,6 +1006,8 @@ async function main() {
     const opts = {
       crn: valueOf('--crn'),
       stop: valueOf('--stop'),
+      parcel: valueOf('--parcel'),
+      mockNoActions: argv.includes('--mock-no-actions'),
       baseUrl,
       headed: argv.includes('--headed'),
       clear: argv.includes('--clear'),
@@ -1455,6 +1463,28 @@ async function main() {
         }
       }
 
+      // Offer the land-parcel mock before the stop-page question, so a run can be
+      // pointed at the "no eligible actions" path. The local seed gives every
+      // parcel at least one action, so this is the only way to reach that page.
+      // Only offered for journeys that actually have a map step.
+      let mockNoActions = false
+      if (journeySteps(chosen).some((s) => s.type === 'mapParcel')) {
+        const mockItems = [
+          { key: 'off', label: 'API Data', description: 'Use whatever actions the land-grants API returns' },
+          {
+            key: 'no-actions',
+            label: 'Mock no eligible actions',
+            description: 'Land parcels report no actions — shows the error on the map page'
+          }
+        ]
+        const pickedMock = await radioMenu(mockItems, `Land parcel actions for '${chosen}'?`, { hint: SELECT_HINT })
+        if (pickedMock === '__quit__') {
+          statusLine = ''
+          continue
+        }
+        mockNoActions = pickedMock === 'no-actions'
+      }
+
       // Headed only: let the user stop the browser on a chosen page. Lists every
       // page in the journey; picking one passes it as --stop so the run halts
       // there (on the page, before filling it) for inspection.
@@ -1483,6 +1513,7 @@ async function main() {
         {
           crn,
           stop,
+          mockNoActions,
           baseUrl: journeyBaseUrl(),
           headed: mode === 'headed',
           clear: clearChoice === 'clear',

--- a/tools/grants-tui/journey.js
+++ b/tools/grants-tui/journey.js
@@ -130,7 +130,7 @@ export function listJourneys() {
  * Read and parse a journey's step definition file. Returns [] if the file is
  * missing or unparseable — the single source of truth for the readers below.
  * @param {string} slug  grant URL slug
- * @returns {{name?: string, slug: string}[]}
+ * @returns {{name?: string, slug: string, type?: string}[]}
  */
 function loadJourney(slug) {
   try {
@@ -153,12 +153,13 @@ export function firstStepSlug(slug) {
 
 /**
  * The ordered steps of a journey, for building a "stop at page" picker. Each
- * entry's 1-based position is the number `runJourney`/`--stop` expects.
+ * entry's 1-based position is the number `runJourney`/`--stop` expects. `type` is
+ * carried through so callers can tell whether a journey has, say, a map step.
  * @param {string} slug
- * @returns {{name: string, slug: string}[]}
+ * @returns {{name: string, slug: string, type?: string}[]}
  */
 export function journeySteps(slug) {
-  return loadJourney(slug).map((s) => ({ name: s.name ?? s.slug, slug: s.slug }))
+  return loadJourney(slug).map((s) => ({ name: s.name ?? s.slug, slug: s.slug, type: s.type }))
 }
 
 /**
@@ -166,7 +167,7 @@ export function journeySteps(slug) {
  * (`acceptance/journey-cli.js`). Streams the driver's output and returns its
  * exit code (0 = journey completed).
  * @param {string} slug  grant URL slug with a matching journeys/<slug>.json
- * @param {{crn?: string, stop?: string, headed?: boolean, clear?: boolean, acknowledged?: boolean, baseUrl?: string, skipInstall?: boolean}} [opts]
+ * @param {{crn?: string, stop?: string, parcel?: string, mockNoActions?: boolean, headed?: boolean, clear?: boolean, acknowledged?: boolean, baseUrl?: string, skipInstall?: boolean}} [opts]
  * @param {boolean} [dryRun]  print the command without running it
  * @returns {number}  child exit code
  */
@@ -214,6 +215,8 @@ export function cmdJourney(slug, opts = {}, dryRun = false) {
   if (startPage && startPage !== 'start') driverArgs.push('--start', startPage)
   driverArgs.push('--crn', crn)
   if (opts.stop) driverArgs.push('--stop', opts.stop)
+  if (opts.parcel) driverArgs.push('--parcel', opts.parcel)
+  if (opts.mockNoActions) driverArgs.push('--mock-no-actions')
   if (opts.headed) driverArgs.push('--headed')
   if (opts.clear) driverArgs.push('--clear')
   if (opts.baseUrl) driverArgs.push('--base-url', opts.baseUrl)


### PR DESCRIPTION
The map page now checks the selected land parcel has at least one eligible action before allowing Continue, rejecting it in place rather than sending the user on to the select-actions page. The check runs per parcel so one failed API call cannot excuse the rest of the selection, and reuses the wording already shown by the select-actions page. Adds dev tooling to reach the state locally — a request-scoped `dev_mock_no_actions` cookie behind `isDevToolsEnabled()`, plus `--parcel` and `--mock-no-actions` flags on the journey runner.