### PR TITLE
Adopt the parcels API availability and inputRequired contract

### DIFF
--- a/mockserver/expectations.json
+++ b/mockserver/expectations.json
@@ -188,7 +188,7 @@
             "actions": [
               {
                 "code": "TEST1",
-                "availableArea": {
+                "availability": {
                   "value": 7.0,
                   "unit": "ha"
                 },
@@ -197,7 +197,7 @@
               },
               {
                 "code": "TEST2",
-                "availableArea": {
+                "availability": {
                   "value": 8.5,
                   "unit": "ha"
                 },
@@ -206,7 +206,7 @@
               },
               {
                 "code": "CLIG3",
-                "availableArea": {
+                "availability": {
                   "value": 9.0,
                   "unit": "ha"
                 },
@@ -215,7 +215,7 @@
               },
               {
                 "code": "CSAM3",
-                "availableArea": {
+                "availability": {
                   "value": 6.25,
                   "unit": "ha"
                 },
@@ -224,12 +224,22 @@
               },
               {
                 "code": "SCR2",
-                "availableArea": {
+                "availability": {
                   "value": 4.5,
                   "unit": "ha"
                 },
                 "ratePerUnitGbp": 130.0,
                 "description": "Manage grassland with low nutrient inputs"
+              },
+              {
+                "code": "SCR3",
+                "availability": {
+                  "value": null,
+                  "unit": "ha"
+                },
+                "inputRequired": true,
+                "ratePerUnitGbp": 95.0,
+                "description": "Manage grassland with no availability restriction"
               }
             ]
           }

--- a/mockserver/expectations.json
+++ b/mockserver/expectations.json
@@ -235,9 +235,9 @@
                 "code": "SCR3",
                 "availability": {
                   "value": null,
-                  "unit": "ha"
+                  "unit": "ha",
+                  "type": "partial"
                 },
-                "inputRequired": true,
                 "ratePerUnitGbp": 95.0,
                 "description": "Manage grassland with no availability restriction"
               }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23296,9 +23296,9 @@
       "license": "MIT"
     },
     "node_modules/liquidjs": {
-      "version": "10.27.1",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.1.tgz",
-      "integrity": "sha512-ylE+1q2kSef1UxAyxqbyuWM3FRWS1v48JK1Y3CoW3bD6TSNXZh0+GsVnihujEpKyR+Jejx2aRAFfC3AHm9rElg==",
+      "version": "10.27.2",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.2.tgz",
+      "integrity": "sha512-kvknfAEtOHjHkAAv7GxLEJh8ghpMQm3Fc4uWVyF7hERSTsSRsdC7saWs0p5aDG7GDcWsu5o+T4232O+8KZO55w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "overrides": {
     "fast-uri": "3.1.5",
     "js-yaml": "4.3.1",
-    "liquidjs": "10.27.1",
+    "liquidjs": "10.27.2",
     "serialize-javascript": "7.0.5",
     "shell-quote": "1.9.0",
     "sirv": "3.0.2",

--- a/src/__mocks__/config-mocks.js
+++ b/src/__mocks__/config-mocks.js
@@ -16,6 +16,53 @@ export const mockLandGrantsConfig = () => ({
   }
 })
 
+/** @type {Map<string, unknown>} */
+const stateValues = new Map()
+/** @type {Map<string, unknown>} */
+let stateDefaults = new Map()
+/** @type {unknown} */
+let stateFallback
+
+/**
+ * Feature-flag values a test can flip between cases, paired with
+ * `mockConfigWithState` below.
+ */
+export const configState = {
+  /**
+   * @param {string} key
+   * @param {unknown} value
+   */
+  set(key, value) {
+    stateValues.set(key, value)
+  },
+  reset() {
+    stateValues.clear()
+    stateDefaults.forEach((value, key) => stateValues.set(key, value))
+  },
+  /** @param {string} key */
+  get(key) {
+    return stateValues.has(key) ? stateValues.get(key) : stateFallback
+  }
+}
+
+/**
+ * Mock the config module against the mutable `configState` above.
+ * @param {object} [options]
+ * @param {Record<string, unknown>} [options.defaults] - values restored by `configState.reset()`
+ * @param {unknown} [options.fallback] - returned for a key that was never set
+ * @returns {{ config: { get: import('vitest').Mock } }}
+ */
+export const mockConfigWithState = ({ defaults = {}, fallback } = {}) => {
+  stateDefaults = new Map(Object.entries(defaults))
+  stateFallback = fallback
+  configState.reset()
+  return {
+    config: {
+      get: vi.fn((/** @type {string} */ key) => configState.get(key))
+    }
+  }
+}
+
 /**
  * Mock the config module, resolving keys against a fixed value map.
  * @param {Record<string, unknown>} [configValues] - keyed config values to return

--- a/src/__mocks__/controller-mocks.js
+++ b/src/__mocks__/controller-mocks.js
@@ -14,6 +14,34 @@ export const setupControllerMocks = (controller, { proceed = 'redirected', nextP
 }
 
 /**
+ * Route handlers render `viewName` so a test can assert on what h.view was given.
+ * @param {string} viewName
+ * @returns {{ QuestionPageController: new (model?: object, pageDef?: object) => object }}
+ */
+export const makeQuestionPageControllerMock = (viewName) => ({
+  QuestionPageController: class {
+    constructor(model, pageDef) {
+      this.model = model
+      this.pageDef = pageDef
+    }
+
+    getViewModel(_request, _context) {}
+
+    getHref(path) {
+      return `/${this.model.basePath}/${path}`.replace(/\/{2,}/g, '/')
+    }
+
+    makeGetRouteHandler() {
+      return async (request, context, h) => h.view(viewName, this.getViewModel(request, context))
+    }
+
+    makePostRouteHandler() {
+      return async (request, context, h) => h.view(viewName, this.getViewModel(request, context))
+    }
+  }
+})
+
+/**
  * @typedef {object} SetupControllerMocksOptions
  * @property {string} [proceed] Value resolved by the mocked `proceed` method.
  * @property {string} [nextPath] Value returned by the mocked `getNextPath` method.

--- a/src/__mocks__/index.js
+++ b/src/__mocks__/index.js
@@ -6,7 +6,14 @@ export {
   mockRequestLogger
 } from './logger-mocks.js'
 
-export { mockConfig, mockConfigSimple, createMockConfig, mockLandGrantsConfig } from './config-mocks.js'
+export {
+  mockConfig,
+  mockConfigSimple,
+  createMockConfig,
+  mockLandGrantsConfig,
+  mockConfigWithState,
+  configState
+} from './config-mocks.js'
 
 export {
   mockHapiPino,
@@ -23,6 +30,6 @@ export {
   createMockFetchResponse
 } from './hapi-mocks.js'
 
-export { setupControllerMocks } from './controller-mocks.js'
+export { setupControllerMocks, makeQuestionPageControllerMock } from './controller-mocks.js'
 
 export { mockFilters } from './filters-mocks.js'

--- a/src/client/javascripts/land-grants/select-actions-page.js
+++ b/src/client/javascripts/land-grants/select-actions-page.js
@@ -1,5 +1,6 @@
 import { ACTION_QUANTITY_FIELD_PREFIX, getActionQuantityFieldName } from '../../../shared/action-quantity-field.js'
-import { formatAreaUnit } from '../../../shared/format-area-unit.js'
+import { formatUnit } from '../../../shared/format-unit.js'
+import { getAvailabilityLimit } from '../../../shared/availability.js'
 import { isValidCompoundParcelId } from '../../../shared/format-parcel.js'
 
 const CHECKBOX_NAME = 'landAction'
@@ -17,7 +18,7 @@ const REFRESH_BANNER_HIDDEN_CLASS = 'select-actions-refresh-banner--hidden'
  * @param {number} value
  * @param {string} unit
  */
-const availabilityHintText = (value, unit) => `${value} ${formatAreaUnit(unit)} available`
+const availabilityHintText = (value, unit) => `${value} ${formatUnit(unit)} available`
 
 /** @param {HTMLElement} form */
 function getCheckboxes(form) {
@@ -130,7 +131,13 @@ function disableOtherActions(form, triggeringCheckbox) {
  * @returns {number | undefined}
  */
 function getTotalAvailableArea(checkbox) {
-  const value = Number(checkbox.getAttribute(TOTAL_AVAILABLE_AREA_ATTR))
+  // An action with no availability restriction renders no usable value here,
+  // and Number('') is 0 - which would read as a zero ceiling, not "no ceiling".
+  const raw = checkbox.getAttribute(TOTAL_AVAILABLE_AREA_ATTR)
+  if (raw == null || raw.trim() === '') {
+    return undefined
+  }
+  const value = Number(raw)
   return Number.isFinite(value) ? value : undefined
 }
 
@@ -327,36 +334,48 @@ function markUnavailable(checkbox, quantityInput = getQuantityInput(checkbox)) {
 }
 
 /**
- * Refreshes a quantity input's max/hint from the latest availableArea, as reported by the API.
+ * Refreshes a quantity input's max/hint from the latest availability, as reported
+ * by the API. A null value means no restriction, which has to clear the bound
+ * rather than stringify - the server renders neither max nor hint in that case
+ * (see quantity-input/template.njk), so this keeps the two in step.
  * @param {HTMLInputElement} checkbox
- * @param {{ availableArea?: { value: number, unit: string } }} action
+ * @param {{ availability?: ActionAvailability | null }} action
  */
 function syncQuantityInputBounds(checkbox, action) {
   const quantityInput = getQuantityInput(checkbox)
-  if (!quantityInput || !action.availableArea) {
+  if (!quantityInput || !action.availability) {
     return
   }
-  quantityInput.max = String(action.availableArea.value)
+  const limit = getAvailabilityLimit(action.availability)
   const hint = document.getElementById(`${quantityInput.id}-hint`)
+  if (limit == null) {
+    quantityInput.removeAttribute('max')
+    if (hint) {
+      hint.textContent = ''
+    }
+    return
+  }
+  quantityInput.max = String(limit)
   if (hint) {
-    hint.textContent = availabilityHintText(action.availableArea.value, action.availableArea.unit)
+    hint.textContent = availabilityHintText(limit, action.availability.unit)
   }
 }
 
 /**
  * Refreshes a non-quantity action's own "X available" hint (see
  * getActionQuantityFieldName - shares its id with the quantity-action hint
- * pattern) from the latest availableArea, as reported by the API.
+ * pattern) from the latest availability, as reported by the API.
  * @param {HTMLInputElement} checkbox
- * @param {{ availableArea?: { value: number, unit: string } }} action
+ * @param {{ availability?: ActionAvailability | null }} action
  */
 function syncNonQuantityHint(checkbox, action) {
-  if (getQuantityInput(checkbox) || !action.availableArea) {
+  const limit = getAvailabilityLimit(action.availability)
+  if (getQuantityInput(checkbox) || limit == null) {
     return
   }
   const hint = document.getElementById(`${getActionQuantityFieldName(checkbox.value)}-hint`)
   if (hint) {
-    hint.textContent = availabilityHintText(action.availableArea.value, action.availableArea.unit)
+    hint.textContent = availabilityHintText(limit, /** @type {ActionAvailability} */ (action.availability).unit)
   }
 }
 
@@ -374,16 +393,17 @@ function clearUnavailable(checkbox) {
 }
 
 /**
- * Not selected: unavailable when there's nothing (or not enough, for a typed amount) left to claim.
+ * Not selected: unavailable when there's nothing (or not enough, for a typed amount)
+ * left to claim. An action with no limit at all can never be unavailable - comparing
+ * a null value would coerce it to 0 and reject any typed amount above zero.
  * @param {HTMLInputElement} checkbox
  * @param {HTMLInputElement | null} quantityInput
- * @param {{ value: number, unit: string }} [availableArea]
+ * @param {ActionAvailability | null} [availability]
  */
-function applyUncheckedAvailability(checkbox, quantityInput, availableArea) {
+function applyUncheckedAvailability(checkbox, quantityInput, availability) {
+  const limit = getAvailabilityLimit(availability)
   const isUnavailable =
-    availableArea != null && quantityInput
-      ? availableArea.value === 0 || availableArea.value < (getValidTypedQuantity(checkbox) ?? 0)
-      : availableArea?.value === 0
+    limit != null && quantityInput ? limit === 0 || limit < (getValidTypedQuantity(checkbox) ?? 0) : limit === 0
   if (isUnavailable) {
     markUnavailable(checkbox)
   } else {
@@ -412,16 +432,16 @@ function applyCheckedQuantityAvailability(checkbox, sentQuantity) {
  * hypothetical for THIS action alone and can't be trusted alongside another
  * action's own growth in the same pass. Disables it if nothing's claimed.
  * @param {HTMLInputElement} checkbox
- * @param {number} availableAreaValue
+ * @param {number} availabilityValue
  * @param {number} sentQuantity
  * @param {boolean} allowGrowth
  * @returns {boolean} Whether this action's chosen area grew beyond what was sent -
- *   every OTHER action's own availableArea in this same response was computed
+ *   every OTHER action's own availability in this same response was computed
  *   against the smaller, pre-growth claim, so it's now stale.
  */
-function applyCheckedNonQuantityAvailability(checkbox, availableAreaValue, sentQuantity, allowGrowth) {
-  const grows = allowGrowth && availableAreaValue > 0
-  const chosenArea = grows ? sentQuantity + availableAreaValue : sentQuantity
+function applyCheckedNonQuantityAvailability(checkbox, availabilityValue, sentQuantity, allowGrowth) {
+  const grows = allowGrowth && availabilityValue > 0
+  const chosenArea = grows ? sentQuantity + availabilityValue : sentQuantity
   setChosenArea(checkbox, chosenArea)
   if (chosenArea === 0) {
     markUnavailable(checkbox)
@@ -438,28 +458,32 @@ function applyCheckedNonQuantityAvailability(checkbox, availableAreaValue, sentQ
  * re-enabled/disabled by fresh availability, since that reflects what OTHER
  * actions are doing, not a correction to its own rejected value.
  * @param {HTMLInputElement} checkbox
- * @param {{ availableArea?: { value: number, unit: string } }} action
+ * @param {{ availability?: ActionAvailability | null }} action
  * @param {number | undefined} sentQuantity - What we claimed for this action, if checked and included.
  * @param {boolean} isProtected
  * @param {boolean} allowGrowth - Whether a non-quantity action may grow this pass (see applyRefreshResponse).
  * @returns {boolean} Whether this action grew (see applyCheckedNonQuantityAvailability).
  */
 function applyAvailability(checkbox, action, sentQuantity, isProtected, allowGrowth) {
-  const { availableArea } = action
+  const { availability } = action
   const quantityInput = getQuantityInput(checkbox)
-  if (availableArea) {
-    checkbox.setAttribute(AVAILABLE_UNIT_ATTR, availableArea.unit)
-    checkbox.setAttribute(LIVE_AVAILABLE_AREA_ATTR, String(availableArea.value))
+  const limit = getAvailabilityLimit(availability)
+  if (availability) {
+    checkbox.setAttribute(AVAILABLE_UNIT_ATTR, availability.unit)
+  }
+  // No limit means no live headroom to record - drop the attribute rather than
+  // stringify a null, which would read back as NaN instead of "unrestricted".
+  if (limit == null) {
+    checkbox.removeAttribute(LIVE_AVAILABLE_AREA_ATTR)
+  } else {
+    checkbox.setAttribute(LIVE_AVAILABLE_AREA_ATTR, String(limit))
   }
 
   syncQuantityInputBounds(checkbox, action)
   syncNonQuantityHint(checkbox, action)
 
   if (!checkbox.checked) {
-    applyUncheckedAvailability(checkbox, quantityInput, availableArea)
-    return false
-  }
-  if (availableArea == null) {
+    applyUncheckedAvailability(checkbox, quantityInput, availability)
     return false
   }
   if (isProtected) {
@@ -470,22 +494,29 @@ function applyAvailability(checkbox, action, sentQuantity, isProtected, allowGro
     applyCheckedQuantityAvailability(checkbox, sentQuantity)
     return false
   }
-  return applyCheckedNonQuantityAvailability(
-    checkbox,
-    availableArea.value,
-    /** @type {number} */ (sentQuantity),
-    allowGrowth
-  )
+  if (limit == null) {
+    // Nothing can make an unrestricted action incompatible, but disableOtherActions
+    // disabled it at the start of this refresh and this is its only way back.
+    clearUnavailable(checkbox)
+    return false
+  }
+  return applyCheckedNonQuantityAvailability(checkbox, limit, /** @type {number} */ (sentQuantity), allowGrowth)
 }
 
 /**
- * @typedef {{ code: string, availableArea?: { value: number, unit: string } }} ActionAvailability
+ * How much of an action is still claimable, as the API reports it. `unit` is
+ * always present; a null `value` means no restriction.
+ * @typedef {{ value: number | null, unit: string }} ActionAvailability
+ */
+
+/**
+ * @typedef {{ code: string, availability?: ActionAvailability | null }} ActionAvailabilityUpdate
  */
 
 /**
  * @param {string} parcelId
  * @param {Array<{ actionCode: string, quantity: number, unit: string }>} plannedActions
- * @returns {Promise<ActionAvailability[] | null>}
+ * @returns {Promise<ActionAvailabilityUpdate[] | null>}
  */
 async function postPlannedActions(parcelId, plannedActions) {
   const crumb = /** @type {HTMLInputElement | null} */ (document.querySelector('input[name="crumb"]'))?.value
@@ -499,7 +530,7 @@ async function postPlannedActions(parcelId, plannedActions) {
     if (!response.ok) {
       return null
     }
-    /** @type {{ actions: ActionAvailability[] }} */
+    /** @type {{ actions: ActionAvailabilityUpdate[] }} */
     const { actions = [] } = await response.json()
     return actions
   } catch {
@@ -528,7 +559,7 @@ function recoverFromFailedRefresh(form) {
  * re-ask (with that one action's new, larger claim already sent) before any
  * other action's own growth can be trusted.
  * @param {HTMLElement} form
- * @param {ActionAvailability[]} actions
+ * @param {ActionAvailabilityUpdate[]} actions
  * @param {Array<{ actionCode: string, quantity: number, unit: string }>} plannedActions
  * @returns {boolean} Whether an action grew and a follow-up refresh is needed.
  */

--- a/src/client/javascripts/land-grants/select-actions-page.test.js
+++ b/src/client/javascripts/land-grants/select-actions-page.test.js
@@ -5,14 +5,15 @@ import { initSelectActionsPage } from './select-actions-page.js'
 function checkboxItemHtml({
   code,
   checked = false,
-  availableArea,
+  availability,
   requiresMaxQuantity,
+  unrestricted = false,
   quantityValue = '',
   hasError = false,
   errorOnLoad = false
 }) {
-  const unitAttr = availableArea ? ` data-available-unit="${availableArea.unit}"` : ''
-  const totalAreaAttr = availableArea ? ` data-total-available-area="${availableArea.value}"` : ''
+  const unitAttr = availability ? ` data-available-unit="${availability.unit}"` : ''
+  const totalAreaAttr = availability ? ` data-total-available-area="${availability.value ?? ''}"` : ''
   // Stamped server-side per checkbox for a checked action redisplayed from a
   // rejected submission (see mapActionToViewModel) - not a single form-wide flag.
   const errorOnLoadAttr = errorOnLoad ? ' data-error-on-load="true"' : ''
@@ -27,8 +28,8 @@ function checkboxItemHtml({
     <div class="govuk-checkboxes__conditional${checked ? '' : ' govuk-checkboxes__conditional--hidden'}" id="${conditionalId}">
         <div class="govuk-form-group">
           <div id="landActionQuantity_${code}-refresh-banner" class="select-actions-refresh-banner select-actions-refresh-banner--hidden">Updating available land for this action&hellip;</div>
-          <input class="${inputClass}" id="landActionQuantity_${code}" name="landActionQuantity_${code}" type="text" value="${quantityValue}" max="${requiresMaxQuantity}">
-          <div id="landActionQuantity_${code}-hint">${requiresMaxQuantity} ha available</div>
+          <input class="${inputClass}" id="landActionQuantity_${code}" name="landActionQuantity_${code}" type="text" value="${quantityValue}"${unrestricted ? '' : ` max="${requiresMaxQuantity}"`}>
+          ${unrestricted ? '' : `<div id="landActionQuantity_${code}-hint">${requiresMaxQuantity} ha available</div>`}
           <div class="govuk-input__suffix">ha</div>
         </div>
       </div>`
@@ -36,8 +37,8 @@ function checkboxItemHtml({
   // Matches mapActionToViewModel: a non-quantity action gets its own "X
   // available" hint, kept live by the client (see syncNonQuantityHint).
   const nonQuantityHint =
-    !requiresMaxQuantity && availableArea
-      ? `<span id="landActionQuantity_${code}-hint">${availableArea.value} ha available</span>`
+    !requiresMaxQuantity && availability?.value != null
+      ? `<span id="landActionQuantity_${code}-hint">${availability.value} ha available</span>`
       : ''
   return `
     <div class="govuk-checkboxes__item">
@@ -84,7 +85,7 @@ function getChosenAreaFieldValue(checkbox) {
 }
 
 /**
- * Simulates the real land-grants API: availableArea for a code is headroom
+ * Simulates the real land-grants API: availability for a code is headroom
  * BEYOND any claim already made for that same code in this request - 0
  * whenever the code itself is present in plannedActions (it's already
  * claiming its own share, so no MORE is left for it - self-competing), or
@@ -98,7 +99,7 @@ function mockApi(baseAreasByCode) {
     const competingCodes = new Set(plannedActions.map((p) => p.actionCode))
     const actions = Object.entries(baseAreasByCode).map(([code, value]) => ({
       code,
-      availableArea: {
+      availability: {
         value: competingCodes.size > 0 ? 0 : value,
         unit: 'ha'
       }
@@ -113,6 +114,43 @@ function fetchOk(body) {
 
 // A macrotask boundary reliably drains any depth of pending microtasks.
 const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+const checkbox = (form, code) => form.querySelector(`input[value="${code}"]`)
+
+const quantityInputFor = (form, code) => form.querySelector(`#landActionQuantity_${code}`)
+
+const hintFor = (code) => document.getElementById(`landActionQuantity_${code}-hint`)
+
+// Flip a checkbox and let the refresh it triggers settle. Pass `checked` to
+// drive it to a specific state rather than just firing the event.
+async function toggle(form, code, checked) {
+  const target = checkbox(form, code)
+  if (checked !== undefined) {
+    target.checked = checked
+  }
+  target.dispatchEvent(new Event('change', { bubbles: true }))
+  await flushPromises()
+}
+
+// Type into an action's quantity field and blur, which flushes the debounce.
+async function typeQuantity(form, code, value) {
+  const input = quantityInputFor(form, code)
+  input.value = value
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+  input.dispatchEvent(new Event('blur'))
+  await flushPromises()
+  return input
+}
+
+/** plannedActions from the body of a recorded fetch call. */
+const sentPlannedActions = (callIndex = 0) => JSON.parse(global.fetch.mock.calls[callIndex][1].body).plannedActions
+
+async function initSettled(form, fetchMock) {
+  global.fetch = fetchMock
+  initSelectActionsPage(form)
+  await flushPromises()
+  global.fetch.mockClear()
+}
 
 describe('initSelectActionsPage', () => {
   beforeEach(() => {
@@ -133,7 +171,7 @@ describe('initSelectActionsPage', () => {
 
   it('is a no-op when the URL has no parcelId', () => {
     window.history.pushState(null, '', '/select-actions')
-    const form = setupDom([{ code: 'CMOR1', availableArea: { value: 10, unit: 'ha' } }])
+    const form = setupDom([{ code: 'CMOR1', availability: { value: 10, unit: 'ha' } }])
     global.fetch = vi.fn()
 
     initSelectActionsPage(form)
@@ -147,7 +185,7 @@ describe('initSelectActionsPage', () => {
   // taint path at the source rather than relying solely on encodeURIComponent.
   it('is a no-op when the URL parcelId does not match the expected shape', () => {
     window.history.pushState(null, '', '/select-actions?parcelId=<script>alert(1)</script>')
-    const form = setupDom([{ code: 'CMOR1', availableArea: { value: 10, unit: 'ha' } }])
+    const form = setupDom([{ code: 'CMOR1', availability: { value: 10, unit: 'ha' } }])
     global.fetch = vi.fn()
 
     initSelectActionsPage(form)
@@ -158,16 +196,12 @@ describe('initSelectActionsPage', () => {
 
   it('always sends one request with the full, unfiltered plannedActions list', async () => {
     const form = setupDom([
-      { code: 'CMOR1', checked: true, availableArea: { value: 10, unit: 'ha' } },
-      { code: 'UPL1', checked: true, availableArea: { value: 5, unit: 'ha' } }
+      { code: 'CMOR1', checked: true, availability: { value: 10, unit: 'ha' } },
+      { code: 'UPL1', checked: true, availability: { value: 5, unit: 'ha' } }
     ])
-    global.fetch = fetchOk({ actions: [] })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, fetchOk({ actions: [] }))
 
-    form.querySelector('input[value="CMOR1"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CMOR1')
 
     expect(global.fetch).toHaveBeenCalledTimes(1)
     expect(global.fetch).toHaveBeenCalledWith(
@@ -190,11 +224,11 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 18.5, unit: 'ha' },
+        availability: { value: 18.5, unit: 'ha' },
         requiresMaxQuantity: 18.5,
         quantityValue: '3.25'
       },
-      { code: 'CLIG3', availableArea: { value: 45.2, unit: 'ha' } }
+      { code: 'CLIG3', availability: { value: 45.2, unit: 'ha' } }
     ])
     global.fetch = fetchOk({ actions: [] })
 
@@ -218,18 +252,18 @@ describe('initSelectActionsPage', () => {
         {
           code: 'CSAM3',
           checked: true,
-          availableArea: { value: 0.3271, unit: 'ha' },
+          availability: { value: 0.3271, unit: 'ha' },
           requiresMaxQuantity: 0.3271,
           quantityValue: '0.2'
         },
-        { code: 'CLIG3', checked: false, availableArea: { value: 0.3271, unit: 'ha' } }
+        { code: 'CLIG3', checked: false, availability: { value: 0.3271, unit: 'ha' } }
       ],
       { hasErrors: true }
     )
     global.fetch = fetchOk({
       actions: [
-        { code: 'CSAM3', availableArea: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 },
-        { code: 'CLIG3', availableArea: { value: 0, unit: 'ha' } }
+        { code: 'CSAM3', availability: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 },
+        { code: 'CLIG3', availability: { value: 0, unit: 'ha' } }
       ]
     })
 
@@ -237,13 +271,13 @@ describe('initSelectActionsPage', () => {
     await flushPromises()
 
     expect(global.fetch).toHaveBeenCalledTimes(1)
-    const csam3Checkbox = form.querySelector('input[value="CSAM3"]')
+    const csam3Checkbox = checkbox(form, 'CSAM3')
     const csam3QuantityInput = form.querySelector('#landActionQuantity_CSAM3')
     expect(csam3Checkbox.checked).toBe(true)
     expect(csam3Checkbox.disabled).toBe(false)
     expect(csam3QuantityInput.value).toBe('0.2')
 
-    const clig3Checkbox = form.querySelector('input[value="CLIG3"]')
+    const clig3Checkbox = checkbox(form, 'CLIG3')
     expect(clig3Checkbox.checked).toBe(false)
     expect(clig3Checkbox.disabled).toBe(true)
   })
@@ -254,23 +288,20 @@ describe('initSelectActionsPage', () => {
         {
           code: 'CSAM3',
           checked: true,
-          availableArea: { value: 6.3008, unit: 'ha' },
+          availability: { value: 6.3008, unit: 'ha' },
           requiresMaxQuantity: 6.3008,
           quantityValue: '777',
           hasError: true
         },
-        { code: 'CLIG3', checked: true, availableArea: { value: 6.3008, unit: 'ha' }, chosenArea: 1.3008 }
+        { code: 'CLIG3', checked: true, availability: { value: 6.3008, unit: 'ha' }, chosenArea: 1.3008 }
       ],
       { hasErrors: true }
     )
-    global.fetch = fetchOk({ actions: [{ code: 'CLIG3', availableArea: { value: 1.3008, unit: 'ha' } }] })
+    global.fetch = fetchOk({ actions: [{ code: 'CLIG3', availability: { value: 1.3008, unit: 'ha' } }] })
     initSelectActionsPage(form)
     await flushPromises()
 
-    const clig3Checkbox = form.querySelector('input[value="CLIG3"]')
-    clig3Checkbox.checked = false
-    clig3Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', false)
 
     // The claim just sent for CLIG3 (1.3008, its live headroom from the
     // first response) plus the extra headroom this response reports (5) -
@@ -283,15 +314,13 @@ describe('initSelectActionsPage', () => {
       const value = clig3Quantity >= 6.3008 ? 0 : 5
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ actions: [{ code: 'CLIG3', availableArea: { value, unit: 'ha' } }] })
+        json: () => Promise.resolve({ actions: [{ code: 'CLIG3', availability: { value, unit: 'ha' } }] })
       })
     })
-    clig3Checkbox.checked = true
-    clig3Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', true)
 
-    expect(getChosenAreaFieldValue(clig3Checkbox)).toBe('6.3008')
-    const csam3Checkbox = form.querySelector('input[value="CSAM3"]')
+    expect(getChosenAreaFieldValue(checkbox(form, 'CLIG3'))).toBe('6.3008')
+    const csam3Checkbox = checkbox(form, 'CSAM3')
     expect(csam3Checkbox.checked).toBe(true)
     expect(form.querySelector('#landActionQuantity_CSAM3').value).toBe('777')
   })
@@ -302,12 +331,12 @@ describe('initSelectActionsPage', () => {
         {
           code: 'CSAM3',
           checked: true,
-          availableArea: { value: 6.3008, unit: 'ha' },
+          availability: { value: 6.3008, unit: 'ha' },
           requiresMaxQuantity: 6.3008,
           quantityValue: '777',
           hasError: true
         },
-        { code: 'CLIG3', checked: true, availableArea: { value: 6.3008, unit: 'ha' }, chosenArea: 1.3008 }
+        { code: 'CLIG3', checked: true, availability: { value: 6.3008, unit: 'ha' }, chosenArea: 1.3008 }
       ],
       { hasErrors: true }
     )
@@ -315,14 +344,11 @@ describe('initSelectActionsPage', () => {
     initSelectActionsPage(form)
     await flushPromises()
 
-    const csam3Checkbox = form.querySelector('input[value="CSAM3"]')
+    const csam3Checkbox = checkbox(form, 'CSAM3')
     expect(csam3Checkbox.disabled).toBe(false)
 
-    const clig3Checkbox = form.querySelector('input[value="CLIG3"]')
     global.fetch = mockApi({ CSAM3: 6.3008, CLIG3: 6.3008 })
-    clig3Checkbox.checked = false
-    clig3Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', false)
 
     expect(csam3Checkbox.checked).toBe(true)
     expect(csam3Checkbox.disabled).toBe(false)
@@ -336,12 +362,12 @@ describe('initSelectActionsPage', () => {
         {
           code: 'CSAM3',
           checked: true,
-          availableArea: { value: 6.3008, unit: 'ha' },
+          availability: { value: 6.3008, unit: 'ha' },
           requiresMaxQuantity: 6.3008,
           quantityValue: '777',
           hasError: true
         },
-        { code: 'CLIG3', checked: true, availableArea: { value: 6.3008, unit: 'ha' }, chosenArea: 1.3008 }
+        { code: 'CLIG3', checked: true, availability: { value: 6.3008, unit: 'ha' }, chosenArea: 1.3008 }
       ],
       { hasErrors: true }
     )
@@ -355,13 +381,10 @@ describe('initSelectActionsPage', () => {
     csam3Input.dispatchEvent(new Event('focus'))
     csam3Input.dispatchEvent(new Event('blur'))
 
-    const clig3Checkbox = form.querySelector('input[value="CLIG3"]')
     global.fetch = mockApi({ CSAM3: 6.3008, CLIG3: 6.3008 })
-    clig3Checkbox.checked = false
-    clig3Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', false)
 
-    const csam3Checkbox = form.querySelector('input[value="CSAM3"]')
+    const csam3Checkbox = checkbox(form, 'CSAM3')
     expect(csam3Checkbox.checked).toBe(true)
     expect(csam3Checkbox.disabled).toBe(false)
     expect(csam3Input.value).toBe('777')
@@ -373,12 +396,12 @@ describe('initSelectActionsPage', () => {
         {
           code: 'CSAM3',
           checked: true,
-          availableArea: { value: 9, unit: 'ha' },
+          availability: { value: 9, unit: 'ha' },
           requiresMaxQuantity: 9,
           quantityValue: '2',
           hasError: true
         },
-        { code: 'CLIG3', checked: true, availableArea: { value: 9, unit: 'ha' }, chosenArea: 2.3161 }
+        { code: 'CLIG3', checked: true, availability: { value: 9, unit: 'ha' }, chosenArea: 2.3161 }
       ],
       { hasErrors: true }
     )
@@ -386,7 +409,7 @@ describe('initSelectActionsPage', () => {
     initSelectActionsPage(form)
     await flushPromises()
 
-    const csam3Checkbox = form.querySelector('input[value="CSAM3"]')
+    const csam3Checkbox = checkbox(form, 'CSAM3')
     const csam3Input = form.querySelector('#landActionQuantity_CSAM3')
     expect(csam3Checkbox.disabled).toBe(false)
 
@@ -396,11 +419,8 @@ describe('initSelectActionsPage', () => {
     csam3Input.dispatchEvent(new Event('input', { bubbles: true }))
     csam3Input.dispatchEvent(new Event('blur'))
 
-    const clig3Checkbox = form.querySelector('input[value="CLIG3"]')
     global.fetch = mockApi({ CSAM3: 9, CLIG3: 9 })
-    clig3Checkbox.checked = false
-    clig3Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', false)
 
     expect(csam3Checkbox.checked).toBe(true)
     expect(csam3Checkbox.disabled).toBe(false)
@@ -413,12 +433,12 @@ describe('initSelectActionsPage', () => {
         {
           code: 'CSAM3',
           checked: true,
-          availableArea: { value: 9, unit: 'ha' },
+          availability: { value: 9, unit: 'ha' },
           requiresMaxQuantity: 9,
           quantityValue: '33',
           hasError: true
         },
-        { code: 'CLIG3', checked: false, availableArea: { value: 9, unit: 'ha' } }
+        { code: 'CLIG3', checked: false, availability: { value: 9, unit: 'ha' } }
       ],
       { hasErrors: true }
     )
@@ -426,14 +446,11 @@ describe('initSelectActionsPage', () => {
     initSelectActionsPage(form)
     await flushPromises()
 
-    const csam3Checkbox = form.querySelector('input[value="CSAM3"]')
+    const csam3Checkbox = checkbox(form, 'CSAM3')
     const csam3Input = form.querySelector('#landActionQuantity_CSAM3')
 
-    const clig3Checkbox = form.querySelector('input[value="CLIG3"]')
     global.fetch = mockApi({ CSAM3: 9, CLIG3: 9 })
-    clig3Checkbox.checked = true
-    clig3Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', true)
 
     csam3Input.dispatchEvent(new Event('focus'))
     csam3Input.value = 'asdhasd'
@@ -441,9 +458,7 @@ describe('initSelectActionsPage', () => {
     csam3Input.dispatchEvent(new Event('blur'))
 
     global.fetch = mockApi({ CSAM3: 9, CLIG3: 9 })
-    clig3Checkbox.checked = false
-    clig3Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', false)
 
     expect(csam3Checkbox.checked).toBe(false)
     expect(csam3Checkbox.disabled).toBe(false)
@@ -459,26 +474,21 @@ describe('initSelectActionsPage', () => {
         {
           code: 'CSAM3',
           checked: true,
-          availableArea: { value: 0.3271, unit: 'ha' },
+          availability: { value: 0.3271, unit: 'ha' },
           requiresMaxQuantity: 0.3271,
           quantityValue: '0.2'
         },
-        { code: 'CLIG3', checked: false, availableArea: { value: 0.3271, unit: 'ha' } },
-        { code: 'CMOR1', availableArea: { value: 10, unit: 'ha' } }
+        { code: 'CLIG3', checked: false, availability: { value: 0.3271, unit: 'ha' } },
+        { code: 'CMOR1', availability: { value: 10, unit: 'ha' } }
       ],
       { hasErrors: true }
     )
-    global.fetch = fetchOk({ actions: [] })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, fetchOk({ actions: [] }))
 
-    form.querySelector('input[value="CMOR1"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CMOR1')
 
     expect(global.fetch).toHaveBeenCalledTimes(1)
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toContainEqual({ actionCode: 'CSAM3', quantity: 0.2, unit: 'ha' })
+    expect(sentPlannedActions()).toContainEqual({ actionCode: 'CSAM3', quantity: 0.2, unit: 'ha' })
   })
 
   it('never disables, unchecks or resets a checked action whose quantity input already has a validation error', async () => {
@@ -486,25 +496,25 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 0.3271, unit: 'ha' },
+        availability: { value: 0.3271, unit: 'ha' },
         // requiresMaxQuantity is lower than quantityValue to simulate a stale server-rendered max.
         requiresMaxQuantity: 0.0271,
         quantityValue: '0.3',
         hasError: true
       },
-      { code: 'CLIG3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, chosenArea: 0.15 }
+      { code: 'CLIG3', checked: true, availability: { value: 0.3271, unit: 'ha' }, chosenArea: 0.15 }
     ])
     global.fetch = fetchOk({
       actions: [
-        { code: 'CSAM3', availableArea: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 },
-        { code: 'CLIG3', availableArea: { value: 0, unit: 'ha' } }
+        { code: 'CSAM3', availability: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 },
+        { code: 'CLIG3', availability: { value: 0, unit: 'ha' } }
       ]
     })
 
     initSelectActionsPage(form)
     await flushPromises()
 
-    const csam3Checkbox = form.querySelector('input[value="CSAM3"]')
+    const csam3Checkbox = checkbox(form, 'CSAM3')
     const csam3QuantityInput = form.querySelector('#landActionQuantity_CSAM3')
 
     expect(csam3Checkbox.checked).toBe(true)
@@ -515,7 +525,7 @@ describe('initSelectActionsPage', () => {
   })
 
   it('does not run an initial refresh on load when nothing is checked', () => {
-    const form = setupDom([{ code: 'CLIG3', availableArea: { value: 45.2, unit: 'ha' } }])
+    const form = setupDom([{ code: 'CLIG3', availability: { value: 45.2, unit: 'ha' } }])
     global.fetch = vi.fn()
 
     initSelectActionsPage(form)
@@ -528,7 +538,7 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 18.5, unit: 'ha' },
+        availability: { value: 18.5, unit: 'ha' },
         requiresMaxQuantity: 18.5,
         quantityValue: '3.25'
       }
@@ -537,7 +547,7 @@ describe('initSelectActionsPage', () => {
 
     initSelectActionsPage(form)
 
-    expect(document.getElementById('landActionQuantity_CSAM3-hint').textContent).toBe('15.25 hectares available')
+    expect(hintFor('CSAM3').textContent).toBe('15.25 hectares available')
   })
 
   // The route validates crumb in restful mode (X-CSRF-Token header) rather
@@ -545,14 +555,10 @@ describe('initSelectActionsPage', () => {
   // @hapi/crumb's autoGenerate into silently rotating the cookie and
   // invalidating the crumb already embedded in the page's hidden form field.
   it('sends the crumb from the hidden form field as the X-CSRF-Token header', async () => {
-    const form = setupDom([{ code: 'CMOR1', checked: true, availableArea: { value: 10, unit: 'ha' } }])
-    global.fetch = fetchOk({ actions: [] })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    const form = setupDom([{ code: 'CMOR1', checked: true, availability: { value: 10, unit: 'ha' } }])
+    await initSettled(form, fetchOk({ actions: [] }))
 
-    form.querySelector('input[value="CMOR1"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CMOR1')
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.any(String),
@@ -568,35 +574,28 @@ describe('initSelectActionsPage', () => {
   // at all until a quantity is actually typed.
   it('does not fire a request when checking a quantity-required action with no quantity typed yet', async () => {
     const form = setupDom([
-      { code: 'CSAM3', availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
-      { code: 'CLIG3', availableArea: { value: 45.2, unit: 'ha' } }
+      { code: 'CSAM3', availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
+      { code: 'CLIG3', availability: { value: 45.2, unit: 'ha' } }
     ])
     global.fetch = vi.fn()
     initSelectActionsPage(form)
 
-    const csam3 = form.querySelector('input[value="CSAM3"]')
-    csam3.checked = true
-    csam3.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CSAM3', true)
 
     expect(global.fetch).not.toHaveBeenCalled()
     // Nothing has been confirmed yet, so CLIG3 must not be greyed out just
     // because CSAM3's box is checked.
-    expect(form.querySelector('input[value="CLIG3"]').disabled).toBe(false)
+    expect(checkbox(form, 'CLIG3').disabled).toBe(false)
   })
 
   it('greys out a different, unchecked action genuinely made unavailable by the one checked action', async () => {
     const form = setupDom([
-      { code: 'CLIG3', checked: true, availableArea: { value: 45.2, unit: 'ha' } },
-      { code: 'CSAM3', availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
+      { code: 'CLIG3', checked: true, availability: { value: 45.2, unit: 'ha' } },
+      { code: 'CSAM3', availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
     ])
-    global.fetch = mockApi({ CLIG3: 45.2, CSAM3: 18.5 })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, mockApi({ CLIG3: 45.2, CSAM3: 18.5 }))
 
-    form.querySelector('input[value="CLIG3"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3')
 
     expect(global.fetch).toHaveBeenCalledWith(
       '/api/land-grants/actions/SD7946-0155',
@@ -604,66 +603,29 @@ describe('initSelectActionsPage', () => {
         body: JSON.stringify({ plannedActions: [{ actionCode: 'CLIG3', quantity: 45.2, unit: 'ha' }] })
       })
     )
-    const clig3 = form.querySelector('input[value="CLIG3"]')
-    const csam3 = form.querySelector('input[value="CSAM3"]')
+    const clig3 = checkbox(form, 'CLIG3')
+    const csam3 = checkbox(form, 'CSAM3')
     expect(clig3.disabled).toBe(false)
     expect(csam3.disabled).toBe(true)
   })
 
-  it('does not grey out a non-quantity action whose availableArea is reduced but still non-zero', async () => {
+  it("updates a non-quantity action's hint from the response without greying it out when it is still non-zero", async () => {
     const form = setupDom([
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 0.3271, unit: 'ha' },
+        availability: { value: 0.3271, unit: 'ha' },
         requiresMaxQuantity: 0.3271,
         quantityValue: '0.1'
       },
-      { code: 'CLIG3', availableArea: { value: 0.3271, unit: 'ha' } }
+      { code: 'CLIG3', availability: { value: 0.3271, unit: 'ha' } }
     ])
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          actions: [{ code: 'CLIG3', availableArea: { value: 0.2271, unit: 'ha' } }]
-        })
-    })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, fetchOk({ actions: [{ code: 'CLIG3', availability: { value: 0.2271, unit: 'ha' } }] }))
 
-    form.querySelector('input[value="CSAM3"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CSAM3')
 
-    expect(form.querySelector('input[value="CLIG3"]').disabled).toBe(false)
-  })
-
-  it("updates a non-quantity action's own availability hint from the response", async () => {
-    const form = setupDom([
-      {
-        code: 'CSAM3',
-        checked: true,
-        availableArea: { value: 0.3271, unit: 'ha' },
-        requiresMaxQuantity: 0.3271,
-        quantityValue: '0.1'
-      },
-      { code: 'CLIG3', availableArea: { value: 0.3271, unit: 'ha' } }
-    ])
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          actions: [{ code: 'CLIG3', availableArea: { value: 0.2271, unit: 'ha' } }]
-        })
-    })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
-
-    form.querySelector('input[value="CSAM3"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
-
-    expect(document.getElementById('landActionQuantity_CLIG3-hint').textContent).toBe('0.2271 hectares available')
+    expect(checkbox(form, 'CLIG3').disabled).toBe(false)
+    expect(hintFor('CLIG3').textContent).toBe('0.2271 hectares available')
   })
 
   it('unchecks and clears a checked quantity-required action that has no confirmed quantity, without disabling it', async () => {
@@ -671,23 +633,23 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CLIG3',
         checked: true,
-        availableArea: { value: 0.3271, unit: 'ha' },
+        availability: { value: 0.3271, unit: 'ha' },
         requiresMaxQuantity: 0.3271,
         quantityValue: '0.25'
       },
-      { code: 'CSAM3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 }
+      { code: 'CSAM3', checked: true, availability: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 }
     ])
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () =>
         Promise.resolve({
-          actions: [{ code: 'CSAM3', availableArea: { value: 0.0771, unit: 'ha' }, requiresMaxQuantity: 0.0771 }]
+          actions: [{ code: 'CSAM3', availability: { value: 0.0771, unit: 'ha' }, requiresMaxQuantity: 0.0771 }]
         })
     })
     initSelectActionsPage(form)
     await flushPromises()
 
-    const csam3 = form.querySelector('input[value="CSAM3"]')
+    const csam3 = checkbox(form, 'CSAM3')
     expect(csam3.checked).toBe(false)
     expect(csam3.disabled).toBe(false)
     expect(isConditionalHidden(csam3)).toBe(true)
@@ -709,22 +671,18 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 18.5, unit: 'ha' },
+        availability: { value: 18.5, unit: 'ha' },
         requiresMaxQuantity: 18.5,
         quantityValue: '13.5'
       },
-      { code: 'UPL1', checked: true, availableArea: { value: 5, unit: 'ha' } }
+      { code: 'UPL1', checked: true, availability: { value: 5, unit: 'ha' } }
     ])
-    global.fetch = mockApi({ CSAM3: 18.5, UPL1: 5 })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, mockApi({ CSAM3: 18.5, UPL1: 5 }))
 
-    form.querySelector('input[value="UPL1"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'UPL1')
 
-    const csam3 = form.querySelector('input[value="CSAM3"]')
-    const upl1 = form.querySelector('input[value="UPL1"]')
+    const csam3 = checkbox(form, 'CSAM3')
+    const upl1 = checkbox(form, 'UPL1')
     expect(csam3.disabled).toBe(false)
     expect(upl1.disabled).toBe(false)
   })
@@ -734,48 +692,42 @@ describe('initSelectActionsPage', () => {
   // checked (a genuinely unrelated action) must not affect CSAM3 at all.
   it('does not grey out an action that a different, non-competing action does not affect', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
-      { code: 'UPL1', checked: true, availableArea: { value: 5, unit: 'ha' } }
+      { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
+      { code: 'UPL1', checked: true, availability: { value: 5, unit: 'ha' } }
     ])
     // Neither action's area is reduced by the other being present - simulates
     // two actions that don't compete for the same land.
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          actions: [
-            { code: 'CSAM3', availableArea: { value: 18.5, unit: 'ha' } },
-            { code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }
-          ]
-        })
-    })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(
+      form,
+      fetchOk({
+        actions: [
+          { code: 'CSAM3', availability: { value: 18.5, unit: 'ha' } },
+          { code: 'UPL1', availability: { value: 5, unit: 'ha' } }
+        ]
+      })
+    )
 
-    form.querySelector('input[value="UPL1"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'UPL1')
 
-    const csam3 = form.querySelector('input[value="CSAM3"]')
-    const upl1 = form.querySelector('input[value="UPL1"]')
+    const csam3 = checkbox(form, 'CSAM3')
+    const upl1 = checkbox(form, 'UPL1')
     expect(csam3.disabled).toBe(false)
     expect(upl1.disabled).toBe(false)
   })
 
-  it('resets every action back to its unconstrained availableArea when nothing is checked', async () => {
-    const form = setupDom([{ code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }])
-    const upl1 = form.querySelector('input[value="UPL1"]')
+  it('resets every action back to its unconstrained availability when nothing is checked', async () => {
+    const form = setupDom([{ code: 'UPL1', availability: { value: 5, unit: 'ha' } }])
+    const upl1 = checkbox(form, 'UPL1')
     upl1.disabled = true
 
-    global.fetch = fetchOk({ actions: [{ code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }] })
+    global.fetch = fetchOk({ actions: [{ code: 'UPL1', availability: { value: 5, unit: 'ha' } }] })
     initSelectActionsPage(form)
 
     upl1.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
     expect(global.fetch).toHaveBeenCalledTimes(1)
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toEqual([])
+    expect(sentPlannedActions()).toEqual([])
   })
 
   // When the action being edited is checked solo, its own request is NOT
@@ -786,21 +738,13 @@ describe('initSelectActionsPage', () => {
   // because there's no other request to source a clean number from).
   it('uses the typed quantity value over the full available area when present', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
+      { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
     ])
-    global.fetch = fetchOk({ actions: [] })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, fetchOk({ actions: [] }))
 
-    const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
-    quantityInput.value = '3.25'
-    quantityInput.dispatchEvent(new Event('input', { bubbles: true }))
-    quantityInput.dispatchEvent(new Event('blur'))
-    await flushPromises()
+    await typeQuantity(form, 'CSAM3', '3.25')
 
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toEqual([{ actionCode: 'CSAM3', quantity: 3.25, unit: 'ha' }])
+    expect(sentPlannedActions()).toEqual([{ actionCode: 'CSAM3', quantity: 3.25, unit: 'ha' }])
   })
 
   // A quantity-required action's own hint updates instantly as the user
@@ -813,13 +757,13 @@ describe('initSelectActionsPage', () => {
   // out to be wrong once a competing action's claim is taken into account.
   it("does not change a quantity input's own hint as the user types, only after a refresh response", async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 }
+      { code: 'CSAM3', checked: true, availability: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 }
     ])
     global.fetch = vi.fn()
     initSelectActionsPage(form)
 
     const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
-    const hint = document.getElementById('landActionQuantity_CSAM3-hint')
+    const hint = hintFor('CSAM3')
     const before = hint.textContent
 
     quantityInput.value = '0.2'
@@ -839,59 +783,45 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 18.5, unit: 'ha' },
+        availability: { value: 18.5, unit: 'ha' },
         requiresMaxQuantity: 18.5,
         quantityValue: '25'
       },
-      { code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }
+      { code: 'UPL1', availability: { value: 5, unit: 'ha' } }
     ])
-    global.fetch = fetchOk({ actions: [] })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, fetchOk({ actions: [] }))
 
-    const upl1 = form.querySelector('input[value="UPL1"]')
-    upl1.checked = true
-    upl1.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'UPL1', true)
 
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toEqual([{ actionCode: 'UPL1', quantity: 5, unit: 'ha' }])
+    expect(sentPlannedActions()).toEqual([{ actionCode: 'UPL1', quantity: 5, unit: 'ha' }])
   })
 
   it('still fires a request when typing a valid quantity within the latest refreshed max', async () => {
     const form = setupDom([
-      { code: 'CLIG3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 }
+      { code: 'CLIG3', checked: true, availability: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 }
     ])
     global.fetch = fetchOk({
-      actions: [{ code: 'CLIG3', availableArea: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 }]
+      actions: [{ code: 'CLIG3', availability: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 }]
     })
     initSelectActionsPage(form)
 
-    const quantityInput = form.querySelector('#landActionQuantity_CLIG3')
-    quantityInput.value = '0.1'
-    quantityInput.dispatchEvent(new Event('input', { bubbles: true }))
-    quantityInput.dispatchEvent(new Event('blur'))
-    await flushPromises()
+    const quantityInput = await typeQuantity(form, 'CLIG3', '0.1')
 
     expect(quantityInput.max).toBe('0.2271')
     global.fetch.mockClear()
 
-    quantityInput.value = '0.2'
-    quantityInput.dispatchEvent(new Event('input', { bubbles: true }))
-    quantityInput.dispatchEvent(new Event('blur'))
-    await flushPromises()
+    await typeQuantity(form, 'CLIG3', '0.2')
 
     expect(global.fetch).toHaveBeenCalledTimes(1)
   })
 
   it('allows reducing a quantity at or below its last-confirmed value even when the displayed max reads 0', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 },
-      { code: 'CLIG3', availableArea: { value: 0.3271, unit: 'ha' } }
+      { code: 'CSAM3', checked: true, availability: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 },
+      { code: 'CLIG3', availability: { value: 0.3271, unit: 'ha' } }
     ])
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 0.1, unit: 'ha' }, requiresMaxQuantity: 0.1 }]
+      actions: [{ code: 'CSAM3', availability: { value: 0.1, unit: 'ha' }, requiresMaxQuantity: 0.1 }]
     })
     const csam3QuantityInput = form.querySelector('#landActionQuantity_CSAM3')
     csam3QuantityInput.value = '0.10'
@@ -901,31 +831,26 @@ describe('initSelectActionsPage', () => {
     await flushPromises()
 
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
+      actions: [{ code: 'CSAM3', availability: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
     })
-    form.querySelector('input[value="CLIG3"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3')
 
-    expect(document.getElementById('landActionQuantity_CSAM3-hint').textContent).toBe('0 hectares available')
+    expect(hintFor('CSAM3').textContent).toBe('0 hectares available')
     global.fetch.mockClear()
 
-    csam3QuantityInput.value = '0.05'
-    csam3QuantityInput.dispatchEvent(new Event('input', { bubbles: true }))
-    csam3QuantityInput.dispatchEvent(new Event('blur'))
-    await flushPromises()
+    await typeQuantity(form, 'CSAM3', '0.05')
 
     expect(global.fetch).toHaveBeenCalledTimes(1)
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toContainEqual({ actionCode: 'CSAM3', quantity: 0.05, unit: 'ha' })
+    expect(sentPlannedActions()).toContainEqual({ actionCode: 'CSAM3', quantity: 0.05, unit: 'ha' })
   })
 
   it('allows increasing a quantity back up after a reduction, up to the static uncompeted total', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 },
-      { code: 'CLIG3', availableArea: { value: 0.3271, unit: 'ha' } }
+      { code: 'CSAM3', checked: true, availability: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 },
+      { code: 'CLIG3', availability: { value: 0.3271, unit: 'ha' } }
     ])
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 0.1, unit: 'ha' }, requiresMaxQuantity: 0.1 }]
+      actions: [{ code: 'CSAM3', availability: { value: 0.1, unit: 'ha' }, requiresMaxQuantity: 0.1 }]
     })
     const csam3QuantityInput = form.querySelector('#landActionQuantity_CSAM3')
     csam3QuantityInput.value = '0.10'
@@ -935,40 +860,32 @@ describe('initSelectActionsPage', () => {
     await flushPromises()
 
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
+      actions: [{ code: 'CSAM3', availability: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
     })
-    form.querySelector('input[value="CLIG3"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3')
 
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 0.05, unit: 'ha' }, requiresMaxQuantity: 0.05 }]
+      actions: [{ code: 'CSAM3', availability: { value: 0.05, unit: 'ha' }, requiresMaxQuantity: 0.05 }]
     })
-    csam3QuantityInput.value = '0.05'
-    csam3QuantityInput.dispatchEvent(new Event('input', { bubbles: true }))
-    csam3QuantityInput.dispatchEvent(new Event('blur'))
-    await flushPromises()
+    await typeQuantity(form, 'CSAM3', '0.05')
     global.fetch.mockClear()
 
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
+      actions: [{ code: 'CSAM3', availability: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
     })
-    csam3QuantityInput.value = '0.10'
-    csam3QuantityInput.dispatchEvent(new Event('input', { bubbles: true }))
-    csam3QuantityInput.dispatchEvent(new Event('blur'))
-    await flushPromises()
+    await typeQuantity(form, 'CSAM3', '0.10')
 
     expect(global.fetch).toHaveBeenCalledTimes(1)
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toContainEqual({ actionCode: 'CSAM3', quantity: 0.1, unit: 'ha' })
+    expect(sentPlannedActions()).toContainEqual({ actionCode: 'CSAM3', quantity: 0.1, unit: 'ha' })
   })
 
   it('still blocks an increase above the static uncompeted total', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 },
-      { code: 'CLIG3', availableArea: { value: 0.3271, unit: 'ha' } }
+      { code: 'CSAM3', checked: true, availability: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 },
+      { code: 'CLIG3', availability: { value: 0.3271, unit: 'ha' } }
     ])
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 0.1, unit: 'ha' }, requiresMaxQuantity: 0.1 }]
+      actions: [{ code: 'CSAM3', availability: { value: 0.1, unit: 'ha' }, requiresMaxQuantity: 0.1 }]
     })
     const csam3QuantityInput = form.querySelector('#landActionQuantity_CSAM3')
     csam3QuantityInput.value = '0.10'
@@ -978,29 +895,25 @@ describe('initSelectActionsPage', () => {
     await flushPromises()
 
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
+      actions: [{ code: 'CSAM3', availability: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
     })
-    form.querySelector('input[value="CLIG3"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3')
     global.fetch.mockClear()
 
-    csam3QuantityInput.value = '0.35'
-    csam3QuantityInput.dispatchEvent(new Event('input', { bubbles: true }))
-    csam3QuantityInput.dispatchEvent(new Event('blur'))
-    await flushPromises()
+    await typeQuantity(form, 'CSAM3', '0.35')
 
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
   it('reverts an in-progress invalid quantity edit to the last confirmed value instead of losing the selection', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 },
-      { code: 'CLIG3', availableArea: { value: 0.3271, unit: 'ha' } },
-      { code: 'CMOR1', availableArea: { value: 10, unit: 'ha' } }
+      { code: 'CSAM3', checked: true, availability: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 },
+      { code: 'CLIG3', availability: { value: 0.3271, unit: 'ha' } },
+      { code: 'CMOR1', availability: { value: 10, unit: 'ha' } }
     ])
 
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 }]
+      actions: [{ code: 'CSAM3', availability: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 }]
     })
     const csam3QuantityInput = form.querySelector('#landActionQuantity_CSAM3')
     csam3QuantityInput.value = '0.1'
@@ -1011,12 +924,11 @@ describe('initSelectActionsPage', () => {
 
     global.fetch = fetchOk({
       actions: [
-        { code: 'CSAM3', availableArea: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 },
-        { code: 'CLIG3', availableArea: { value: 0.2271, unit: 'ha' } }
+        { code: 'CSAM3', availability: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 },
+        { code: 'CLIG3', availability: { value: 0.2271, unit: 'ha' } }
       ]
     })
-    form.querySelector('input[value="CLIG3"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3')
 
     // An in-progress edit, never blurred - no refresh fires for this yet.
     csam3QuantityInput.value = '0.4'
@@ -1024,20 +936,18 @@ describe('initSelectActionsPage', () => {
 
     global.fetch = fetchOk({
       actions: [
-        { code: 'CSAM3', availableArea: { value: 0.1271, unit: 'ha' }, requiresMaxQuantity: 0.1271 },
-        { code: 'CMOR1', availableArea: { value: 9.8, unit: 'ha' } }
+        { code: 'CSAM3', availability: { value: 0.1271, unit: 'ha' }, requiresMaxQuantity: 0.1271 },
+        { code: 'CMOR1', availability: { value: 9.8, unit: 'ha' } }
       ]
     })
-    form.querySelector('input[value="CMOR1"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CMOR1')
 
-    const csam3Checkbox = form.querySelector('input[value="CSAM3"]')
+    const csam3Checkbox = checkbox(form, 'CSAM3')
     expect(csam3Checkbox.checked).toBe(true)
     expect(csam3Checkbox.disabled).toBe(false)
     expect(csam3QuantityInput.value).toBe('0.1')
 
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toContainEqual({ actionCode: 'CSAM3', quantity: 0.1, unit: 'ha' })
+    expect(sentPlannedActions()).toContainEqual({ actionCode: 'CSAM3', quantity: 0.1, unit: 'ha' })
   })
 
   it('includes a checked action in plannedActions when a different action is being edited', async () => {
@@ -1045,35 +955,27 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CLIG3',
         checked: true,
-        availableArea: { value: 0.3271, unit: 'ha' },
+        availability: { value: 0.3271, unit: 'ha' },
         requiresMaxQuantity: 0.3271,
         quantityValue: '0.25'
       },
-      { code: 'CSAM3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 }
+      { code: 'CSAM3', checked: true, availability: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 }
     ])
 
-    global.fetch = fetchOk({ actions: [] })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, fetchOk({ actions: [] }))
 
-    const csam3QuantityInput = form.querySelector('#landActionQuantity_CSAM3')
-    csam3QuantityInput.value = '0.0771'
-    csam3QuantityInput.dispatchEvent(new Event('input', { bubbles: true }))
-    csam3QuantityInput.dispatchEvent(new Event('blur'))
-    await flushPromises()
+    await typeQuantity(form, 'CSAM3', '0.0771')
 
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toContainEqual({ actionCode: 'CLIG3', quantity: 0.25, unit: 'ha' })
+    expect(sentPlannedActions()).toContainEqual({ actionCode: 'CLIG3', quantity: 0.25, unit: 'ha' })
   })
 
   // Typing doesn't fire a request at all - only leaving the field does, so
   // rapid successive keystrokes never trigger more than the one refresh
   // that happens on blur.
-  it('sends a non-quantity action its live availableArea from the previous response, not its original total', async () => {
+  it('sends a non-quantity action its live availability from the previous response, not its original total', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 },
-      { code: 'CLIG3', availableArea: { value: 0.3271, unit: 'ha' } }
+      { code: 'CSAM3', checked: true, availability: { value: 0.3271, unit: 'ha' }, requiresMaxQuantity: 0.3271 },
+      { code: 'CLIG3', availability: { value: 0.3271, unit: 'ha' } }
     ])
     initSelectActionsPage(form)
 
@@ -1082,21 +984,17 @@ describe('initSelectActionsPage', () => {
     csam3QuantityInput.dispatchEvent(new Event('input', { bubbles: true }))
     global.fetch = fetchOk({
       actions: [
-        { code: 'CSAM3', availableArea: { value: 0.2271, unit: 'ha' } },
-        { code: 'CLIG3', availableArea: { value: 0.2271, unit: 'ha' } }
+        { code: 'CSAM3', availability: { value: 0.2271, unit: 'ha' } },
+        { code: 'CLIG3', availability: { value: 0.2271, unit: 'ha' } }
       ]
     })
     csam3QuantityInput.dispatchEvent(new Event('blur'))
     await flushPromises()
 
     global.fetch = mockApi({ CSAM3: 0.2271, CLIG3: 0.2271 })
-    const clig3Checkbox = form.querySelector('#landAction-CLIG3')
-    clig3Checkbox.checked = true
-    clig3Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', true)
 
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toContainEqual({
+    expect(sentPlannedActions()).toContainEqual({
       actionCode: 'CLIG3',
       quantity: 0.2271,
       unit: 'ha'
@@ -1105,13 +1003,10 @@ describe('initSelectActionsPage', () => {
 
   it('does not fire a request while typing, only once the field is blurred (which flushes any pending debounce immediately)', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
-      { code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }
+      { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
+      { code: 'UPL1', availability: { value: 5, unit: 'ha' } }
     ])
-    global.fetch = fetchOk({ actions: [] })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, fetchOk({ actions: [] }))
 
     const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
     quantityInput.value = '1'
@@ -1128,19 +1023,15 @@ describe('initSelectActionsPage', () => {
     await flushPromises()
 
     expect(global.fetch).toHaveBeenCalledTimes(1)
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toEqual([{ actionCode: 'CSAM3', quantity: 3, unit: 'ha' }])
+    expect(sentPlannedActions()).toEqual([{ actionCode: 'CSAM3', quantity: 3, unit: 'ha' }])
   })
 
   it('fires a request 500ms after the user stops typing, without waiting for blur', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
-      { code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }
+      { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
+      { code: 'UPL1', availability: { value: 5, unit: 'ha' } }
     ])
-    global.fetch = fetchOk({ actions: [] })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, fetchOk({ actions: [] }))
 
     const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
     quantityInput.value = '1'
@@ -1157,19 +1048,15 @@ describe('initSelectActionsPage', () => {
     // Past the debounce window from the last keystroke - fires on its own.
     await new Promise((resolve) => setTimeout(resolve, 300))
     expect(global.fetch).toHaveBeenCalledTimes(1)
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toEqual([{ actionCode: 'CSAM3', quantity: 3, unit: 'ha' }])
+    expect(sentPlannedActions()).toEqual([{ actionCode: 'CSAM3', quantity: 3, unit: 'ha' }])
   })
 
   it('restarts the 500ms debounce on every keystroke, rather than firing from the first one', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
-      { code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }
+      { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
+      { code: 'UPL1', availability: { value: 5, unit: 'ha' } }
     ])
-    global.fetch = fetchOk({ actions: [] })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, fetchOk({ actions: [] }))
 
     const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
     quantityInput.value = '1'
@@ -1185,14 +1072,13 @@ describe('initSelectActionsPage', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 200))
     expect(global.fetch).toHaveBeenCalledTimes(1)
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toEqual([{ actionCode: 'CSAM3', quantity: 12, unit: 'ha' }])
+    expect(sentPlannedActions()).toEqual([{ actionCode: 'CSAM3', quantity: 12, unit: 'ha' }])
   })
 
   it("shows the triggering action's own refresh banner while a blur-triggered refresh is in flight, hiding it once it resolves, and never shows another action's banner", async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
-      { code: 'UPL1', checked: true, availableArea: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }
+      { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
+      { code: 'UPL1', checked: true, availability: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }
     ])
     global.fetch = fetchOk({ actions: [] })
     initSelectActionsPage(form)
@@ -1205,11 +1091,7 @@ describe('initSelectActionsPage', () => {
           resolveFetch = () => resolve({ ok: true, json: () => Promise.resolve({ actions: [] }) })
         })
     )
-    const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
-    quantityInput.value = '5'
-    quantityInput.dispatchEvent(new Event('input', { bubbles: true }))
-    quantityInput.dispatchEvent(new Event('blur'))
-    await flushPromises()
+    const quantityInput = await typeQuantity(form, 'CSAM3', '5')
 
     const csam3Banner = document.getElementById('landActionQuantity_CSAM3-refresh-banner')
     const upl1Banner = document.getElementById('landActionQuantity_UPL1-refresh-banner')
@@ -1229,8 +1111,8 @@ describe('initSelectActionsPage', () => {
 
   it('shows a lazily-created refresh banner on the checked/unchecked non-quantity action, removing it once the refresh resolves, and never on a different action', async () => {
     const form = setupDom([
-      { code: 'CMOR1', availableArea: { value: 10, unit: 'ha' } },
-      { code: 'UPL1', availableArea: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }
+      { code: 'CMOR1', availability: { value: 10, unit: 'ha' } },
+      { code: 'UPL1', availability: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }
     ])
     // 0 headroom beyond CMOR1's own claim (self-competing, realistic) - not
     // the same static 10 echoed back, which would read as fresh surplus and
@@ -1245,8 +1127,8 @@ describe('initSelectActionsPage', () => {
               json: () =>
                 Promise.resolve({
                   actions: [
-                    { code: 'CMOR1', availableArea: { value: 0, unit: 'ha' } },
-                    { code: 'UPL1', availableArea: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }
+                    { code: 'CMOR1', availability: { value: 0, unit: 'ha' } },
+                    { code: 'UPL1', availability: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }
                   ]
                 })
             })
@@ -1254,11 +1136,9 @@ describe('initSelectActionsPage', () => {
     )
     initSelectActionsPage(form)
 
-    const cmor1Checkbox = form.querySelector('#landAction-CMOR1')
-    cmor1Checkbox.checked = true
-    cmor1Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CMOR1', true)
 
+    const cmor1Checkbox = checkbox(form, 'CMOR1')
     const cmor1Item = cmor1Checkbox.closest('.govuk-checkboxes__item')
     expect(cmor1Item.querySelector('.select-actions-refresh-banner')).not.toBeNull()
 
@@ -1279,8 +1159,8 @@ describe('initSelectActionsPage', () => {
 
   it('keeps the refresh banner visible across a growth follow-up chain, without hiding and re-showing between links', async () => {
     const form = setupDom([
-      { code: 'CMOR1', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, chosenArea: 0.2271 },
-      { code: 'CLIG3', availableArea: { value: 0.3271, unit: 'ha' } }
+      { code: 'CMOR1', checked: true, availability: { value: 0.3271, unit: 'ha' }, chosenArea: 0.2271 },
+      { code: 'CLIG3', availability: { value: 0.3271, unit: 'ha' } }
     ])
     // First call (triggered by checking CLIG3) reports growth for CMOR1;
     // the automatic follow-up it triggers must not let the banner drop in
@@ -1297,15 +1177,13 @@ describe('initSelectActionsPage', () => {
 
     const clig3Checkbox = form.querySelector('#landAction-CLIG3')
     const clig3Item = clig3Checkbox.closest('.govuk-checkboxes__item')
-    clig3Checkbox.checked = true
-    clig3Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', true)
 
     expect(clig3Item.querySelector('.select-actions-refresh-banner')).not.toBeNull()
 
     pending.shift()({
       ok: true,
-      json: () => Promise.resolve({ actions: [{ code: 'CMOR1', availableArea: { value: 0.1, unit: 'ha' } }] })
+      json: () => Promise.resolve({ actions: [{ code: 'CMOR1', availability: { value: 0.1, unit: 'ha' } }] })
     })
     await flushPromises()
 
@@ -1315,7 +1193,7 @@ describe('initSelectActionsPage', () => {
 
     pending.shift()({
       ok: true,
-      json: () => Promise.resolve({ actions: [{ code: 'CMOR1', availableArea: { value: 0, unit: 'ha' } }] })
+      json: () => Promise.resolve({ actions: [{ code: 'CMOR1', availability: { value: 0, unit: 'ha' } }] })
     })
     await flushPromises()
 
@@ -1324,12 +1202,9 @@ describe('initSelectActionsPage', () => {
 
   it.each([[''], ['  ']])('does not fire a request when the quantity field is left empty (%j)', async (typedValue) => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
+      { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
     ])
-    global.fetch = fetchOk({ actions: [] })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
+    await initSettled(form, fetchOk({ actions: [] }))
 
     const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
     quantityInput.value = typedValue
@@ -1344,12 +1219,9 @@ describe('initSelectActionsPage', () => {
     'does not fire a request when the typed quantity is invalid but not empty (%j)',
     async (typedValue) => {
       const form = setupDom([
-        { code: 'CSAM3', checked: true, availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
+        { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
       ])
-      global.fetch = fetchOk({ actions: [] })
-      initSelectActionsPage(form)
-      await flushPromises()
-      global.fetch.mockClear()
+      await initSettled(form, fetchOk({ actions: [] }))
 
       const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
       quantityInput.value = typedValue
@@ -1365,69 +1237,122 @@ describe('initSelectActionsPage', () => {
   // request fires until the user types something within range.
   it('does not fire a request when the typed quantity exceeds the input max', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
+      { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
     ])
-    global.fetch = fetchOk({ actions: [] })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
-
-    const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
-    quantityInput.value = '25'
-    quantityInput.dispatchEvent(new Event('input', { bubbles: true }))
-    quantityInput.dispatchEvent(new Event('blur'))
-    await flushPromises()
+    await initSettled(form, fetchOk({ actions: [] }))
 
     expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('accepts any typed quantity for an action with no availability restriction', async () => {
+    const form = setupDom([
+      {
+        code: 'CSAM3',
+        checked: true,
+        availability: { value: null, unit: 'ha' },
+        requiresMaxQuantity: true,
+        unrestricted: true
+      }
+    ])
+    await initSettled(form, fetchOk({ actions: [] }))
+
+    const quantityInput = await typeQuantity(form, 'CSAM3', '9999')
+
+    expect(global.fetch).toHaveBeenCalled()
+    // Unrestricted or not, it still claims land that competes with everything
+    // else - and the API always gives it a unit, so the claim is sendable.
+    expect(sentPlannedActions()).toEqual([{ actionCode: 'CSAM3', quantity: 9999, unit: 'ha' }])
+    expect(quantityInput.disabled).toBe(false)
+  })
+
+  it('clears the max and hint rather than showing "null" when a refresh reports no restriction', async () => {
+    const form = setupDom([
+      { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
+      { code: 'CLIG3', availability: { value: 45.2, unit: 'ha' } }
+    ])
+    await initSettled(
+      form,
+      fetchOk({
+        actions: [
+          { code: 'CSAM3', availability: { value: null, unit: 'ha' } },
+          { code: 'CLIG3', availability: { value: 45.2, unit: 'ha' } }
+        ]
+      })
+    )
+
+    await toggle(form, 'CLIG3')
+
+    const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
+    expect(quantityInput.hasAttribute('max')).toBe(false)
+    expect(hintFor('CSAM3').textContent).toBe('')
+    expect(checkbox(form, 'CSAM3').getAttribute('data-live-available-area')).toBeNull()
+  })
+
+  it('does not grey out an unchecked, unrestricted action when a quantity is typed into it', async () => {
+    const form = setupDom([
+      { code: 'CSAM3', availability: { value: null, unit: 'ha' }, requiresMaxQuantity: true, unrestricted: true },
+      { code: 'CLIG3', availability: { value: 45.2, unit: 'ha' } }
+    ])
+    await initSettled(
+      form,
+      fetchOk({
+        actions: [
+          { code: 'CSAM3', availability: { value: null, unit: 'ha' } },
+          { code: 'CLIG3', availability: { value: 45.2, unit: 'ha' } }
+        ]
+      })
+    )
+
+    // A typed amount on an unchecked action must not be compared against a null
+    // ceiling - that coerces to 0 and rejects anything above zero.
+    const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
+    quantityInput.value = '12'
+    quantityInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await toggle(form, 'CLIG3')
+
+    expect(global.fetch).toHaveBeenCalled()
+    expect(checkbox(form, 'CSAM3').disabled).toBe(false)
+    expect(quantityInput.value).toBe('12')
   })
 
   it('does not grey out a different, unchecked action when a checked action is given an over-max quantity', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
-      { code: 'CLIG3', availableArea: { value: 45.2, unit: 'ha' } }
+      { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 },
+      { code: 'CLIG3', availability: { value: 45.2, unit: 'ha' } }
     ])
-    global.fetch = mockApi({ CSAM3: 18.5, CLIG3: 45.2 })
-    initSelectActionsPage(form)
-    await flushPromises()
-    global.fetch.mockClear()
-
-    const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
-    quantityInput.value = '25'
-    quantityInput.dispatchEvent(new Event('input', { bubbles: true }))
-    quantityInput.dispatchEvent(new Event('blur'))
-    await flushPromises()
+    await initSettled(form, mockApi({ CSAM3: 18.5, CLIG3: 45.2 }))
 
     expect(global.fetch).not.toHaveBeenCalled()
-    expect(form.querySelector('input[value="CLIG3"]').disabled).toBe(false)
+    expect(checkbox(form, 'CLIG3').disabled).toBe(false)
   })
 
   it('disables and shows a message for an action with 0 available area in the response', async () => {
     const form = setupDom([
-      { code: 'CMOR1', checked: true, availableArea: { value: 10, unit: 'ha' } },
-      { code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }
+      { code: 'CMOR1', checked: true, availability: { value: 10, unit: 'ha' } },
+      { code: 'UPL1', availability: { value: 5, unit: 'ha' } }
     ])
-    global.fetch = fetchOk({ actions: [{ code: 'UPL1', availableArea: { value: 0, unit: 'ha' } }] })
+    global.fetch = fetchOk({ actions: [{ code: 'UPL1', availability: { value: 0, unit: 'ha' } }] })
     initSelectActionsPage(form)
 
-    const cmor1 = form.querySelector('input[value="CMOR1"]')
+    const cmor1 = checkbox(form, 'CMOR1')
     cmor1.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
 
-    const upl1 = form.querySelector('input[value="UPL1"]')
+    const upl1 = checkbox(form, 'UPL1')
     expect(upl1.disabled).toBe(true)
     expect(upl1.closest('.govuk-checkboxes__item').textContent).toContain('Not compatible with other selected actions.')
   })
 
   it('re-enables and clears the message for an action that becomes available again', async () => {
-    const form = setupDom([{ code: 'UPL1', availableArea: { value: 0, unit: 'ha' } }])
-    const upl1 = form.querySelector('input[value="UPL1"]')
+    const form = setupDom([{ code: 'UPL1', availability: { value: 0, unit: 'ha' } }])
+    const upl1 = checkbox(form, 'UPL1')
     upl1.disabled = true
     const message = document.createElement('p')
     message.className = 'select-actions-unavailable-message'
     message.textContent = 'Not compatible with other selected actions.'
     upl1.closest('.govuk-checkboxes__item').appendChild(message)
 
-    global.fetch = fetchOk({ actions: [{ code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }] })
+    global.fetch = fetchOk({ actions: [{ code: 'UPL1', availability: { value: 5, unit: 'ha' } }] })
     initSelectActionsPage(form)
 
     upl1.dispatchEvent(new Event('change', { bubbles: true }))
@@ -1442,21 +1367,18 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 18.5, unit: 'ha' },
+        availability: { value: 18.5, unit: 'ha' },
         requiresMaxQuantity: 18.5,
         quantityValue: '2'
       }
     ])
-    global.fetch = fetchOk({ actions: [{ code: 'CSAM3', availableArea: { value: 18.5, unit: 'ha' } }] })
+    global.fetch = fetchOk({ actions: [{ code: 'CSAM3', availability: { value: 18.5, unit: 'ha' } }] })
     initSelectActionsPage(form)
     await flushPromises()
 
-    const csam3 = form.querySelector('input[value="CSAM3"]')
-    csam3.checked = false
-    csam3.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CSAM3', false)
 
-    expect(csam3.disabled).toBe(false)
+    expect(checkbox(form, 'CSAM3').disabled).toBe(false)
   })
 
   it('clears the quantity input when its action is unchecked', async () => {
@@ -1464,7 +1386,7 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 18.5, unit: 'ha' },
+        availability: { value: 18.5, unit: 'ha' },
         requiresMaxQuantity: 18.5,
         quantityValue: '2'
       }
@@ -1473,7 +1395,7 @@ describe('initSelectActionsPage', () => {
     initSelectActionsPage(form)
     await flushPromises()
 
-    const csam3 = form.querySelector('input[value="CSAM3"]')
+    const csam3 = checkbox(form, 'CSAM3')
     csam3.checked = false
     csam3.dispatchEvent(new Event('change', { bubbles: true }))
 
@@ -1482,70 +1404,66 @@ describe('initSelectActionsPage', () => {
 
   it('updates the data-available-unit attribute but does not disable a non-quantity action whose area is reduced but still non-zero', async () => {
     const form = setupDom([
-      { code: 'CMOR1', checked: true, availableArea: { value: 10, unit: 'ha' } },
-      { code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }
+      { code: 'CMOR1', checked: true, availability: { value: 10, unit: 'ha' } },
+      { code: 'UPL1', availability: { value: 5, unit: 'ha' } }
     ])
-    global.fetch = fetchOk({ actions: [{ code: 'UPL1', availableArea: { value: 2, unit: 'ha' } }] })
+    global.fetch = fetchOk({ actions: [{ code: 'UPL1', availability: { value: 2, unit: 'ha' } }] })
     initSelectActionsPage(form)
 
-    form.querySelector('input[value="CMOR1"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CMOR1')
 
-    const upl1 = form.querySelector('input[value="UPL1"]')
+    const upl1 = checkbox(form, 'UPL1')
     expect(upl1.getAttribute('data-available-unit')).toBe('ha')
     expect(upl1.disabled).toBe(false)
   })
 
   it('updates the quantity input max and hint from the response for an UNCHECKED quantity-required action', async () => {
     const form = setupDom([
-      { code: 'CMOR1', checked: true, availableArea: { value: 10, unit: 'ha' } },
-      { code: 'CSAM3', availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
+      { code: 'CMOR1', checked: true, availability: { value: 10, unit: 'ha' } },
+      { code: 'CSAM3', availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
     ])
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 12, unit: 'ha' }, requiresMaxQuantity: 12 }]
+      actions: [{ code: 'CSAM3', availability: { value: 12, unit: 'ha' }, requiresMaxQuantity: 12 }]
     })
     initSelectActionsPage(form)
 
-    form.querySelector('input[value="CMOR1"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CMOR1')
 
     const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
     expect(quantityInput.max).toBe('12')
-    expect(document.getElementById('landActionQuantity_CSAM3-hint').textContent).toBe('12 hectares available')
+    expect(hintFor('CSAM3').textContent).toBe('12 hectares available')
   })
 
   it('checking an action with no quantity typed yet leaves its own hint/max at the un-competed full total (nothing confirmed yet to send)', async () => {
     const form = setupDom([
-      { code: 'CSAM3', checked: true, availableArea: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
+      { code: 'CSAM3', checked: true, availability: { value: 18.5, unit: 'ha' }, requiresMaxQuantity: 18.5 }
     ])
     global.fetch = mockApi({ CSAM3: 18.5 })
     initSelectActionsPage(form)
 
-    form.querySelector('input[value="CSAM3"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CSAM3')
 
     // No request fires at all (nothing confirmed to send yet, per the
     // checkbox-change guard) - the hint is untouched, still whatever the
     // initial fixture/server-rendered markup set it to.
     const quantityInput = form.querySelector('#landActionQuantity_CSAM3')
     expect(quantityInput.max).toBe('18.5')
-    expect(document.getElementById('landActionQuantity_CSAM3-hint').textContent).toBe('18.5 ha available')
+    expect(hintFor('CSAM3').textContent).toBe('18.5 ha available')
   })
 
   it('hides the conditional reveal panel when a quantity-required action is disabled', async () => {
     const form = setupDom([
-      { code: 'CMOR1', checked: true, availableArea: { value: 10, unit: 'ha' } },
-      { code: 'CSAM3', availableArea: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }
+      { code: 'CMOR1', checked: true, availability: { value: 10, unit: 'ha' } },
+      { code: 'CSAM3', availability: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }
     ])
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
+      actions: [{ code: 'CSAM3', availability: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
     })
     initSelectActionsPage(form)
 
-    form.querySelector('input[value="CMOR1"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CMOR1')
 
-    const csam3 = form.querySelector('input[value="CSAM3"]')
+    const csam3 = checkbox(form, 'CSAM3')
     expect(csam3.disabled).toBe(true)
     expect(isConditionalHidden(csam3)).toBe(true)
   })
@@ -1553,21 +1471,20 @@ describe('initSelectActionsPage', () => {
   // Never force a conditional panel open - that's the browser's job on click.
   it('does not force an unchecked action back open when it becomes available again', async () => {
     const form = setupDom([
-      { code: 'CMOR1', checked: true, availableArea: { value: 10, unit: 'ha' } },
-      { code: 'CSAM3', availableArea: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }
+      { code: 'CMOR1', checked: true, availability: { value: 10, unit: 'ha' } },
+      { code: 'CSAM3', availability: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }
     ])
-    const csam3 = form.querySelector('input[value="CSAM3"]')
+    const csam3 = checkbox(form, 'CSAM3')
     const conditionalId = csam3.getAttribute('aria-controls')
     document.getElementById(conditionalId).classList.add('govuk-checkboxes__conditional--hidden')
     csam3.disabled = true
 
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }]
+      actions: [{ code: 'CSAM3', availability: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }]
     })
     initSelectActionsPage(form)
 
-    form.querySelector('input[value="CMOR1"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CMOR1')
 
     expect(csam3.disabled).toBe(false)
     expect(isConditionalHidden(csam3)).toBe(true)
@@ -1578,18 +1495,18 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 5, unit: 'ha' },
+        availability: { value: 5, unit: 'ha' },
         requiresMaxQuantity: 5,
         quantityValue: '2'
       }
     ])
     global.fetch = fetchOk({
-      actions: [{ code: 'CSAM3', availableArea: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }]
+      actions: [{ code: 'CSAM3', availability: { value: 5, unit: 'ha' }, requiresMaxQuantity: 5 }]
     })
     initSelectActionsPage(form)
     await flushPromises()
 
-    const csam3 = form.querySelector('input[value="CSAM3"]')
+    const csam3 = checkbox(form, 'CSAM3')
     const conditionalId = csam3.getAttribute('aria-controls')
     csam3.checked = false
     // Simulate the browser's native click handling closing the panel
@@ -1606,24 +1523,23 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CLIG3',
         checked: true,
-        availableArea: { value: 0.3271, unit: 'ha' },
+        availability: { value: 0.3271, unit: 'ha' },
         requiresMaxQuantity: 0.3271,
         quantityValue: '0.3271'
       }
     ])
     global.fetch = fetchOk({
-      actions: [{ code: 'CLIG3', availableArea: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
+      actions: [{ code: 'CLIG3', availability: { value: 0, unit: 'ha' }, requiresMaxQuantity: 0 }]
     })
     initSelectActionsPage(form)
 
-    form.querySelector('input[value="CLIG3"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3')
 
-    const clig3 = form.querySelector('input[value="CLIG3"]')
+    const clig3 = checkbox(form, 'CLIG3')
     const quantityInput = form.querySelector('#landActionQuantity_CLIG3')
     expect(clig3.disabled).toBe(false)
     expect(quantityInput.disabled).toBe(false)
-    expect(document.getElementById('landActionQuantity_CLIG3-hint').textContent).toBe('0 hectares available')
+    expect(hintFor('CLIG3').textContent).toBe('0 hectares available')
   })
 
   it('refreshes the hint to the raw response value after a refresh, not the typed value plus it', async () => {
@@ -1631,20 +1547,19 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CLIG3',
         checked: true,
-        availableArea: { value: 0.3271, unit: 'ha' },
+        availability: { value: 0.3271, unit: 'ha' },
         requiresMaxQuantity: 0.3271,
         quantityValue: '0.1'
       }
     ])
     global.fetch = fetchOk({
-      actions: [{ code: 'CLIG3', availableArea: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 }]
+      actions: [{ code: 'CLIG3', availability: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 }]
     })
     initSelectActionsPage(form)
 
-    form.querySelector('input[value="CLIG3"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3')
 
-    expect(document.getElementById('landActionQuantity_CLIG3-hint').textContent).toBe('0.2271 hectares available')
+    expect(hintFor('CLIG3').textContent).toBe('0.2271 hectares available')
   })
 
   // Full sequence from the algorithm this page implements: CSAM3=0.10, then
@@ -1655,18 +1570,18 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 0.3271, unit: 'ha' },
+        availability: { value: 0.3271, unit: 'ha' },
         requiresMaxQuantity: 0.3271,
         quantityValue: '0.10'
       },
-      { code: 'CLIG3', availableArea: { value: 0.3271, unit: 'ha' } },
-      { code: 'CMOR1', availableArea: { value: 0.0301, unit: 'ha' } }
+      { code: 'CLIG3', availability: { value: 0.3271, unit: 'ha' } },
+      { code: 'CMOR1', availability: { value: 0.0301, unit: 'ha' } }
     ])
     global.fetch = fetchOk({
       actions: [
-        { code: 'CSAM3', availableArea: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 },
-        { code: 'CLIG3', availableArea: { value: 0.2271, unit: 'ha' } },
-        { code: 'CMOR1', availableArea: { value: 0.0301, unit: 'ha' } }
+        { code: 'CSAM3', availability: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 },
+        { code: 'CLIG3', availability: { value: 0.2271, unit: 'ha' } },
+        { code: 'CMOR1', availability: { value: 0.0301, unit: 'ha' } }
       ]
     })
     initSelectActionsPage(form)
@@ -1675,28 +1590,24 @@ describe('initSelectActionsPage', () => {
     const clig3Checkbox = form.querySelector('#landAction-CLIG3')
     global.fetch = fetchOk({
       actions: [
-        { code: 'CSAM3', availableArea: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 },
-        { code: 'CLIG3', availableArea: { value: 0, unit: 'ha' } },
-        { code: 'CMOR1', availableArea: { value: 0.0301, unit: 'ha' } }
+        { code: 'CSAM3', availability: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 },
+        { code: 'CLIG3', availability: { value: 0, unit: 'ha' } },
+        { code: 'CMOR1', availability: { value: 0.0301, unit: 'ha' } }
       ]
     })
-    clig3Checkbox.checked = true
-    clig3Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', true)
 
     expect(getChosenAreaFieldValue(clig3Checkbox)).toBe('0.2271')
 
     const cmor1Checkbox = form.querySelector('#landAction-CMOR1')
     global.fetch = fetchOk({
       actions: [
-        { code: 'CSAM3', availableArea: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 },
-        { code: 'CLIG3', availableArea: { value: 0, unit: 'ha' } },
-        { code: 'CMOR1', availableArea: { value: 0, unit: 'ha' } }
+        { code: 'CSAM3', availability: { value: 0.2271, unit: 'ha' }, requiresMaxQuantity: 0.2271 },
+        { code: 'CLIG3', availability: { value: 0, unit: 'ha' } },
+        { code: 'CMOR1', availability: { value: 0, unit: 'ha' } }
       ]
     })
-    cmor1Checkbox.checked = true
-    cmor1Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CMOR1', true)
 
     expect(getChosenAreaFieldValue(cmor1Checkbox)).toBe('0.0301')
   })
@@ -1706,12 +1617,12 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 0.3271, unit: 'ha' },
+        availability: { value: 0.3271, unit: 'ha' },
         requiresMaxQuantity: 0.3271,
         quantityValue: '0.10'
       },
-      { code: 'CLIG3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, chosenArea: 0.2271 },
-      { code: 'CMOR1', checked: true, availableArea: { value: 0.0301, unit: 'ha' }, chosenArea: 0.0301 }
+      { code: 'CLIG3', checked: true, availability: { value: 0.3271, unit: 'ha' }, chosenArea: 0.2271 },
+      { code: 'CMOR1', checked: true, availability: { value: 0.0301, unit: 'ha' }, chosenArea: 0.0301 }
     ])
     // Self-competing on load (everything checked, nothing freed yet) reports
     // no surplus for either non-quantity action.
@@ -1732,19 +1643,16 @@ describe('initSelectActionsPage', () => {
         json: () =>
           Promise.resolve({
             actions: [
-              { code: 'CLIG3', availableArea: { value: surplus, unit: 'ha' } },
-              { code: 'CMOR1', availableArea: { value: surplus, unit: 'ha' } }
+              { code: 'CLIG3', availability: { value: surplus, unit: 'ha' } },
+              { code: 'CMOR1', availability: { value: surplus, unit: 'ha' } }
             ]
           })
       })
     })
-    const csam3 = form.querySelector('input[value="CSAM3"]')
-    csam3.checked = false
-    csam3.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CSAM3', false)
 
-    const clig3 = form.querySelector('input[value="CLIG3"]')
-    const cmor1 = form.querySelector('input[value="CMOR1"]')
+    const clig3 = checkbox(form, 'CLIG3')
+    const cmor1 = checkbox(form, 'CMOR1')
     expect(getChosenAreaFieldValue(clig3)).toBe('0.3271')
     expect(getChosenAreaFieldValue(cmor1)).toBe('0.0301')
   })
@@ -1758,12 +1666,12 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CMOR3',
         checked: true,
-        availableArea: { value: 23.9457, unit: 'ha' },
+        availability: { value: 23.9457, unit: 'ha' },
         requiresMaxQuantity: 23.9457,
         quantityValue: '20'
       },
-      { code: 'CLIG3', checked: true, availableArea: { value: 23.9457, unit: 'ha' }, chosenArea: 2.9957 },
-      { code: 'CMOR1', checked: true, availableArea: { value: 23.9457, unit: 'ha' }, chosenArea: 0.975 }
+      { code: 'CLIG3', checked: true, availability: { value: 23.9457, unit: 'ha' }, chosenArea: 2.9957 },
+      { code: 'CMOR1', checked: true, availability: { value: 23.9457, unit: 'ha' }, chosenArea: 0.975 }
     ])
     global.fetch = mockApi({ CLIG3: 2.9957, CMOR1: 0.975 })
     initSelectActionsPage(form)
@@ -1781,19 +1689,16 @@ describe('initSelectActionsPage', () => {
         json: () =>
           Promise.resolve({
             actions: [
-              { code: 'CLIG3', availableArea: { value: stillFree ? 20 : 0, unit: 'ha' } },
-              { code: 'CMOR1', availableArea: { value: stillFree ? 20 : 0, unit: 'ha' } }
+              { code: 'CLIG3', availability: { value: stillFree ? 20 : 0, unit: 'ha' } },
+              { code: 'CMOR1', availability: { value: stillFree ? 20 : 0, unit: 'ha' } }
             ]
           })
       })
     })
-    const cmor3 = form.querySelector('input[value="CMOR3"]')
-    cmor3.checked = false
-    cmor3.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CMOR3', false)
 
-    const clig3 = form.querySelector('input[value="CLIG3"]')
-    const cmor1 = form.querySelector('input[value="CMOR1"]')
+    const clig3 = checkbox(form, 'CLIG3')
+    const cmor1 = checkbox(form, 'CMOR1')
     expect(getChosenAreaFieldValue(clig3)).toBe('22.9957')
     expect(getChosenAreaFieldValue(cmor1)).toBe('0.975')
   })
@@ -1806,11 +1711,11 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 22.9957, unit: 'ha' },
+        availability: { value: 22.9957, unit: 'ha' },
         requiresMaxQuantity: 22.9957,
         quantityValue: '20'
       },
-      { code: 'CLIG3', checked: true, availableArea: { value: 22.9957, unit: 'ha' }, chosenArea: 2.9957 }
+      { code: 'CLIG3', checked: true, availability: { value: 22.9957, unit: 'ha' }, chosenArea: 2.9957 }
     ])
     global.fetch = mockApi({ CLIG3: 2.9957 })
     initSelectActionsPage(form)
@@ -1833,23 +1738,21 @@ describe('initSelectActionsPage', () => {
             actions: [
               {
                 code: 'CSAM3',
-                availableArea: { value: csam3Available, unit: 'ha' },
+                availability: { value: csam3Available, unit: 'ha' },
                 requiresMaxQuantity: csam3Available
               },
-              { code: 'CLIG3', availableArea: { value: clig3Available, unit: 'ha' } }
+              { code: 'CLIG3', availability: { value: clig3Available, unit: 'ha' } }
             ]
           })
       })
     })
-    const csam3 = form.querySelector('input[value="CSAM3"]')
-    csam3.checked = false
-    csam3.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CSAM3', false)
 
-    const clig3 = form.querySelector('input[value="CLIG3"]')
+    const clig3 = checkbox(form, 'CLIG3')
+    const csam3 = checkbox(form, 'CSAM3')
     expect(getChosenAreaFieldValue(clig3)).toBe('22.9957')
     expect(csam3.disabled).toBe(true)
-    expect(document.getElementById('landActionQuantity_CSAM3-hint').textContent).toBe('0 hectares available')
+    expect(hintFor('CSAM3').textContent).toBe('0 hectares available')
     expect(csam3.closest('.govuk-checkboxes__item').textContent).toContain(
       'Not compatible with other selected actions.'
     )
@@ -1860,12 +1763,12 @@ describe('initSelectActionsPage', () => {
       {
         code: 'CSAM3',
         checked: true,
-        availableArea: { value: 0.3271, unit: 'ha' },
+        availability: { value: 0.3271, unit: 'ha' },
         requiresMaxQuantity: 0.3271,
         quantityValue: '0.10'
       },
-      { code: 'CLIG3', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, chosenArea: 0.2271 },
-      { code: 'CMOR1', checked: true, availableArea: { value: 0.0301, unit: 'ha' }, chosenArea: 0.0301 }
+      { code: 'CLIG3', checked: true, availability: { value: 0.3271, unit: 'ha' }, chosenArea: 0.2271 },
+      { code: 'CMOR1', checked: true, availability: { value: 0.0301, unit: 'ha' }, chosenArea: 0.0301 }
     ])
     // 0.1ha surplus is only genuinely available once - growth (both the
     // initial checked-on-load refresh and any follow-up it triggers) must
@@ -1879,8 +1782,8 @@ describe('initSelectActionsPage', () => {
         json: () =>
           Promise.resolve({
             actions: [
-              { code: 'CLIG3', availableArea: { value, unit: 'ha' } },
-              { code: 'CMOR1', availableArea: { value, unit: 'ha' } }
+              { code: 'CLIG3', availability: { value, unit: 'ha' } },
+              { code: 'CMOR1', availability: { value, unit: 'ha' } }
             ]
           })
       })
@@ -1888,35 +1791,28 @@ describe('initSelectActionsPage', () => {
     initSelectActionsPage(form)
     await flushPromises()
 
-    const csam3 = form.querySelector('input[value="CSAM3"]')
-    csam3.checked = false
-    csam3.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CSAM3', false)
 
     // CLIG3 already claimed the only surplus during the initial load's
     // refresh (only one non-quantity action may grow per response) - CMOR1
     // never had anything left to grow into, so it's still at its flat 0.0301.
     global.fetch = mockApi({ CMOR1: 0.0301 })
-    const clig3 = form.querySelector('input[value="CLIG3"]')
-    clig3.checked = false
-    clig3.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', false)
 
-    const [, options] = global.fetch.mock.calls[0]
-    expect(JSON.parse(options.body).plannedActions).toEqual([{ actionCode: 'CMOR1', quantity: 0.0301, unit: 'ha' }])
+    expect(sentPlannedActions()).toEqual([{ actionCode: 'CMOR1', quantity: 0.0301, unit: 'ha' }])
   })
 
   it('ignores an out-of-order (stale) response', async () => {
     const form = setupDom([
-      { code: 'CMOR1', checked: true, availableArea: { value: 10, unit: 'ha' } },
-      { code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }
+      { code: 'CMOR1', checked: true, availability: { value: 10, unit: 'ha' } },
+      { code: 'UPL1', availability: { value: 5, unit: 'ha' } }
     ])
     let resolveFirst
     const firstResponse = new Promise((resolve) => {
       resolveFirst = () =>
         resolve({
           ok: true,
-          json: () => Promise.resolve({ actions: [{ code: 'UPL1', availableArea: { value: 0, unit: 'ha' } }] })
+          json: () => Promise.resolve({ actions: [{ code: 'UPL1', availability: { value: 0, unit: 'ha' } }] })
         })
     })
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ actions: [] }) })
@@ -1929,52 +1825,51 @@ describe('initSelectActionsPage', () => {
       .mockImplementationOnce(() =>
         Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ actions: [{ code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }] })
+          json: () => Promise.resolve({ actions: [{ code: 'UPL1', availability: { value: 5, unit: 'ha' } }] })
         })
       )
 
-    const cmor1 = form.querySelector('input[value="CMOR1"]')
+    const cmor1 = checkbox(form, 'CMOR1')
     cmor1.dispatchEvent(new Event('change', { bubbles: true }))
     cmor1.dispatchEvent(new Event('change', { bubbles: true }))
     await flushPromises()
     resolveFirst()
     await flushPromises()
 
-    const upl1 = form.querySelector('input[value="UPL1"]')
+    const upl1 = checkbox(form, 'UPL1')
     expect(upl1.disabled).toBe(false)
   })
 
   it('does nothing when the fetch call fails', async () => {
-    const form = setupDom([{ code: 'CMOR1', checked: true, availableArea: { value: 10, unit: 'ha' } }])
+    const form = setupDom([
+      { code: 'CMOR1', checked: true, availability: { value: 10, unit: 'ha' } },
+      { code: 'UPL1', availability: { value: 5, unit: 'ha' } }
+    ])
     global.fetch = vi.fn().mockRejectedValue(new Error('network error'))
     initSelectActionsPage(form)
 
-    const checkbox = form.querySelector('input[value="CMOR1"]')
-    const action = async () => {
-      checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-      await Promise.resolve()
-      await Promise.resolve()
-    }
+    await toggle(form, 'CMOR1')
 
-    await expect(action()).resolves.toBeUndefined()
+    expect(global.fetch).toHaveBeenCalled()
+    expect(checkbox(form, 'UPL1').disabled).toBe(false)
+    expect(checkbox(form, 'CMOR1').checked).toBe(true)
   })
 
   it('does nothing when the response is not ok', async () => {
     const form = setupDom([
-      { code: 'CMOR1', checked: true, availableArea: { value: 10, unit: 'ha' } },
-      { code: 'UPL1', availableArea: { value: 5, unit: 'ha' } }
+      { code: 'CMOR1', checked: true, availability: { value: 10, unit: 'ha' } },
+      { code: 'UPL1', availability: { value: 5, unit: 'ha' } }
     ])
     global.fetch = vi.fn().mockResolvedValue({ ok: false })
     initSelectActionsPage(form)
 
-    form.querySelector('input[value="UPL1"]').dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'UPL1')
 
-    expect(form.querySelector('input[value="UPL1"]').disabled).toBe(false)
+    expect(checkbox(form, 'UPL1').disabled).toBe(false)
   })
 
-  it('ignores unrelated form input events', async () => {
-    const form = setupDom([{ code: 'CMOR1', availableArea: { value: 10, unit: 'ha' } }])
+  it('ignores unrelated form input events', () => {
+    const form = setupDom([{ code: 'CMOR1', availability: { value: 10, unit: 'ha' } }])
     const other = document.createElement('input')
     other.name = 'crumb'
     form.appendChild(other)
@@ -1988,8 +1883,8 @@ describe('initSelectActionsPage', () => {
 
   it('keeps other actions disabled continuously across a growth follow-up chain, without a re-enabled gap between links', async () => {
     const form = setupDom([
-      { code: 'CMOR1', checked: true, availableArea: { value: 0.3271, unit: 'ha' }, chosenArea: 0.2271 },
-      { code: 'CLIG3', availableArea: { value: 0.3271, unit: 'ha' } }
+      { code: 'CMOR1', checked: true, availability: { value: 0.3271, unit: 'ha' }, chosenArea: 0.2271 },
+      { code: 'CLIG3', availability: { value: 0.3271, unit: 'ha' } }
     ])
     // First call (triggered by checking CLIG3) reports growth for CMOR1;
     // applyRefreshResponse re-enables CMOR1 as part of applying that growth,
@@ -2005,17 +1900,14 @@ describe('initSelectActionsPage', () => {
     initSelectActionsPage(form)
     await flushPromises()
 
-    const clig3Checkbox = form.querySelector('#landAction-CLIG3')
     const cmor1Checkbox = form.querySelector('#landAction-CMOR1')
-    clig3Checkbox.checked = true
-    clig3Checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-    await flushPromises()
+    await toggle(form, 'CLIG3', true)
 
     expect(cmor1Checkbox.disabled).toBe(true)
 
     pending.shift()({
       ok: true,
-      json: () => Promise.resolve({ actions: [{ code: 'CMOR1', availableArea: { value: 0.1, unit: 'ha' } }] })
+      json: () => Promise.resolve({ actions: [{ code: 'CMOR1', availability: { value: 0.1, unit: 'ha' } }] })
     })
     await flushPromises()
 
@@ -2025,7 +1917,7 @@ describe('initSelectActionsPage', () => {
 
     pending.shift()({
       ok: true,
-      json: () => Promise.resolve({ actions: [{ code: 'CMOR1', availableArea: { value: 0, unit: 'ha' } }] })
+      json: () => Promise.resolve({ actions: [{ code: 'CMOR1', availability: { value: 0, unit: 'ha' } }] })
     })
     await flushPromises()
 

--- a/src/contracts/v2/land-grants.client.contract.test.js
+++ b/src/contracts/v2/land-grants.client.contract.test.js
@@ -445,22 +445,20 @@ describe('parcels', () => {
       actions: [
         {
           code: 'CLIG3',
-          availability: { value: 10.5, unit: 'ha' },
+          availability: { value: 10.5, unit: 'ha', type: 'total' },
           description: 'Manage grassland with very low nutrient inputs',
           ratePerUnitGbp: 10.6,
           ratePerAgreementPerYearGbp: 272,
           guidanceUrl: string(
             'https://www.gov.uk/find-funding-for-land-or-farms/clig3-manage-grassland-with-very-low-nutrient-inputs'
-          ),
-          inputRequired: false
+          )
         },
         {
           code: 'CSAM3',
-          availability: { value: 20.75, unit: 'ha' },
+          availability: { value: 20.75, unit: 'ha', type: 'partial' },
           description: 'Herbal leys',
           ratePerUnitGbp: 224,
-          guidanceUrl: string('https://www.gov.uk/find-funding-for-land-or-farms/csam3-herbal-leys'),
-          inputRequired: true
+          guidanceUrl: string('https://www.gov.uk/find-funding-for-land-or-farms/csam3-herbal-leys')
         }
       ]
     }
@@ -487,11 +485,11 @@ describe('parcels', () => {
 
         expect(response.parcels[0].actions[0].code).toBe('CLIG3')
         expect(response.parcels[0].actions[0].guidanceUrl).toEqual(expect.any(String))
-        expect(response.parcels[0].actions[0].inputRequired).toBe(false)
+        expect(response.parcels[0].actions[0].availability.type).toBe('total')
 
         expect(response.parcels[0].actions[1].code).toBe('CSAM3')
         expect(response.parcels[0].actions[1].guidanceUrl).toEqual(expect.any(String))
-        expect(response.parcels[0].actions[1].inputRequired).toBe(true)
+        expect(response.parcels[0].actions[1].availability.type).toBe('partial')
       }
     )
   })

--- a/src/contracts/v2/land-grants.client.contract.test.js
+++ b/src/contracts/v2/land-grants.client.contract.test.js
@@ -26,6 +26,16 @@ const postToLandGrantsApi = (endpoint, body, baseUrl) => postToLandGrantsApiClie
 
 const validateApplication = (request, baseUrl) => validate(request, baseUrl, userContext)
 
+const JSON_HEADERS = { 'Content-Type': 'application/json' }
+const CALCULATE_PATH = '/api/v2/payments/calculate'
+const PARCELS_PATH = '/api/v2/parcels'
+const VALIDATE_PATH = '/api/v2/application/validate'
+
+const PARCEL_8083 = { sheetId: 'SD6743', parcelId: '8083' }
+const HAS_8083 = { parcels: [PARCEL_8083] }
+const HAS_NO_PARCELS = { parcels: [] }
+const HAS_5677 = { parcels: [{ sheetId: 'SD7861', parcelId: '5677' }] }
+
 function createProvider() {
   return new PactV3({
     dir: path.resolve(process.cwd(), 'src/contracts/pacts'),
@@ -34,6 +44,66 @@ function createProvider() {
     spec: SpecificationVersion.SPECIFICATION_VERSION_V4,
     port: 0
   })
+}
+
+/**
+ * Register one interaction and run `assert` against the mock provider.
+ * `given` is optional - a malformed request never reaches parcel lookup, so
+ * those interactions carry no provider state.
+ */
+function pactInteraction({ given, receiving, path: requestPath, body, status, responseBody }, assert) {
+  const provider = createProvider()
+  const withState = given ? provider.given('has parcels', given) : provider
+
+  return withState
+    .uponReceiving(receiving)
+    .withRequest({ method: 'POST', path: requestPath, headers: makeLandGrantsHeaders(), body })
+    .willRespondWith({ status, headers: JSON_HEADERS, body: like(responseBody) })
+    .executeTest(assert)
+}
+
+/**
+ * Register an error interaction and return whatever the client rejected with,
+ * for the calling test to assert on.
+ */
+async function catchApiError({ path: requestPath, body, status, error, message, call, ...rest }) {
+  let caught
+  await pactInteraction(
+    { path: requestPath, body, status, responseBody: { statusCode: status, error, message }, ...rest },
+    async (mockserver) => {
+      caught = await call(mockserver.url).then(
+        () => new Error('expected the request to be rejected'),
+        (rejection) => rejection
+      )
+    }
+  )
+  return caught
+}
+
+/** An error contract exercised through the generic POST client. */
+const catchPostError = ({ path: requestPath, body, ...rest }) =>
+  catchApiError({
+    path: requestPath,
+    body,
+    call: (baseUrl) => postToLandGrantsApi(requestPath, body, baseUrl),
+    ...rest
+  })
+
+/** An error contract exercised through `validate()`, which appends the sbi itself. */
+const catchValidateError = ({ payload, ...rest }) =>
+  catchApiError({
+    path: VALIDATE_PATH,
+    body: { ...payload, sbi: userContext.sbi },
+    call: (baseUrl) => validateApplication(payload, baseUrl),
+    ...rest
+  })
+
+/** Every validate response carries per-action rule outcomes. */
+const expectValidatedActionShape = (response) => {
+  expect(response.actions.length).toBeGreaterThan(0)
+  expect(response.actions[0]).toHaveProperty('actionCode')
+  expect(response.actions[0]).toHaveProperty('hasPassed')
+  expect(response.actions[0]).toHaveProperty('rules')
 }
 
 describe('calculate', () => {
@@ -163,323 +233,152 @@ describe('calculate', () => {
         }
       ]
     }
-    const EXPECTED_BODY = like({
-      message: 'success',
-      payment: calculateResponseContract
-    })
-    const provider = createProvider()
-    await provider
-      .given('has parcels', {
-        parcels: [
-          { sheetId: 'SD6743', parcelId: '8083' },
-          { sheetId: 'SD6743', parcelId: '8084' }
-        ]
-      })
-      .uponReceiving('a calculate request for a valid parcel and action')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/payments/calculate',
-        headers: makeLandGrantsHeaders(),
-        body: payload
-      })
-      .willRespondWith({
+
+    await pactInteraction(
+      {
+        given: {
+          parcels: [
+            { sheetId: 'SD6743', parcelId: '8083' },
+            { sheetId: 'SD6743', parcelId: '8084' }
+          ]
+        },
+        receiving: 'a calculate request for a valid parcel and action',
+        path: CALCULATE_PATH,
+        body: payload,
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
-        const response = await postToLandGrantsApi('/api/v2/payments/calculate', payload, mockserver.url)
+        responseBody: { message: 'success', payment: calculateResponseContract }
+      },
+      async (mockserver) => {
+        const response = await postToLandGrantsApi(CALCULATE_PATH, payload, mockserver.url)
         expect(response.payment).toEqual(expectedPaymentResponse)
-      })
+      }
+    )
   })
 
-  it('returns HTTP 400 when parcel is invalid', async () => {
-    const badRequestPayload = {
-      parcel: [
-        {
-          sheetId: 'INVALID',
-          parcelId: 'PARCEL',
-          actions: [
-            {
-              code: 'CMOR1',
-              quantity: 1.0
-            }
-          ]
-        }
-      ]
-    }
-    const notFoundResponseExample = {
-      statusCode: 400,
-      error: 'Bad Request',
-      message: 'Land parcels not found: INVALID-PARCEL'
-    }
-    const EXPECTED_BODY = like(notFoundResponseExample)
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [] })
-      .uponReceiving('a calculate request for an invalid parcel')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/payments/calculate',
-        headers: makeLandGrantsHeaders(),
-        body: badRequestPayload
-      })
-      .willRespondWith({
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
-        await expect(
-          postToLandGrantsApi('/api/v2/payments/calculate', badRequestPayload, mockserver.url)
-        ).rejects.toMatchObject({ code: 400, status: 400 })
-      })
-  })
+  it.each([
+    [
+      400,
+      'a calculate request for an invalid parcel',
+      HAS_NO_PARCELS,
+      { parcel: [{ sheetId: 'INVALID', parcelId: 'PARCEL', actions: [{ code: 'CMOR1', quantity: 1.0 }] }] },
+      'Bad Request',
+      'Land parcels not found: INVALID-PARCEL'
+    ],
+    [
+      400,
+      'a calculate request for an invalid action',
+      HAS_8083,
+      { parcel: [{ ...PARCEL_8083, actions: [{ code: 'INVALID_ACTION', quantity: 1.0 }] }] },
+      'Bad Request',
+      'Actions not found: INVALID_ACTION'
+    ],
+    [
+      422,
+      'a calculate request with invalid quantity',
+      HAS_8083,
+      { parcel: [{ ...PARCEL_8083, actions: [{ code: 'UPL1', quantity: 'invalid quantity provided' }] }] },
+      'Unprocessable Entity',
+      'Quantity must be a positive number'
+    ],
+    [
+      422,
+      'a calculate request with a negative quantity',
+      HAS_8083,
+      { parcel: [{ ...PARCEL_8083, actions: [{ code: 'UPL1', quantity: -5.0 }] }] },
+      'Unprocessable Entity',
+      'Quantity must be a positive number'
+    ]
+  ])('returns HTTP %s for %s', async (status, receiving, given, body, error, message) => {
+    const caught = await catchPostError({ path: CALCULATE_PATH, status, receiving, given, body, error, message })
 
-  it('returns HTTP 400 when action code is invalid', async () => {
-    const badRequestPayload = {
-      parcel: [
-        {
-          sheetId: 'SD6743',
-          parcelId: '8083',
-          actions: [
-            {
-              code: 'INVALID_ACTION',
-              quantity: 1.0
-            }
-          ]
-        }
-      ]
-    }
-    const notFoundResponseExample = {
-      statusCode: 400,
-      error: 'Bad Request',
-      message: 'Actions not found: INVALID_ACTION'
-    }
-    const EXPECTED_BODY = like(notFoundResponseExample)
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a calculate request for an invalid action')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/payments/calculate',
-        headers: makeLandGrantsHeaders(),
-        body: badRequestPayload
-      })
-      .willRespondWith({
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
-        await expect(
-          postToLandGrantsApi('/api/v2/payments/calculate', badRequestPayload, mockserver.url)
-        ).rejects.toMatchObject({ code: 400, status: 400 })
-      })
-  })
-
-  it('returns HTTP 422 when quantity is a string', async () => {
-    const invalidQuantityPayload = {
-      parcel: [
-        {
-          sheetId: 'SD6743',
-          parcelId: '8083',
-          actions: [
-            {
-              code: 'UPL1',
-              quantity: 'invalid quantity provided'
-            }
-          ]
-        }
-      ]
-    }
-    const unprocessableResponseExample = {
-      statusCode: 422,
-      error: 'Unprocessable Entity',
-      message: 'Quantity must be a positive number'
-    }
-    const EXPECTED_BODY = like(unprocessableResponseExample)
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a calculate request with invalid quantity')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/payments/calculate',
-        headers: makeLandGrantsHeaders(),
-        body: invalidQuantityPayload
-      })
-      .willRespondWith({
-        status: 422,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
-        await expect(
-          postToLandGrantsApi('/api/v2/payments/calculate', invalidQuantityPayload, mockserver.url)
-        ).rejects.toMatchObject({ code: 422, status: 422 })
-      })
-  })
-
-  it('returns HTTP 422 when quantity is negative', async () => {
-    const invalidQuantityPayload = {
-      parcel: [
-        {
-          sheetId: 'SD6743',
-          parcelId: '8083',
-          actions: [
-            {
-              code: 'UPL1',
-              quantity: -5.0
-            }
-          ]
-        }
-      ]
-    }
-    const unprocessableResponseExample = {
-      statusCode: 422,
-      error: 'Unprocessable Entity',
-      message: 'Quantity must be a positive number'
-    }
-    const EXPECTED_BODY = like(unprocessableResponseExample)
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a calculate request with a negative quantity')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/payments/calculate',
-        headers: makeLandGrantsHeaders(),
-        body: invalidQuantityPayload
-      })
-      .willRespondWith({
-        status: 422,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
-        await expect(
-          postToLandGrantsApi('/api/v2/payments/calculate', invalidQuantityPayload, mockserver.url)
-        ).rejects.toMatchObject({ code: 422, status: 422 })
-      })
+    expect(caught).toMatchObject({ code: status, status })
   })
 })
 
 describe('parcels', () => {
-  it('returns HTTP 400 when passing a wrong field name', async () => {
-    const badRequestResponseExample = {
-      statusCode: 400,
-      error: 'Bad Request',
-      message: '"fields[0]" must be one of [size, actions, actions.results]'
-    }
-    const EXPECTED_BODY = like(badRequestResponseExample)
+  it.each([
+    [
+      400,
+      'a v2 request for a wrong field name',
+      HAS_8083,
+      { parcelIds: ['SD6743-8083'], fields: ['WRONG'], sbi: userContext.sbi },
+      'Bad Request',
+      '"fields[0]" must be one of [size, actions, actions.results]'
+    ],
+    [
+      400,
+      'a v2 request for a malformed parcel with size field',
+      undefined,
+      { parcelIds: ['BADFORMAT-91977'], fields: ['size'], sbi: userContext.sbi },
+      'Bad Request',
+      '"parcelIds[0]" with value "BADFORMAT-91977" fails to match the required pattern: /^[A-Za-z0-9]{6}-[0-9]{4}$/'
+    ],
+    [
+      404,
+      'a v2 request for a not found parcel with size field',
+      HAS_NO_PARCELS,
+      { parcelIds: ['SD6843-1234'], fields: ['size'], sbi: userContext.sbi },
+      'Not Found',
+      'Land parcel not found: SD6843-1234'
+    ],
+    [
+      400,
+      'a v2 request for multiple parcels with SSSI consent information',
+      {
+        parcels: [
+          { sheetId: 'SD6743', parcelId: '8083' },
+          { sheetId: 'SD6743', parcelId: '8084' }
+        ]
+      },
+      {
+        parcelIds: ['SD6743-8083', 'SD6743-8084'],
+        fields: ['actions', 'size', 'actions.sssiConsentRequired'],
+        plannedActions: [],
+        sbi: userContext.sbi
+      },
+      'Bad Request',
+      'SSSI consent required is not supported for multiple parcels.'
+    ],
+    [
+      400,
+      'a v2 request for a malformed parcel with actions and size',
+      undefined,
+      { parcelIds: ['MALFORMED-PARCEL'], fields: ['actions', 'size'], plannedActions: [], sbi: userContext.sbi },
+      'Bad Request',
+      '"parcelIds[0]" with value "MALFORMED-PARCEL" fails to match the required pattern: /^[A-Za-z0-9]{6}-[0-9]{4}$/'
+    ],
+    [
+      404,
+      'a v2 request for a not found parcel with actions and size',
+      HAS_NO_PARCELS,
+      { parcelIds: ['SD1234-5678'], fields: ['actions', 'size'], plannedActions: [], sbi: userContext.sbi },
+      'Not Found',
+      'Land parcel not found: SD1234-5678'
+    ]
+  ])('returns HTTP %s for %s', async (status, receiving, given, body, error, message) => {
+    const caught = await catchPostError({ path: PARCELS_PATH, status, receiving, given, body, error, message })
 
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a v2 request for a wrong field name')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/parcels',
-        headers: makeLandGrantsHeaders(),
-        body: { parcelIds: ['SD6743-8083'], fields: ['WRONG'], sbi: userContext.sbi }
-      })
-      .willRespondWith({ status: 400, headers: { 'Content-Type': 'application/json' }, body: EXPECTED_BODY })
-      .executeTest(async (mockserver) => {
-        await expect(
-          postToLandGrantsApi(
-            '/api/v2/parcels',
-            { parcelIds: ['SD6743-8083'], fields: ['WRONG'], sbi: userContext.sbi },
-            mockserver.url
-          )
-        ).rejects.toMatchObject({ code: 400, status: 400 })
-      })
+    expect(caught).toMatchObject({ code: status, status })
   })
 
   it('returns HTTP 200 and a list of parcels with size', async () => {
     const parcelWithSizeExample = { sheetId: 'SD6743', parcelId: '8083', size: { value: 23.3424, unit: 'ha' } }
-    const EXPECTED_BODY = like({ message: 'success', parcels: eachLike(parcelWithSizeExample) })
+    const requestBody = { parcelIds: ['SD6743-8083'], fields: ['size'], sbi: userContext.sbi }
 
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a v2 request for specific parcels with size field')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/parcels',
-        headers: makeLandGrantsHeaders(),
-        body: { parcelIds: ['SD6743-8083'], fields: ['size'], sbi: userContext.sbi }
-      })
-      .willRespondWith({ status: 200, headers: { 'Content-Type': 'application/json' }, body: EXPECTED_BODY })
-      .executeTest(async (mockserver) => {
-        const response = await postToLandGrantsApi(
-          '/api/v2/parcels',
-          { parcelIds: ['SD6743-8083'], fields: ['size'], sbi: userContext.sbi },
-          mockserver.url
-        )
+    await pactInteraction(
+      {
+        given: HAS_8083,
+        receiving: 'a v2 request for specific parcels with size field',
+        path: PARCELS_PATH,
+        body: requestBody,
+        status: 200,
+        responseBody: { message: 'success', parcels: eachLike(parcelWithSizeExample) }
+      },
+      async (mockserver) => {
+        const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
         expect(response.parcels[0]).toEqual(parcelWithSizeExample)
-      })
-  })
-
-  it('returns HTTP 400 when passing a wrong formatted parcel', async () => {
-    const badRequestResponseExample = {
-      statusCode: 400,
-      error: 'Bad Request',
-      message:
-        '"parcelIds[0]" with value "BADFORMAT-91977" fails to match the required pattern: /^[A-Za-z0-9]{6}-[0-9]{4}$/'
-    }
-    const EXPECTED_BODY = like(badRequestResponseExample)
-
-    const provider = createProvider()
-    await provider
-      .uponReceiving('a v2 request for a malformed parcel with size field')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/parcels',
-        headers: makeLandGrantsHeaders(),
-        body: { parcelIds: ['BADFORMAT-91977'], fields: ['size'], sbi: userContext.sbi }
-      })
-      .willRespondWith({ status: 400, headers: { 'Content-Type': 'application/json' }, body: EXPECTED_BODY })
-      .executeTest(async (mockserver) => {
-        await expect(
-          postToLandGrantsApi(
-            '/api/v2/parcels',
-            { parcelIds: ['BADFORMAT-91977'], fields: ['size'], sbi: userContext.sbi },
-            mockserver.url
-          )
-        ).rejects.toMatchObject({ code: 400, status: 400 })
-      })
-  })
-
-  it('returns HTTP 404 when parcel with size field is not found', async () => {
-    const notFoundParcelExample = {
-      statusCode: 404,
-      error: 'Not Found',
-      message: 'Land parcel not found: SD6843-1234'
-    }
-    const EXPECTED_BODY = like(notFoundParcelExample)
-
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [] })
-      .uponReceiving('a v2 request for a not found parcel with size field')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/parcels',
-        headers: makeLandGrantsHeaders(),
-        body: { parcelIds: ['SD6843-1234'], fields: ['size'], sbi: userContext.sbi }
-      })
-      .willRespondWith({ status: 404, headers: { 'Content-Type': 'application/json' }, body: EXPECTED_BODY })
-      .executeTest(async (mockserver) => {
-        await expect(
-          postToLandGrantsApi(
-            '/api/v2/parcels',
-            { parcelIds: ['SD6843-1234'], fields: ['size'], sbi: userContext.sbi },
-            mockserver.url
-          )
-        ).rejects.toMatchObject({ code: 404, status: 404 })
-      })
+      }
+    )
   })
 
   it('returns HTTP 200 with consent information for a single parcel', async () => {
@@ -490,7 +389,7 @@ describe('parcels', () => {
       actions: [
         {
           code: 'CMOR1',
-          availableArea: { value: 10.5, unit: 'ha' },
+          availability: { value: 10.5, unit: 'ha' },
           description: 'Assess moorland and produce a written record',
           ratePerUnitGbp: 10.6,
           ratePerAgreementPerYearGbp: 272,
@@ -499,7 +398,7 @@ describe('parcels', () => {
         },
         {
           code: 'UPL1',
-          availableArea: { value: 20.75, unit: 'ha' },
+          availability: { value: 20.75, unit: 'ha' },
           description: 'Moderate livestock grazing on moorland',
           ratePerUnitGbp: 20,
           sssiConsentRequired: true,
@@ -507,7 +406,7 @@ describe('parcels', () => {
         },
         {
           code: 'UPL2',
-          availableArea: { value: 15.25, unit: 'ha' },
+          availability: { value: 15.25, unit: 'ha' },
           description: 'Moderate livestock grazing on moorland',
           ratePerUnitGbp: 53,
           sssiConsentRequired: true,
@@ -515,45 +414,27 @@ describe('parcels', () => {
         }
       ]
     }
-    const EXPECTED_BODY = like({ message: 'success', parcels: eachLike(parcelWithConsentExample) })
+    const requestBody = {
+      parcelIds: ['SD6743-8083'],
+      fields: ['actions', 'size', 'actions.sssiConsentRequired', 'actions.heferRequired'],
+      sbi: userContext.sbi
+    }
 
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a v2 request for a single parcel with SSSI consent information')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/parcels',
-        headers: makeLandGrantsHeaders(),
-        body: {
-          parcelIds: ['SD6743-8083'],
-          fields: ['actions', 'size', 'actions.sssiConsentRequired', 'actions.heferRequired'],
-          sbi: userContext.sbi
-        }
-      })
-      .willRespondWith({ status: 200, headers: { 'Content-Type': 'application/json' }, body: EXPECTED_BODY })
-      .executeTest(async (mockserver) => {
-        const response = await postToLandGrantsApi(
-          '/api/v2/parcels',
-          {
-            parcelIds: ['SD6743-8083'],
-            fields: ['actions', 'size', 'actions.sssiConsentRequired', 'actions.heferRequired'],
-            sbi: userContext.sbi
-          },
-          mockserver.url
-        )
+    await pactInteraction(
+      {
+        given: HAS_8083,
+        receiving: 'a v2 request for a single parcel with SSSI consent information',
+        path: PARCELS_PATH,
+        body: requestBody,
+        status: 200,
+        responseBody: { message: 'success', parcels: eachLike(parcelWithConsentExample) }
+      },
+      async (mockserver) => {
+        const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
 
         expect(response.parcels[0]).toEqual(parcelWithConsentExample)
-
-        expect(response.parcels[0].actions[0].sssiConsentRequired).toBe(false)
-        expect(response.parcels[0].actions[0].heferRequired).toBe(true)
-
-        expect(response.parcels[0].actions[1].sssiConsentRequired).toBe(true)
-        expect(response.parcels[0].actions[1].heferRequired).toBe(false)
-
-        expect(response.parcels[0].actions[2].heferRequired).toBe(false)
-        expect(response.parcels[0].actions[2].sssiConsentRequired).toBe(true)
-      })
+      }
+    )
   })
 
   it('returns HTTP 200 with guidance and availability always included on each action', async () => {
@@ -564,109 +445,55 @@ describe('parcels', () => {
       actions: [
         {
           code: 'CLIG3',
-          availableArea: { value: 10.5, unit: 'ha' },
+          availability: { value: 10.5, unit: 'ha' },
           description: 'Manage grassland with very low nutrient inputs',
           ratePerUnitGbp: 10.6,
           ratePerAgreementPerYearGbp: 272,
           guidanceUrl: string(
             'https://www.gov.uk/find-funding-for-land-or-farms/clig3-manage-grassland-with-very-low-nutrient-inputs'
           ),
-          availability: { type: 'total' }
+          inputRequired: false
         },
         {
           code: 'CSAM3',
-          availableArea: { value: 20.75, unit: 'ha' },
+          availability: { value: 20.75, unit: 'ha' },
           description: 'Herbal leys',
           ratePerUnitGbp: 224,
           guidanceUrl: string('https://www.gov.uk/find-funding-for-land-or-farms/csam3-herbal-leys'),
-          availability: { type: 'partial' }
+          inputRequired: true
         }
       ]
     }
-    const EXPECTED_BODY = like({ message: 'success', parcels: eachLike(parcelWithMetadataExample) })
+    const requestBody = {
+      parcelIds: ['SD6743-8083'],
+      fields: ['actions', 'size'],
+      sbi: userContext.sbi
+    }
 
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a v2 request for a single parcel with actions and size, expecting guidance and availability')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/parcels',
-        headers: makeLandGrantsHeaders(),
-        body: {
-          parcelIds: ['SD6743-8083'],
-          fields: ['actions', 'size'],
-          sbi: userContext.sbi
-        }
-      })
-      .willRespondWith({ status: 200, headers: { 'Content-Type': 'application/json' }, body: EXPECTED_BODY })
-      .executeTest(async (mockserver) => {
-        const response = await postToLandGrantsApi(
-          '/api/v2/parcels',
-          {
-            parcelIds: ['SD6743-8083'],
-            fields: ['actions', 'size'],
-            sbi: userContext.sbi
-          },
-          mockserver.url
-        )
+    await pactInteraction(
+      {
+        given: HAS_8083,
+        receiving: 'a v2 request for a single parcel with actions and size, expecting guidance and availability',
+        path: PARCELS_PATH,
+        body: requestBody,
+        status: 200,
+        responseBody: { message: 'success', parcels: eachLike(parcelWithMetadataExample) }
+      },
+      async (mockserver) => {
+        const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
 
         expect(response.parcels[0].parcelId).toBe('SD6743')
         expect(response.parcels[0].sheetId).toBe('8083')
 
         expect(response.parcels[0].actions[0].code).toBe('CLIG3')
         expect(response.parcels[0].actions[0].guidanceUrl).toEqual(expect.any(String))
-        expect(response.parcels[0].actions[0].availability.type).toBe('total')
+        expect(response.parcels[0].actions[0].inputRequired).toBe(false)
 
         expect(response.parcels[0].actions[1].code).toBe('CSAM3')
         expect(response.parcels[0].actions[1].guidanceUrl).toEqual(expect.any(String))
-        expect(response.parcels[0].actions[1].availability.type).toBe('partial')
-      })
-  })
-
-  it('returns HTTP 400 when requesting SSSI consent information for multiple parcels', async () => {
-    const badRequestResponseExample = {
-      statusCode: 400,
-      error: 'Bad Request',
-      message: 'SSSI consent required is not supported for multiple parcels.'
-    }
-    const EXPECTED_BODY = like(badRequestResponseExample)
-
-    const provider = createProvider()
-    await provider
-      .given('has parcels', {
-        parcels: [
-          { sheetId: 'SD6743', parcelId: '8083' },
-          { sheetId: 'SD6743', parcelId: '8084' }
-        ]
-      })
-      .uponReceiving('a v2 request for multiple parcels with SSSI consent information')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/parcels',
-        headers: makeLandGrantsHeaders(),
-        body: {
-          parcelIds: ['SD6743-8083', 'SD6743-8084'],
-          fields: ['actions', 'size', 'actions.sssiConsentRequired'],
-          plannedActions: [],
-          sbi: userContext.sbi
-        }
-      })
-      .willRespondWith({ status: 400, headers: { 'Content-Type': 'application/json' }, body: EXPECTED_BODY })
-      .executeTest(async (mockserver) => {
-        await expect(
-          postToLandGrantsApi(
-            '/api/v2/parcels',
-            {
-              parcelIds: ['SD6743-8083', 'SD6743-8084'],
-              fields: ['actions', 'size', 'actions.sssiConsentRequired'],
-              plannedActions: [],
-              sbi: userContext.sbi
-            },
-            mockserver.url
-          )
-        ).rejects.toMatchObject({ code: 400, status: 400 })
-      })
+        expect(response.parcels[0].actions[1].inputRequired).toBe(true)
+      }
+    )
   })
 
   it('returns HTTP 200 and a list of parcels with actions and size', async () => {
@@ -677,49 +504,49 @@ describe('parcels', () => {
       actions: [
         {
           code: 'CMOR1',
-          availableArea: { value: 10.5, unit: 'ha' },
+          availability: { value: 10.5, unit: 'ha' },
           description: 'Assess moorland and produce a written record',
           ratePerUnitGbp: 10.6,
           ratePerAgreementPerYearGbp: 272
         },
         {
           code: 'UPL1',
-          availableArea: { value: 20.75, unit: 'ha' },
+          availability: { value: 20.75, unit: 'ha' },
           description: 'Moderate livestock grazing on moorland',
           ratePerUnitGbp: 20
         },
         {
           code: 'UPL2',
-          availableArea: { value: 15.25, unit: 'ha' },
+          availability: { value: 15.25, unit: 'ha' },
           description: 'Moderate livestock grazing on moorland',
           ratePerUnitGbp: 53
         }
       ]
     }
-    const EXPECTED_BODY = like({ message: 'success', parcels: eachLike(parcelWithActionsAndSizeExample) })
+    const requestBody = {
+      parcelIds: ['SD6743-8083'],
+      fields: ['actions', 'size'],
+      plannedActions: [],
+      sbi: userContext.sbi
+    }
 
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a v2 request for a single parcel with actions and size')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/parcels',
-        headers: makeLandGrantsHeaders(),
-        body: { parcelIds: ['SD6743-8083'], fields: ['actions', 'size'], plannedActions: [], sbi: userContext.sbi }
-      })
-      .willRespondWith({ status: 200, headers: { 'Content-Type': 'application/json' }, body: EXPECTED_BODY })
-      .executeTest(async (mockserver) => {
-        const response = await postToLandGrantsApi(
-          '/api/v2/parcels',
-          { parcelIds: ['SD6743-8083'], fields: ['actions', 'size'], plannedActions: [], sbi: userContext.sbi },
-          mockserver.url
-        )
+    await pactInteraction(
+      {
+        given: HAS_8083,
+        receiving: 'a v2 request for a single parcel with actions and size',
+        path: PARCELS_PATH,
+        body: requestBody,
+        status: 200,
+        responseBody: { message: 'success', parcels: eachLike(parcelWithActionsAndSizeExample) }
+      },
+      async (mockserver) => {
+        const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
         expect(response.parcels[0]).toEqual(parcelWithActionsAndSizeExample)
-      })
+      }
+    )
   })
 
-  it('returns HTTP 200 with availableArea recomputed against a non-empty plannedActions selection', async () => {
+  it('returns HTTP 200 with availability recomputed against a non-empty plannedActions selection', async () => {
     const parcelWithRecomputedAreaExample = {
       parcelId: 'SD6743',
       sheetId: '8083',
@@ -727,111 +554,57 @@ describe('parcels', () => {
       actions: [
         {
           code: 'CMOR1',
-          availableArea: { value: 4.5341, unit: 'ha' },
+          availability: { value: 4.5341, unit: 'ha' },
           description: 'Assess moorland and produce a written record',
           ratePerUnitGbp: 10.6,
           ratePerAgreementPerYearGbp: 272
         },
         {
           code: 'UPL1',
-          availableArea: { value: 4.5341, unit: 'ha' },
+          availability: { value: 4.5341, unit: 'ha' },
           description: 'Moderate livestock grazing on moorland',
           ratePerUnitGbp: 20
         },
         {
           code: 'UPL2',
-          availableArea: { value: 4.5341, unit: 'ha' },
+          availability: { value: 4.5341, unit: 'ha' },
           description: 'Moderate livestock grazing on moorland',
           ratePerUnitGbp: 53
         }
       ]
     }
-    const EXPECTED_BODY = like({ message: 'success', parcels: eachLike(parcelWithRecomputedAreaExample) })
-    const plannedActions = [{ actionCode: 'UPL1', quantity: 1.0, unit: 'ha' }]
+    const requestBody = {
+      parcelIds: ['SD6743-8083'],
+      fields: ['actions', 'size'],
+      plannedActions: [{ actionCode: 'UPL1', quantity: 1.0, unit: 'ha' }],
+      sbi: userContext.sbi
+    }
 
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a v2 request for a single parcel with actions and size, competing against a planned selection')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/parcels',
-        headers: makeLandGrantsHeaders(),
-        body: { parcelIds: ['SD6743-8083'], fields: ['actions', 'size'], plannedActions, sbi: userContext.sbi }
-      })
-      .willRespondWith({ status: 200, headers: { 'Content-Type': 'application/json' }, body: EXPECTED_BODY })
-      .executeTest(async (mockserver) => {
-        const response = await postToLandGrantsApi(
-          '/api/v2/parcels',
-          { parcelIds: ['SD6743-8083'], fields: ['actions', 'size'], plannedActions, sbi: userContext.sbi },
-          mockserver.url
-        )
+    await pactInteraction(
+      {
+        given: HAS_8083,
+        receiving: 'a v2 request for a single parcel with actions and size, competing against a planned selection',
+        path: PARCELS_PATH,
+        body: requestBody,
+        status: 200,
+        responseBody: { message: 'success', parcels: eachLike(parcelWithRecomputedAreaExample) }
+      },
+      async (mockserver) => {
+        const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
         expect(response.parcels[0]).toEqual(parcelWithRecomputedAreaExample)
-      })
-  })
-
-  it('returns HTTP 400 when parcel id is malformed', async () => {
-    const badRequestResponseExample = {
-      statusCode: 400,
-      error: 'Bad Request',
-      message:
-        '"parcelIds[0]" with value "MALFORMED-PARCEL" fails to match the required pattern: /^[A-Za-z0-9]{6}-[0-9]{4}$/'
-    }
-    const EXPECTED_BODY = like(badRequestResponseExample)
-
-    const provider = createProvider()
-    await provider
-      .uponReceiving('a v2 request for a malformed parcel with actions and size')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/parcels',
-        headers: makeLandGrantsHeaders(),
-        body: { parcelIds: ['MALFORMED-PARCEL'], fields: ['actions', 'size'], plannedActions: [], sbi: userContext.sbi }
-      })
-      .willRespondWith({ status: 400, headers: { 'Content-Type': 'application/json' }, body: EXPECTED_BODY })
-      .executeTest(async (mockserver) => {
-        await expect(
-          postToLandGrantsApi(
-            '/api/v2/parcels',
-            { parcelIds: ['MALFORMED-PARCEL'], fields: ['actions', 'size'], plannedActions: [], sbi: userContext.sbi },
-            mockserver.url
-          )
-        ).rejects.toMatchObject({ code: 400, status: 400 })
-      })
-  })
-
-  it('returns HTTP 404 when parcel with actions and size is not found', async () => {
-    const notFoundParcelExample = {
-      statusCode: 404,
-      error: 'Not Found',
-      message: 'Land parcel not found: SD1234-5678'
-    }
-    const EXPECTED_BODY = like(notFoundParcelExample)
-
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [] })
-      .uponReceiving('a v2 request for a not found parcel with actions and size')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/parcels',
-        headers: makeLandGrantsHeaders(),
-        body: { parcelIds: ['SD1234-5678'], fields: ['actions', 'size'], plannedActions: [], sbi: userContext.sbi }
-      })
-      .willRespondWith({ status: 404, headers: { 'Content-Type': 'application/json' }, body: EXPECTED_BODY })
-      .executeTest(async (mockserver) => {
-        await expect(
-          postToLandGrantsApi(
-            '/api/v2/parcels',
-            { parcelIds: ['SD1234-5678'], fields: ['actions', 'size'], plannedActions: [], sbi: userContext.sbi },
-            mockserver.url
-          )
-        ).rejects.toMatchObject({ code: 404, status: 404 })
-      })
+      }
+    )
   })
 })
 
 describe('validate', () => {
+  const moorlandRules = (passed, reason) =>
+    like({
+      name: string('parcel-has-intersection-with-data-layer-moorland'),
+      passed: like(passed),
+      reason: string(reason)
+    })
+
   it('returns HTTP 200 with validation for multiple actions with no caveat', async () => {
     const validateResponseExample = {
       id: like(33),
@@ -844,11 +617,7 @@ describe('validate', () => {
           parcelId: 'SD7861',
           hasPassed: true,
           rules: arrayContaining(
-            like({
-              name: string('parcel-has-intersection-with-data-layer-moorland'),
-              passed: like(true),
-              reason: string('This parcel is majority on the moorland')
-            }),
+            moorlandRules(true, 'This parcel is majority on the moorland'),
             like({
               name: string('applied-for-total-available-area'),
               passed: like(true),
@@ -862,11 +631,7 @@ describe('validate', () => {
           parcelId: '5677',
           hasPassed: true,
           rules: arrayContaining(
-            like({
-              name: string('parcel-has-intersection-with-data-layer-moorland'),
-              passed: like(true),
-              reason: string('This parcel is majority on the moorland')
-            }),
+            moorlandRules(true, 'This parcel is majority on the moorland'),
             like({
               name: string('applied-for-total-available-area'),
               passed: like(true),
@@ -897,36 +662,23 @@ describe('validate', () => {
         }
       ]
     }
-    const EXPECTED_BODY = like(validateResponseExample)
 
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD7861', parcelId: '5677' }] })
-      .uponReceiving('a v2 validation request for multiple actions with no caveat')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/application/validate',
-        headers: makeLandGrantsHeaders(),
-        body: {
-          ...payload,
-          sbi: userContext.sbi
-        }
-      })
-      .willRespondWith({
+    await pactInteraction(
+      {
+        given: HAS_5677,
+        receiving: 'a v2 validation request for multiple actions with no caveat',
+        path: VALIDATE_PATH,
+        body: { ...payload, sbi: userContext.sbi },
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
+        responseBody: validateResponseExample
+      },
+      async (mockserver) => {
         const response = await validateApplication(payload, mockserver.url)
 
         expect(response.valid).toBe(true)
-        expect(response.actions).toBeDefined()
-        expect(response.actions.length).toBeGreaterThan(0)
-        expect(response.actions[0]).toHaveProperty('actionCode')
-        expect(response.actions[0]).toHaveProperty('hasPassed')
-        expect(response.actions[0]).toHaveProperty('rules')
-      })
+        expectValidatedActionShape(response)
+      }
+    )
   })
 
   it('returns HTTP 200 with validation for an action including SSSI caveat', async () => {
@@ -941,11 +693,7 @@ describe('validate', () => {
           parcelId: '5677',
           hasPassed: true,
           rules: [
-            like({
-              name: string('parcel-has-intersection-with-data-layer-moorland'),
-              passed: like(true),
-              reason: string('This parcel is majority on the moorland')
-            }),
+            moorlandRules(true, 'This parcel is majority on the moorland'),
             like({
               name: string('applied-for-total-available-area'),
               passed: like(true),
@@ -981,45 +729,37 @@ describe('validate', () => {
         }
       ]
     }
-    const EXPECTED_BODY = like(validateResponseExample)
 
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD7861', parcelId: '5677' }] })
-      .uponReceiving('a v2 validation request for an action with SSSI caveat')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/application/validate',
-        headers: makeLandGrantsHeaders(),
-        body: {
-          ...payload,
-          sbi: userContext.sbi
-        }
-      })
-      .willRespondWith({
+    await pactInteraction(
+      {
+        given: HAS_5677,
+        receiving: 'a v2 validation request for an action with SSSI caveat',
+        path: VALIDATE_PATH,
+        body: { ...payload, sbi: userContext.sbi },
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
+        responseBody: validateResponseExample
+      },
+      async (mockserver) => {
         const response = await validateApplication(payload, mockserver.url)
 
         expect(response.valid).toBe(true)
-        expect(response.actions).toBeDefined()
-        expect(response.actions.length).toBeGreaterThan(0)
-        expect(response.actions[0]).toHaveProperty('actionCode')
-        expect(response.actions[0]).toHaveProperty('hasPassed')
-        expect(response.actions[0]).toHaveProperty('rules')
+        expectValidatedActionShape(response)
 
         const sssiRule = response.actions[0].rules.find((rule) => rule.name === 'sssi-consent-required-sssi')
         expect(sssiRule).toBeDefined()
         expect(sssiRule).toHaveProperty('caveat')
         expect(sssiRule.caveat).toHaveProperty('code')
         expect(sssiRule.caveat).toHaveProperty('metadata')
-      })
+      }
+    )
   })
 
   it('returns HTTP 200 when parcel fails moorland check with no SSSI caveat', async () => {
+    const failedMoorlandRules = eachLike({
+      name: string('parcel-has-intersection-with-data-layer-moorland'),
+      passed: like(false),
+      reason: string('This parcel is not majority on the moorland')
+    })
     const validateResponseWithMoorlandFailure = {
       message: 'Application validated successfully',
       valid: false,
@@ -1029,22 +769,14 @@ describe('validate', () => {
           sheetId: 'SK0971',
           parcelId: '4262',
           hasPassed: false,
-          rules: eachLike({
-            name: string('parcel-has-intersection-with-data-layer-moorland'),
-            passed: like(false),
-            reason: string('This parcel is not majority on the moorland')
-          })
+          rules: failedMoorlandRules
         }),
         {
           actionCode: 'UPL1',
           sheetId: 'SK0971',
           parcelId: '4262',
           hasPassed: false,
-          rules: eachLike({
-            name: string('parcel-has-intersection-with-data-layer-moorland'),
-            passed: like(false),
-            reason: string('This parcel is not majority on the moorland')
-          })
+          rules: failedMoorlandRules
         }
       ],
       id: like(23)
@@ -1062,215 +794,77 @@ describe('validate', () => {
         }
       ]
     }
-    const EXPECTED_BODY = like(validateResponseWithMoorlandFailure)
 
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SK0971', parcelId: '4262' }] })
-      .uponReceiving('a v2 validation request that fails moorland check without SSSI caveat')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/application/validate',
-        headers: makeLandGrantsHeaders(),
-        body: {
-          ...payload,
-          sbi: userContext.sbi
-        }
-      })
-      .willRespondWith({
+    await pactInteraction(
+      {
+        given: { parcels: [{ sheetId: 'SK0971', parcelId: '4262' }] },
+        receiving: 'a v2 validation request that fails moorland check without SSSI caveat',
+        path: VALIDATE_PATH,
+        body: { ...payload, sbi: userContext.sbi },
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
+        responseBody: validateResponseWithMoorlandFailure
+      },
+      async (mockserver) => {
         const response = await validateApplication(payload, mockserver.url)
 
         expect(response.valid).toBe(false)
-        expect(response.actions).toBeDefined()
-        expect(response.actions.length).toBeGreaterThan(0)
-        expect(response.actions[0]).toHaveProperty('actionCode')
-        expect(response.actions[0]).toHaveProperty('hasPassed')
-        expect(response.actions[0]).toHaveProperty('rules')
-      })
+        expectValidatedActionShape(response)
+      }
+    )
   })
 
-  it('returns HTTP 422 with error message when quantity is a string', async () => {
-    const negativeQuantityPayload = {
-      applicationId: '34E-8CA-45D',
-      requester: 'grants-ui',
-      applicantCrn: '1100014934',
-      landActions: [
-        {
-          sheetId: 'SD6743',
-          parcelId: '8083',
-          actions: [{ code: 'CMOR1', quantity: 'invalid quantity provided' }]
-        }
-      ]
-    }
-    const unprocessableResponseExample = {
-      statusCode: 422,
-      error: 'Unprocessable Entity',
-      message: 'Quantity must be a positive number'
-    }
-    const EXPECTED_BODY = like(unprocessableResponseExample)
-
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a v2 validation request for invalid quantity')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/application/validate',
-        headers: makeLandGrantsHeaders(),
-        body: {
-          ...negativeQuantityPayload,
-          sbi: userContext.sbi
-        }
-      })
-      .willRespondWith({
-        status: 422,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
-        await expect(validateApplication(negativeQuantityPayload, mockserver.url)).rejects.toMatchObject({
-          code: 422,
-          status: 422
-        })
-      })
-  })
-
-  it('returns HTTP 422 with error message when quantity is negative', async () => {
-    const negativeQuantityPayload = {
-      applicationId: '34E-8CA-45D',
-      requester: 'grants-ui',
-      applicantCrn: '1100014934',
-      landActions: [
-        {
-          sheetId: 'SD6743',
-          parcelId: '8083',
-          actions: [{ code: 'CMOR1', quantity: -0.14472089 }]
-        }
-      ]
-    }
-    const unprocessableResponseExample = {
-      statusCode: 422,
-      error: 'Unprocessable Entity',
-      message: 'Quantity must be a positive number'
-    }
-    const EXPECTED_BODY = like(unprocessableResponseExample)
-
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a v2 validation request for negative quantity')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/application/validate',
-        headers: makeLandGrantsHeaders(),
-        body: {
-          ...negativeQuantityPayload,
-          sbi: userContext.sbi
-        }
-      })
-      .willRespondWith({
-        status: 422,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
-        await expect(validateApplication(negativeQuantityPayload, mockserver.url)).rejects.toMatchObject({
-          code: 422,
-          status: 422
-        })
-      })
-  })
-
-  it('returns HTTP 400 when required fields are missing', async () => {
-    const incompletePayload = {
-      applicationId: '34E-8CA-45D',
-      requester: 'grants-ui'
+  it.each([
+    [
+      422,
+      'a v2 validation request for invalid quantity',
+      HAS_8083,
+      {
+        applicationId: '34E-8CA-45D',
+        requester: 'grants-ui',
+        applicantCrn: '1100014934',
+        landActions: [{ ...PARCEL_8083, actions: [{ code: 'CMOR1', quantity: 'invalid quantity provided' }] }]
+      },
+      'Unprocessable Entity',
+      'Quantity must be a positive number'
+    ],
+    [
+      422,
+      'a v2 validation request for negative quantity',
+      HAS_8083,
+      {
+        applicationId: '34E-8CA-45D',
+        requester: 'grants-ui',
+        applicantCrn: '1100014934',
+        landActions: [{ ...PARCEL_8083, actions: [{ code: 'CMOR1', quantity: -0.14472089 }] }]
+      },
+      'Unprocessable Entity',
+      'Quantity must be a positive number'
+    ],
+    [
+      400,
+      'a v2 validation request with missing required fields',
+      HAS_8083,
       // Missing applicantCrn and landActions
-    }
+      { applicationId: '34E-8CA-45D', requester: 'grants-ui' },
+      'Bad Request',
+      '"applicantCrn" is required'
+    ],
+    [
+      400,
+      'a v2 validation request for a non-existent parcel',
+      HAS_NO_PARCELS,
+      {
+        applicationId: '34E-8CA-45D',
+        requester: 'grants-ui',
+        applicantCrn: '1100014934',
+        landActions: [{ sheetId: 'NONEXIST', parcelId: '9999', actions: [{ code: 'CMOR1', quantity: 0.14472089 }] }]
+      },
+      'Bad Request',
+      'Land parcels not found: NONEXIST-9999'
+    ]
+  ])('returns HTTP %s for %s', async (status, receiving, given, payload, error, message) => {
+    const caught = await catchValidateError({ status, receiving, given, payload, error, message })
 
-    const badRequestResponseExample = {
-      statusCode: 400,
-      error: 'Bad Request',
-      message: '"applicantCrn" is required'
-    }
-    const EXPECTED_BODY = like(badRequestResponseExample)
-
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [{ sheetId: 'SD6743', parcelId: '8083' }] })
-      .uponReceiving('a v2 validation request with missing required fields')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/application/validate',
-        headers: makeLandGrantsHeaders(),
-        body: {
-          ...incompletePayload,
-          sbi: userContext.sbi
-        }
-      })
-      .willRespondWith({
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
-        await expect(validateApplication(incompletePayload, mockserver.url)).rejects.toMatchObject({
-          code: 400,
-          status: 400
-        })
-      })
-  })
-
-  it('returns HTTP 400 when parcel is not found', async () => {
-    const notFoundPayload = {
-      applicationId: '34E-8CA-45D',
-      requester: 'grants-ui',
-      applicantCrn: '1100014934',
-      landActions: [
-        {
-          sheetId: 'NONEXIST',
-          parcelId: '9999',
-          actions: [{ code: 'CMOR1', quantity: 0.14472089 }]
-        }
-      ]
-    }
-
-    const notFoundResponseExample = {
-      statusCode: 400,
-      error: 'Bad Request',
-      message: 'Land parcels not found: NONEXIST-9999'
-    }
-
-    const EXPECTED_BODY = like(notFoundResponseExample)
-
-    const provider = createProvider()
-    await provider
-      .given('has parcels', { parcels: [] })
-      .uponReceiving('a v2 validation request for a non-existent parcel')
-      .withRequest({
-        method: 'POST',
-        path: '/api/v2/application/validate',
-        headers: makeLandGrantsHeaders(),
-        body: {
-          ...notFoundPayload,
-          sbi: userContext.sbi
-        }
-      })
-      .willRespondWith({
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-        body: EXPECTED_BODY
-      })
-      .executeTest(async (mockserver) => {
-        await expect(validateApplication(notFoundPayload, mockserver.url)).rejects.toMatchObject({
-          code: 400,
-          status: 400
-        })
-      })
+    expect(caught).toMatchObject({ code: status, status })
   })
 })

--- a/src/server/land-grants/controllers/select-actions-base-page.controller.js
+++ b/src/server/land-grants/controllers/select-actions-base-page.controller.js
@@ -213,7 +213,7 @@ export default class SelectActionsBasePageController extends QuestionPageWithPar
    * @param {string} sheetId
    * @param {string} parcelId
    * @param {PlannedAction[]} [plannedActions] - When given, recomputes each
-   *   action's availableArea against this combination.
+   *   action's availability against this combination.
    */
   async fetchActions(request, sheetId, parcelId, plannedActions = []) {
     try {

--- a/src/server/land-grants/controllers/select-actions-base-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-actions-base-page.controller.test.js
@@ -1,36 +1,25 @@
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
 import {
   fetchGroupedActionsForParcel,
   fetchParcels,
   validateApplication
 } from '~/src/server/land-grants/services/land-grants.service.js'
-import { formatParcelReference, parseLandParcel } from '~/src/shared/format-parcel.js'
 import SelectActionsBasePageController from './select-actions-base-page.controller.js'
+import {
+  CMOR1,
+  PARCELS_WITH_SIZE,
+  USER_CONTEXT,
+  makeLandGrantsRequest,
+  makeViewToolkit,
+  mockFormatParcelImplementations,
+  stubControllerMethods
+} from '~/src/server/land-grants/test-helpers.js'
 
-vi.mock('@defra/forms-engine-plugin/controllers/QuestionPageController.js', () => ({
-  QuestionPageController: class {
-    constructor(model, pageDef) {
-      this.model = model
-      this.pageDef = pageDef
-    }
-
-    getViewModel() {}
-
-    getHref(path) {
-      return `/${this.model.basePath}/${path}`.replace(/\/{2,}/g, '/')
-    }
-
-    makeGetRouteHandler() {
-      return async (request, context, h) => h.view('stub-view', this.getViewModel(request, context))
-    }
-
-    makePostRouteHandler() {
-      return async (request, context, h) => h.view('stub-view', this.getViewModel(request, context))
-    }
-  }
-}))
+vi.mock('@defra/forms-engine-plugin/controllers/QuestionPageController.js', async () => {
+  const { makeQuestionPageControllerMock } = await import('~/src/__mocks__')
+  return makeQuestionPageControllerMock('stub-view')
+})
 
 vi.mock('~/src/server/task-list/task-list.helper.js', () => ({
   withTaskContext: (Base) => Base
@@ -92,14 +81,7 @@ class StubSelectActionsController extends SelectActionsBasePageController {
   }
 }
 
-const mockParcelsResponse = [{ parcelId: '0155', sheetId: 'SD7946', area: { unit: 'ha', value: 4.0383 } }]
-
-const mockGroupedActions = [
-  {
-    name: 'Assess moorland',
-    actions: [{ code: 'CMOR1', description: 'Assess moorland: CMOR1', availableArea: { unit: 'ha', value: 10 } }]
-  }
-]
+const mockGroupedActions = [{ name: 'Assess moorland', actions: [CMOR1] }]
 
 describe('SelectActionsBasePageController', () => {
   let controller
@@ -111,32 +93,18 @@ describe('SelectActionsBasePageController', () => {
     QuestionPageController.prototype.getViewModel = vi.fn().mockReturnValue({ pageTitle: 'Stub page' })
 
     const mockModel = { def: { metadata: {} }, getSection: vi.fn(), pages: [] }
-    controller = new StubSelectActionsController(mockModel, {})
-    controller.collection = { getErrors: vi.fn().mockReturnValue([]) }
-    controller.setState = vi.fn().mockResolvedValue(true)
-    controller.proceed = vi.fn().mockReturnValue('redirected')
-    controller.getNextPath = vi.fn().mockReturnValue('/next-path')
-    controller.performAuthCheck = vi.fn().mockResolvedValue(null)
+    controller = stubControllerMethods(new StubSelectActionsController(mockModel, {}))
 
-    fetchParcels.mockResolvedValue(mockParcelsResponse)
+    fetchParcels.mockResolvedValue(PARCELS_WITH_SIZE.slice(0, 1))
 
-    mockRequest = {
+    mockRequest = makeLandGrantsRequest({
       payload: { CMOR1: 'CMOR1' },
-      query: { parcelId: 'sheet1-parcel1' },
-      logger: mockRequestLogger(),
-      auth: {
-        isAuthenticated: true,
-        credentials: { token: 'defra-id-access-token', sbi: '106284736', crn: 'CRN123' }
-      }
-    }
-    mockContext = { state: {}, referenceNumber: 'REF123' }
-    mockH = { view: vi.fn().mockReturnValue('rendered view'), redirect: vi.fn() }
-
-    parseLandParcel.mockReturnValue(['sheet1', 'parcel1'])
-    formatParcelReference.mockImplementation((parcel) => {
-      const [sheetId, parcelId] = typeof parcel === 'string' ? parcel.split('-') : [parcel.sheetId, parcel.parcelId]
-      return [sheetId, parcelId].filter((part) => part != null && part !== '').join(' ')
+      query: { parcelId: 'sheet1-parcel1' }
     })
+    mockContext = { state: {}, referenceNumber: 'REF123' }
+    mockH = makeViewToolkit()
+
+    mockFormatParcelImplementations()
     fetchGroupedActionsForParcel.mockResolvedValue({
       actions: mockGroupedActions,
       parcel: { parcelId: 'parcel1', sheetId: 'sheet1', size: 10 }
@@ -186,7 +154,7 @@ describe('SelectActionsBasePageController', () => {
 
       expect(fetchGroupedActionsForParcel).toHaveBeenCalledWith(
         { parcelId: 'parcel1', sheetId: 'sheet1', enabledLandActions: [], plannedActions: [] },
-        { defraIdToken: 'defra-id-access-token', sbi: '106284736' }
+        USER_CONTEXT
       )
       const [viewName, viewModel] = mockH.view.mock.calls[0]
       expect(viewName).toBe('stub-view')
@@ -250,7 +218,7 @@ describe('SelectActionsBasePageController', () => {
           applicationId: 'REF123',
           crn: 'CRN123'
         }),
-        { defraIdToken: 'defra-id-access-token', sbi: '106284736' }
+        USER_CONTEXT
       )
       const [, viewModel] = mockH.view.mock.calls[0]
       expect(viewModel.errors).toEqual([{ text: 'Too much land', href: '#CMOR1' }])

--- a/src/server/land-grants/controllers/select-actions-page.controller.js
+++ b/src/server/land-grants/controllers/select-actions-page.controller.js
@@ -42,7 +42,7 @@ function buildPlannedActionsFromFields(payload, actions) {
     }
     const quantity = Number(payload[getActionQuantityFieldName(action.code)])
     return Number.isFinite(quantity) && quantity > 0
-      ? [{ actionCode: action.code, quantity, unit: action.availableArea?.unit }]
+      ? [{ actionCode: action.code, quantity, unit: action.availability?.unit }]
       : []
   })
 }
@@ -146,7 +146,7 @@ export default class SelectActionsPageController extends SelectActionsBasePageCo
   }
 
   /**
-   * Recomputes availableArea for every action against the quantity claims
+   * Recomputes availability for every action against the quantity claims
    * in this same submission.
    * @param {AnyFormRequest} request
    * @param {{ selectedLandParcel: string, sheetId: string, parcelId: string }} parcel
@@ -181,9 +181,9 @@ export default class SelectActionsPageController extends SelectActionsBasePageCo
     const sentByCode = new Map(plannedActions.map((p) => [p.actionCode, p.quantity]))
     const actionsByCode = new Map(actions.map((a) => [a.code, a]))
     const withSentClaim = recomputed.map((action) => {
-      const needsQuantity = requiresQuantityInput(actionsByCode.get(action.code)?.availability?.type)
+      const needsQuantity = requiresQuantityInput(actionsByCode.get(action.code)?.inputRequired)
       return sentByCode.has(action.code) && !needsQuantity
-        ? { ...action, availableArea: { ...action.availableArea, value: sentByCode.get(action.code) } }
+        ? { ...action, availability: { ...action.availability, value: sentByCode.get(action.code) } }
         : action
     })
 

--- a/src/server/land-grants/controllers/select-actions-page.controller.js
+++ b/src/server/land-grants/controllers/select-actions-page.controller.js
@@ -181,7 +181,7 @@ export default class SelectActionsPageController extends SelectActionsBasePageCo
     const sentByCode = new Map(plannedActions.map((p) => [p.actionCode, p.quantity]))
     const actionsByCode = new Map(actions.map((a) => [a.code, a]))
     const withSentClaim = recomputed.map((action) => {
-      const needsQuantity = requiresQuantityInput(actionsByCode.get(action.code)?.inputRequired)
+      const needsQuantity = requiresQuantityInput(actionsByCode.get(action.code)?.availability?.type)
       return sentByCode.has(action.code) && !needsQuantity
         ? { ...action, availability: { ...action.availability, value: sentByCode.get(action.code) } }
         : action

--- a/src/server/land-grants/controllers/select-actions-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-actions-page.controller.test.js
@@ -57,7 +57,7 @@ describe('SelectActionsPageController', () => {
 
   const enabledLandActions = ['CMOR1', 'UPL1', 'UPL2']
 
-  const mockActions = [CMOR1, UPL1, { ...UPL2, inputRequired: true }]
+  const mockActions = [CMOR1, UPL1, { ...UPL2, availability: { ...UPL2.availability, type: 'partial' } }]
 
   beforeEach(() => {
     QuestionPageController.prototype.getViewModel = vi.fn().mockReturnValue({
@@ -376,7 +376,7 @@ describe('SelectActionsPageController', () => {
 
     test('should still send the unit for an action with no availability restriction', async () => {
       fetchActionsForParcel.mockResolvedValue({
-        actions: [{ ...UPL2, availability: { unit: 'ha', value: null }, inputRequired: true }],
+        actions: [{ ...UPL2, availability: { unit: 'ha', value: null, type: 'partial' } }],
         parcel: { sheetId: 'sheet1', parcelId: 'parcel1', size: { unit: 'ha', value: 20 } }
       })
       mockRequest.payload = { landAction: ['UPL2'], landActionQuantity_UPL2: '7' }

--- a/src/server/land-grants/controllers/select-actions-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-actions-page.controller.test.js
@@ -1,39 +1,30 @@
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
 import {
   fetchActionsForParcel,
   fetchActionsWithPlannedActions,
   fetchParcels,
   validateApplication
 } from '~/src/server/land-grants/services/land-grants.service.js'
-import { formatParcelReference, parseLandParcel, stringifyParcel } from '~/src/shared/format-parcel.js'
 import SelectActionsPageController from './select-actions-page.controller.js'
 import { error, log } from '~/src/server/common/helpers/logging/log.js'
 import { config } from '~/src/config/config.js'
+import {
+  CMOR1,
+  PARCELS_WITH_SIZE,
+  UPL1,
+  UPL2,
+  USER_CONTEXT,
+  makeLandGrantsRequest,
+  makeViewToolkit,
+  mockFormatParcelImplementations,
+  stubControllerMethods
+} from '~/src/server/land-grants/test-helpers.js'
 
-vi.mock('@defra/forms-engine-plugin/controllers/QuestionPageController.js', () => ({
-  QuestionPageController: class {
-    constructor(model, pageDef) {
-      this.model = model
-      this.pageDef = pageDef
-    }
-
-    getViewModel() {}
-
-    getHref(path) {
-      return `/${this.model.basePath}/${path}`.replace(/\/{2,}/g, '/')
-    }
-
-    makeGetRouteHandler() {
-      return async (request, context, h) => h.view('select-actions', this.getViewModel(request, context))
-    }
-
-    makePostRouteHandler() {
-      return async (request, context, h) => h.view('select-actions', this.getViewModel(request, context))
-    }
-  }
-}))
+vi.mock('@defra/forms-engine-plugin/controllers/QuestionPageController.js', async () => {
+  const { makeQuestionPageControllerMock } = await import('~/src/__mocks__')
+  return makeQuestionPageControllerMock('select-actions')
+})
 
 vi.mock('~/src/server/task-list/task-list.helper.js', () => ({
   withTaskContext: (Base) => Base
@@ -55,46 +46,18 @@ vi.mock('~/src/config/config.js', async () => {
 vi.mock('~/src/server/land-grants/services/land-grants.service.js')
 vi.mock('~/src/shared/format-parcel.js')
 
-const mockParcelsResponse = [
-  {
-    parcelId: '0155',
-    sheetId: 'SD7946',
-    area: { unit: 'ha', value: 4.0383 }
-  }
-]
-const userContext = { defraIdToken: 'defra-id-access-token', sbi: '106284736' }
-
 describe('SelectActionsPageController', () => {
+  const post = () => controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+  const get = () => controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
+
   let controller
   let mockRequest
   let mockContext
   let mockH
-  let mockResponseWithCode
 
   const enabledLandActions = ['CMOR1', 'UPL1', 'UPL2']
 
-  const mockActions = [
-    {
-      code: 'CMOR1',
-      description: 'Assess moorland and produce a written record: CMOR1',
-      availableArea: { unit: 'ha', value: 10 },
-      ratePerUnitGbp: 16,
-      ratePerAgreementPerYearGbp: 272
-    },
-    {
-      code: 'UPL1',
-      description: 'Moderate livestock grazing on moorland: UPL1',
-      availableArea: { unit: 'ha', value: 5 },
-      ratePerUnitGbp: 33
-    },
-    {
-      code: 'UPL2',
-      description: 'Heavy livestock grazing on moorland: UPL2',
-      availableArea: { unit: 'ha', value: 3 },
-      ratePerUnitGbp: 45,
-      availability: { type: 'partial' }
-    }
-  ]
+  const mockActions = [CMOR1, UPL1, { ...UPL2, inputRequired: true }]
 
   beforeEach(() => {
     QuestionPageController.prototype.getViewModel = vi.fn().mockReturnValue({
@@ -106,56 +69,15 @@ describe('SelectActionsPageController', () => {
     })
 
     const mockModel = { def: { metadata: { tasklist: {}, enabledLandActions } }, getSection: vi.fn(), pages: [] }
-    controller = new SelectActionsPageController(mockModel, {})
-    controller.collection = {
-      getErrors: vi.fn().mockReturnValue([])
-    }
-    controller.setState = vi.fn().mockResolvedValue(true)
-    controller.proceed = vi.fn().mockReturnValue('redirected')
-    controller.getNextPath = vi.fn().mockReturnValue('/next-path')
-    controller.performAuthCheck = vi.fn().mockResolvedValue(null)
+    controller = stubControllerMethods(new SelectActionsPageController(mockModel, {}))
 
-    fetchParcels.mockResolvedValue(mockParcelsResponse)
+    fetchParcels.mockResolvedValue(PARCELS_WITH_SIZE.slice(0, 1))
 
-    mockRequest = {
-      payload: { landAction: 'CMOR1' },
-      query: {},
-      logger: mockRequestLogger(),
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          token: userContext.defraIdToken,
-          sbi: userContext.sbi,
-          crn: 'CRN123',
-          name: 'John Doe',
-          organisationName: 'Farm 1',
-          role: 'admin',
-          sessionId: 'valid-session-id'
-        }
-      }
-    }
+    mockRequest = makeLandGrantsRequest({ payload: { landAction: 'CMOR1' } })
+    mockContext = { state: {}, referenceNumber: 'REF123' }
+    mockH = makeViewToolkit()
 
-    mockContext = {
-      state: {},
-      referenceNumber: 'REF123'
-    }
-
-    mockResponseWithCode = {
-      code: vi.fn().mockReturnValue('final-response')
-    }
-
-    mockH = {
-      view: vi.fn().mockReturnValue('rendered view'),
-      redirect: vi.fn(),
-      response: vi.fn().mockReturnValue(mockResponseWithCode)
-    }
-
-    parseLandParcel.mockReturnValue(['sheet1', 'parcel1'])
-    stringifyParcel.mockImplementation(({ sheetId, parcelId }) => `${sheetId}-${parcelId}`)
-    formatParcelReference.mockImplementation((parcel) => {
-      const [sheetId, parcelId] = typeof parcel === 'string' ? parcel.split('-') : [parcel.sheetId, parcel.parcelId]
-      return [sheetId, parcelId].filter((part) => part != null && part !== '').join(' ')
-    })
+    mockFormatParcelImplementations()
     fetchActionsForParcel.mockResolvedValue({
       actions: mockActions,
       parcel: { parcelId: 'parcel1', sheetId: 'sheet1', size: 10 }
@@ -179,8 +101,7 @@ describe('SelectActionsPageController', () => {
     test('should redirect to /select-land-parcel if no selected land parcel is set', async () => {
       mockRequest.query = {}
 
-      const handler = controller.makeGetRouteHandler()
-      const result = await handler(mockRequest, mockContext, mockH)
+      const result = await get()
 
       expect(controller.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/select-land-parcel')
       expect(result).toBe('redirected')
@@ -188,10 +109,9 @@ describe('SelectActionsPageController', () => {
 
     test('should fetch actions for the parcel', async () => {
       mockRequest.query.parcelId = 'sheet2-parcel2'
-      parseLandParcel.mockReturnValue(['sheet2', 'parcel2'])
+      mockFormatParcelImplementations({ sheetId: 'sheet2', parcelId: 'parcel2' })
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       expect(fetchActionsForParcel).toHaveBeenCalledWith(
         {
@@ -200,13 +120,12 @@ describe('SelectActionsPageController', () => {
           enabledLandActions,
           plannedActions: []
         },
-        userContext
+        USER_CONTEXT
       )
     })
 
     test('should render the view with a flat actionItems list rather than grouped actions', async () => {
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-actions',
@@ -224,8 +143,7 @@ describe('SelectActionsPageController', () => {
     })
 
     test('should surface a conditional quantity input for actions that require a max quantity', async () => {
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       const { actionItems } = mockH.view.mock.calls[0][1]
       const upl2 = actionItems.find((item) => item.value === 'UPL2')
@@ -241,8 +159,7 @@ describe('SelectActionsPageController', () => {
         parcel: { parcelId: 'parcel1', sheetId: 'sheet1', size: { value: 45.22, unit: 'ha' } }
       })
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       const [, viewModel] = mockH.view.mock.calls[0]
       expect(viewModel.parcelSummaryList.rows).toEqual([
@@ -252,8 +169,7 @@ describe('SelectActionsPageController', () => {
     })
 
     test('should return an empty pageConsents array when no action requires SSSI consent or HEFER', async () => {
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       const [, viewModel] = mockH.view.mock.calls[0]
       expect(viewModel.pageConsents).toEqual([])
@@ -266,8 +182,7 @@ describe('SelectActionsPageController', () => {
         parcel: { parcelId: 'parcel1', sheetId: 'sheet1', size: 10 }
       })
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       const [, viewModel] = mockH.view.mock.calls[0]
       expect(viewModel.pageConsents).toEqual(['hefer'])
@@ -280,8 +195,7 @@ describe('SelectActionsPageController', () => {
         parcel: { parcelId: 'parcel1', sheetId: 'sheet1', size: 10 }
       })
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       const [, viewModel] = mockH.view.mock.calls[0]
       expect(viewModel.pageConsents).toEqual(['sssi'])
@@ -293,8 +207,7 @@ describe('SelectActionsPageController', () => {
         parcel: { parcelId: 'parcel1', sheetId: 'sheet1', size: 10 }
       })
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       const [, viewModel] = mockH.view.mock.calls[0]
       expect(viewModel.pageConsents).toEqual([])
@@ -309,8 +222,7 @@ describe('SelectActionsPageController', () => {
         }
       }
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       const { actionItems } = mockH.view.mock.calls[0][1]
       const upl2 = actionItems.find((item) => item.value === 'UPL2')
@@ -322,8 +234,7 @@ describe('SelectActionsPageController', () => {
     test('should handle fetch errors gracefully', async () => {
       fetchActionsForParcel.mockRejectedValue(new Error('API Error'))
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-actions',
@@ -349,8 +260,7 @@ describe('SelectActionsPageController', () => {
         parcel: { parcelId: 'parcel1', sheetId: 'sheet1', size: 10 }
       })
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       expect(log).toHaveBeenCalledWith(
         expect.objectContaining({ level: 'error', messageFunc: expect.any(Function) }),
@@ -359,15 +269,13 @@ describe('SelectActionsPageController', () => {
       )
     })
 
-    describe('when the user does not own the land parcel', () => {
-      it('should return unauthorized response when user does not own the selected land parcel', async () => {
-        controller.performAuthCheck.mockResolvedValue('failed auth check')
+    test('should return the unauthorized response when the user does not own the selected land parcel', async () => {
+      controller.performAuthCheck.mockResolvedValue('failed auth check')
 
-        const result = await controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
+      const result = await get()
 
-        expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, ['sheet1-parcel1'])
-        expect(result).toEqual('failed auth check')
-      })
+      expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, ['sheet1-parcel1'])
+      expect(result).toEqual('failed auth check')
     })
   })
 
@@ -380,8 +288,7 @@ describe('SelectActionsPageController', () => {
     test('should show errors when no actions selected', async () => {
       mockRequest.payload = {}
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-actions',
@@ -394,8 +301,7 @@ describe('SelectActionsPageController', () => {
     test('should update state and proceed on valid submission', async () => {
       mockRequest.payload = { landAction: 'CMOR1' }
 
-      const handler = controller.makePostRouteHandler()
-      const result = await handler(mockRequest, mockContext, mockH)
+      const result = await post()
 
       expect(controller.setState).toHaveBeenCalledWith(
         mockRequest,
@@ -421,8 +327,7 @@ describe('SelectActionsPageController', () => {
         landAction: ['CMOR1', 'UPL1']
       }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(controller.setState).toHaveBeenCalledWith(
         mockRequest,
@@ -448,13 +353,12 @@ describe('SelectActionsPageController', () => {
       }
       fetchActionsWithPlannedActions.mockResolvedValue({
         actions: [
-          { code: 'UPL1', availableArea: { unit: 'ha', value: 0 } },
-          { code: 'UPL2', availableArea: { unit: 'ha', value: 2 } }
+          { code: 'UPL1', availability: { unit: 'ha', value: 0 } },
+          { code: 'UPL2', availability: { unit: 'ha', value: 2 } }
         ]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(fetchActionsForParcel).toHaveBeenCalledTimes(1)
       expect(fetchActionsWithPlannedActions).toHaveBeenCalledWith(
@@ -470,6 +374,28 @@ describe('SelectActionsPageController', () => {
       expect(stateArg.landParcels['sheet1-parcel1'].actionsObj.UPL1.value).toBe(5)
     })
 
+    test('should still send the unit for an action with no availability restriction', async () => {
+      fetchActionsForParcel.mockResolvedValue({
+        actions: [{ ...UPL2, availability: { unit: 'ha', value: null }, inputRequired: true }],
+        parcel: { sheetId: 'sheet1', parcelId: 'parcel1', size: { unit: 'ha', value: 20 } }
+      })
+      mockRequest.payload = { landAction: ['UPL2'], landActionQuantity_UPL2: '7' }
+      fetchActionsWithPlannedActions.mockResolvedValue({ actions: [] })
+
+      await post()
+
+      expect(fetchActionsWithPlannedActions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          plannedActions: [{ actionCode: 'UPL2', quantity: 7, unit: 'ha' }]
+        }),
+        expect.anything()
+      )
+      const stateArg = controller.setState.mock.calls[0][1]
+      expect(stateArg.landParcels['sheet1-parcel1'].actionsObj.UPL2).toEqual(
+        expect.objectContaining({ value: 7, unit: 'ha' })
+      )
+    })
+
     test('should keep the original uncompeted actions when the recompute fetch fails', async () => {
       mockRequest.payload = {
         landAction: ['UPL1', 'UPL2'],
@@ -477,18 +403,19 @@ describe('SelectActionsPageController', () => {
       }
       fetchActionsWithPlannedActions.mockRejectedValue(Object.assign(new Error('boom'), { status: 503 }))
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const stateArg = controller.setState.mock.calls[0][1]
       expect(stateArg.landParcels['sheet1-parcel1'].actionsObj.UPL1.value).toBe(5)
     })
 
-    test('should show an error and not save state when a quantity-required action has no submitted quantity', async () => {
-      mockRequest.payload = { landAction: 'UPL2' }
+    test.each([
+      ['has no submitted quantity', { landAction: 'UPL2' }],
+      ['has a submitted quantity of 0', { landAction: 'UPL2', landActionQuantity_UPL2: '0' }]
+    ])('should show an error and not save state when a quantity-required action %s', async (_case, payload) => {
+      mockRequest.payload = payload
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-actions',
@@ -506,35 +433,13 @@ describe('SelectActionsPageController', () => {
       expect(controller.proceed).not.toHaveBeenCalled()
     })
 
-    test('should show an error when a quantity-required action has a submitted quantity of 0', async () => {
-      mockRequest.payload = { landAction: 'UPL2', landActionQuantity_UPL2: '0' }
-
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
-
-      expect(mockH.view).toHaveBeenCalledWith(
-        'select-actions',
-        expect.objectContaining({
-          errors: [
-            {
-              text: 'Enter a quantity for Heavy livestock grazing on moorland: UPL2',
-              href: '#landActionQuantity_UPL2',
-              code: 'UPL2'
-            }
-          ]
-        })
-      )
-      expect(controller.setState).not.toHaveBeenCalled()
-    })
-
     test('should store the submitted quantity override for an action that requires one', async () => {
       mockRequest.payload = {
         landAction: 'UPL2',
         landActionQuantity_UPL2: '1.5'
       }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const stateArg = controller.setState.mock.calls[0][1]
       expect(stateArg.landParcels['sheet1-parcel1'].actionsObj.UPL2.value).toBe(1.5)
@@ -546,8 +451,7 @@ describe('SelectActionsPageController', () => {
         landActionQuantity_CMOR1: '2'
       }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const stateArg = controller.setState.mock.calls[0][1]
       expect(stateArg.landParcels['sheet1-parcel1'].actionsObj.CMOR1.value).toBe(10)
@@ -556,8 +460,7 @@ describe('SelectActionsPageController', () => {
     test('should not save anything to state when no action is selected', async () => {
       mockRequest.payload = { landActionQuantity_UPL2: '1.5' }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-actions',
@@ -568,15 +471,6 @@ describe('SelectActionsPageController', () => {
       expect(controller.setState).not.toHaveBeenCalled()
     })
 
-    test('should verify payload.action === "validate" comparison', async () => {
-      mockRequest.payload = { landAction: 'CMOR1', action: 'validate' }
-
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
-
-      expect(validateApplication).toHaveBeenCalled()
-    })
-
     test('should show validation errors from API', async () => {
       mockRequest.payload = { landAction: 'CMOR1', action: 'validate' }
       validateApplication.mockResolvedValue({
@@ -584,8 +478,7 @@ describe('SelectActionsPageController', () => {
         errorMessages: [{ code: 'CMOR1', description: 'Invalid area', passed: false }]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-actions',
@@ -605,8 +498,8 @@ describe('SelectActionsPageController', () => {
       }
       fetchActionsWithPlannedActions.mockResolvedValue({
         actions: [
-          { code: 'UPL1', availableArea: { unit: 'ha', value: 4 } },
-          { code: 'UPL2', availableArea: { unit: 'ha', value: 2 } }
+          { code: 'UPL1', availability: { unit: 'ha', value: 4 } },
+          { code: 'UPL2', availability: { unit: 'ha', value: 2 } }
         ]
       })
       validateApplication.mockResolvedValue({
@@ -614,8 +507,7 @@ describe('SelectActionsPageController', () => {
         errorMessages: [{ code: 'UPL2', description: 'Not enough available area', passed: false }]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const { actionItems } = mockH.view.mock.calls[0][1]
       const upl2 = actionItems.find((item) => item.value === 'UPL2')
@@ -631,8 +523,7 @@ describe('SelectActionsPageController', () => {
         errorMessages: [{ code: 'UPL1', description: 'Invalid quantity', passed: false }]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-actions',
@@ -654,8 +545,7 @@ describe('SelectActionsPageController', () => {
         errorMessages: [{ code: 'UPL2', description: 'Invalid quantity', passed: false }]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const { actionItems } = mockH.view.mock.calls[0][1]
       const cmor1 = actionItems.find((item) => item.value === 'CMOR1')
@@ -674,8 +564,8 @@ describe('SelectActionsPageController', () => {
       }
       fetchActionsWithPlannedActions.mockResolvedValue({
         actions: [
-          { code: 'UPL1', availableArea: { unit: 'ha', value: 0 } },
-          { code: 'UPL2', availableArea: { unit: 'ha', value: 0 } }
+          { code: 'UPL1', availability: { unit: 'ha', value: 0 } },
+          { code: 'UPL2', availability: { unit: 'ha', value: 0 } }
         ]
       })
       validateApplication.mockResolvedValue({
@@ -683,8 +573,7 @@ describe('SelectActionsPageController', () => {
         errorMessages: [{ code: 'UPL2', description: 'Invalid quantity', passed: false }]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const { actionItems } = mockH.view.mock.calls[0][1]
       const upl2 = actionItems.find((item) => item.value === 'UPL2')
@@ -700,14 +589,13 @@ describe('SelectActionsPageController', () => {
       }
       fetchActionsWithPlannedActions.mockResolvedValue({
         actions: [
-          { code: 'UPL1', availableArea: { unit: 'ha', value: 0 } },
-          { code: 'UPL2', availableArea: { unit: 'ha', value: 0 } }
+          { code: 'UPL1', availability: { unit: 'ha', value: 0 } },
+          { code: 'UPL2', availability: { unit: 'ha', value: 0 } }
         ]
       })
       validateApplication.mockRejectedValue(new Error('API issue'))
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const { actionItems } = mockH.view.mock.calls[0][1]
       const upl1 = actionItems.find((item) => item.value === 'UPL1')
@@ -733,8 +621,7 @@ describe('SelectActionsPageController', () => {
         ]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const { actionItems } = mockH.view.mock.calls[0][1]
       const upl2 = actionItems.find((item) => item.value === 'UPL2')
@@ -754,8 +641,7 @@ describe('SelectActionsPageController', () => {
         errorMessages: [{ code: 'CMOR1', description: 'Some other error', passed: false }]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const { actionItems } = mockH.view.mock.calls[0][1]
       const upl2 = actionItems.find((item) => item.value === 'UPL2')
@@ -771,23 +657,19 @@ describe('SelectActionsPageController', () => {
       }
       validateApplication.mockRejectedValue(new Error('Validation API failed'))
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const { actionItems } = mockH.view.mock.calls[0][1]
       expect(actionItems.find((item) => item.value === 'CMOR1').checked).toBe(true)
     })
 
-    describe('when the user does not own the land parcel', () => {
-      it('should return unauthorized response when user does not own the selected land parcel', async () => {
-        controller.performAuthCheck.mockResolvedValue('failed auth check')
-        mockRequest.query = { parcelId: 'sheet1-parcel1' }
+    test('should return the unauthorized response when the user does not own the selected land parcel', async () => {
+      controller.performAuthCheck.mockResolvedValue('failed auth check')
 
-        const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+      const result = await post()
 
-        expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, ['sheet1-parcel1'])
-        expect(result).toEqual('failed auth check')
-      })
+      expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, ['sheet1-parcel1'])
+      expect(result).toEqual('failed auth check')
     })
   })
 })

--- a/src/server/land-grants/controllers/select-grouped-actions-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-grouped-actions-page.controller.test.js
@@ -1,37 +1,29 @@
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
 import {
   fetchGroupedActionsForParcel,
   fetchParcels,
   validateApplication
 } from '~/src/server/land-grants/services/land-grants.service.js'
-import { formatParcelReference, parseLandParcel, stringifyParcel } from '~/src/shared/format-parcel.js'
+import { parseLandParcel } from '~/src/shared/format-parcel.js'
 import SelectGroupedActionsPageController from './select-grouped-actions-page.controller.js'
 import { error, log } from '~/src/server/common/helpers/logging/log.js'
+import {
+  CMOR1,
+  PARCELS_WITH_SIZE,
+  UPL1,
+  UPL2,
+  USER_CONTEXT,
+  makeLandGrantsRequest,
+  makeViewToolkit,
+  mockFormatParcelImplementations,
+  stubControllerMethods
+} from '~/src/server/land-grants/test-helpers.js'
 
-vi.mock('@defra/forms-engine-plugin/controllers/QuestionPageController.js', () => ({
-  QuestionPageController: class {
-    constructor(model, pageDef) {
-      this.model = model
-      this.pageDef = pageDef
-    }
-
-    getViewModel() {}
-
-    getHref(path) {
-      return `/${this.model.basePath}/${path}`.replace(/\/{2,}/g, '/')
-    }
-
-    makeGetRouteHandler() {
-      return async (request, context, h) => h.view('select-land-actions', this.getViewModel(request, context))
-    }
-
-    makePostRouteHandler() {
-      return async (request, context, h) => h.view('select-land-actions', this.getViewModel(request, context))
-    }
-  }
-}))
+vi.mock('@defra/forms-engine-plugin/controllers/QuestionPageController.js', async () => {
+  const { makeQuestionPageControllerMock } = await import('~/src/__mocks__')
+  return makeQuestionPageControllerMock('select-land-actions')
+})
 
 vi.mock('~/src/server/task-list/task-list.helper.js', () => ({
   withTaskContext: (Base) => Base
@@ -53,61 +45,20 @@ vi.mock('~/src/config/config.js', async () => {
 vi.mock('~/src/server/land-grants/services/land-grants.service.js')
 vi.mock('~/src/shared/format-parcel.js')
 
-const mockParcelsResponse = [
-  {
-    parcelId: '0155',
-    sheetId: 'SD7946',
-    area: { unit: 'ha', value: 4.0383 }
-  },
-  {
-    parcelId: '4509',
-    sheetId: 'SD7846',
-    area: { unit: 'sqm', value: 0.0633 }
-  }
-]
-const userContext = { defraIdToken: 'defra-id-access-token', sbi: '106284736' }
-
 describe('SelectGroupedActionsPageController', () => {
+  const post = () => controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+  const get = () => controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
+
   let controller
   let mockRequest
   let mockContext
   let mockH
-  let mockResponseWithCode
 
   const enabledLandActions = ['CMOR1', 'UPL1', 'UPL2']
 
   const mockGroupedActions = [
-    {
-      name: 'Assess moorland',
-      totalAvailableArea: { unit: 'ha', value: 10 },
-      actions: [
-        {
-          code: 'CMOR1',
-          description: 'Assess moorland and produce a written record: CMOR1',
-          availableArea: { unit: 'ha', value: 10 },
-          ratePerUnitGbp: 16,
-          ratePerAgreementPerYearGbp: 272
-        }
-      ]
-    },
-    {
-      name: 'Livestock grazing on moorland',
-      totalAvailableArea: { unit: 'ha', value: 5 },
-      actions: [
-        {
-          code: 'UPL1',
-          description: 'Moderate livestock grazing on moorland: UPL1',
-          availableArea: { unit: 'ha', value: 5 },
-          ratePerUnitGbp: 33
-        },
-        {
-          code: 'UPL2',
-          description: 'Heavy livestock grazing on moorland: UPL2',
-          availableArea: { unit: 'ha', value: 3 },
-          ratePerUnitGbp: 45
-        }
-      ]
-    }
+    { name: 'Assess moorland', totalAvailableArea: { unit: 'ha', value: 10 }, actions: [CMOR1] },
+    { name: 'Livestock grazing on moorland', totalAvailableArea: { unit: 'ha', value: 5 }, actions: [UPL1, UPL2] }
   ]
 
   beforeEach(() => {
@@ -120,56 +71,15 @@ describe('SelectGroupedActionsPageController', () => {
     })
 
     const mockModel = { def: { metadata: { tasklist: {}, enabledLandActions } }, getSection: vi.fn(), pages: [] }
-    controller = new SelectGroupedActionsPageController(mockModel, {})
-    controller.collection = {
-      getErrors: vi.fn().mockReturnValue([])
-    }
-    controller.setState = vi.fn().mockResolvedValue(true)
-    controller.proceed = vi.fn().mockReturnValue('redirected')
-    controller.getNextPath = vi.fn().mockReturnValue('/next-path')
-    controller.performAuthCheck = vi.fn().mockResolvedValue(null)
+    controller = stubControllerMethods(new SelectGroupedActionsPageController(mockModel, {}))
 
-    fetchParcels.mockResolvedValue(mockParcelsResponse)
+    fetchParcels.mockResolvedValue(PARCELS_WITH_SIZE)
 
-    mockRequest = {
-      payload: { landAction_1: 'CMOR1' },
-      query: {},
-      logger: mockRequestLogger(),
-      auth: {
-        isAuthenticated: true,
-        credentials: {
-          token: userContext.defraIdToken,
-          sbi: userContext.sbi,
-          crn: 'CRN123',
-          name: 'John Doe',
-          organisationName: 'Farm 1',
-          role: 'admin',
-          sessionId: 'valid-session-id'
-        }
-      }
-    }
+    mockRequest = makeLandGrantsRequest({ payload: { landAction_1: 'CMOR1' } })
+    mockContext = { state: {}, referenceNumber: 'REF123' }
+    mockH = makeViewToolkit()
 
-    mockContext = {
-      state: {},
-      referenceNumber: 'REF123'
-    }
-
-    mockResponseWithCode = {
-      code: vi.fn().mockReturnValue('final-response')
-    }
-
-    mockH = {
-      view: vi.fn().mockReturnValue('rendered view'),
-      redirect: vi.fn(),
-      response: vi.fn().mockReturnValue(mockResponseWithCode)
-    }
-
-    parseLandParcel.mockReturnValue(['sheet1', 'parcel1'])
-    stringifyParcel.mockImplementation(({ sheetId, parcelId }) => `${sheetId}-${parcelId}`)
-    formatParcelReference.mockImplementation((parcel) => {
-      const [sheetId, parcelId] = typeof parcel === 'string' ? parcel.split('-') : [parcel.sheetId, parcel.parcelId]
-      return [sheetId, parcelId].filter((part) => part != null && part !== '').join(' ')
-    })
+    mockFormatParcelImplementations()
     fetchGroupedActionsForParcel.mockResolvedValue({
       actions: mockGroupedActions,
       parcel: { parcelId: 'parcel1', sheetId: 'sheet1', size: 10 }
@@ -182,16 +92,10 @@ describe('SelectGroupedActionsPageController', () => {
   })
 
   describe('singleParcelSubmission (grant-level config)', () => {
-    const buildController = (metadata) => {
-      const model = { def: { metadata }, getSection: vi.fn(), pages: [] }
-      const singleController = new SelectGroupedActionsPageController(model, {})
-      singleController.collection = { getErrors: vi.fn().mockReturnValue([]) }
-      singleController.setState = vi.fn().mockResolvedValue(true)
-      singleController.proceed = vi.fn().mockReturnValue('redirected')
-      singleController.getNextPath = vi.fn().mockReturnValue('/next-path')
-      singleController.performAuthCheck = vi.fn().mockResolvedValue(null)
-      return singleController
-    }
+    const buildController = (metadata) =>
+      stubControllerMethods(
+        new SelectGroupedActionsPageController({ def: { metadata }, getSection: vi.fn(), pages: [] }, {})
+      )
 
     test('defaults to false when metadata does not include the flag', () => {
       expect(controller.singleParcelSubmission).toBe(false)
@@ -235,8 +139,7 @@ describe('SelectGroupedActionsPageController', () => {
     test('should redirect to /select-land-parcel if no selected land parcel is set', async () => {
       mockRequest.query = {}
 
-      const handler = controller.makeGetRouteHandler()
-      const result = await handler(mockRequest, mockContext, mockH)
+      const result = await get()
 
       expect(controller.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/select-land-parcel')
       expect(result).toBe('redirected')
@@ -246,8 +149,7 @@ describe('SelectGroupedActionsPageController', () => {
       mockRequest.query.parcelId = 'sheet2-parcel2'
       parseLandParcel.mockReturnValue(['sheet2', 'parcel2'])
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, ['sheet2-parcel2'])
 
@@ -259,7 +161,7 @@ describe('SelectGroupedActionsPageController', () => {
           enabledLandActions,
           plannedActions: []
         },
-        userContext
+        USER_CONTEXT
       )
     })
 
@@ -268,8 +170,7 @@ describe('SelectGroupedActionsPageController', () => {
       controller = new SelectGroupedActionsPageController(mockModel, {})
       controller.performAuthCheck = vi.fn().mockResolvedValue(null)
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       expect(fetchGroupedActionsForParcel).toHaveBeenCalledWith(
         {
@@ -278,13 +179,12 @@ describe('SelectGroupedActionsPageController', () => {
           enabledLandActions: [],
           plannedActions: []
         },
-        userContext
+        USER_CONTEXT
       )
     })
 
     test('should render view with correct data', async () => {
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -304,8 +204,7 @@ describe('SelectGroupedActionsPageController', () => {
         }
       }
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -318,8 +217,7 @@ describe('SelectGroupedActionsPageController', () => {
     test('should handle fetch errors gracefully', async () => {
       fetchGroupedActionsForParcel.mockRejectedValue(new Error('API Error'))
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -352,8 +250,7 @@ describe('SelectGroupedActionsPageController', () => {
         parcel: { parcelId: 'parcel1', sheetId: 'sheet1', size: 10 }
       })
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await get()
 
       expect(log).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -368,16 +265,13 @@ describe('SelectGroupedActionsPageController', () => {
       )
     })
 
-    describe('when the user does not own the land parcel', () => {
-      it('should return unauthorized response when user does not own the selected land parcel', async () => {
-        controller.performAuthCheck.mockResolvedValue('failed auth check')
+    test('should return the unauthorized response when the user does not own the selected land parcel', async () => {
+      controller.performAuthCheck.mockResolvedValue('failed auth check')
 
-        const result = await controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
+      const result = await get()
 
-        expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, ['sheet1-parcel1'])
-
-        expect(result).toEqual('failed auth check')
-      })
+      expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, ['sheet1-parcel1'])
+      expect(result).toEqual('failed auth check')
     })
   })
 
@@ -390,8 +284,7 @@ describe('SelectGroupedActionsPageController', () => {
     test('should handle null payload', async () => {
       mockRequest.payload = null
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -406,8 +299,7 @@ describe('SelectGroupedActionsPageController', () => {
       mockContext.state.selectedLandParcel = 'state-parcel'
       mockRequest.payload = { landAction_1: 'CMOR1' }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, ['query-parcel'])
     })
@@ -416,8 +308,7 @@ describe('SelectGroupedActionsPageController', () => {
       fetchGroupedActionsForParcel.mockResolvedValue({ actions: [], parcel: {} })
       mockRequest.payload = { landAction_1: 'CMOR1' }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -431,46 +322,16 @@ describe('SelectGroupedActionsPageController', () => {
       )
     })
 
-    test('should verify payload.action === "validate" comparison', async () => {
-      mockRequest.payload = {
-        landAction_1: 'CMOR1',
-        action: 'validate'
-      }
-
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
-
-      expect(validateApplication).toHaveBeenCalled()
-    })
-
     test('should skip validation when action is different', async () => {
       mockRequest.payload = {
         landAction_1: 'CMOR1',
         action: 'continue'
       }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(validateApplication).not.toHaveBeenCalled()
       expect(controller.proceed).toHaveBeenCalled()
-    })
-
-    test('should return validation result when not null', async () => {
-      mockRequest.payload = {
-        landAction_1: 'CMOR1',
-        action: 'validate'
-      }
-      validateApplication.mockResolvedValue({
-        valid: false,
-        errorMessages: [{ code: 'CMOR1', description: 'Invalid', passed: false }]
-      })
-
-      const handler = controller.makePostRouteHandler()
-      const result = await handler(mockRequest, mockContext, mockH)
-
-      expect(controller.proceed).not.toHaveBeenCalled()
-      expect(result).not.toBe('redirected')
     })
 
     test('should handle validation error with no code property', async () => {
@@ -483,8 +344,7 @@ describe('SelectGroupedActionsPageController', () => {
         errorMessages: [{ description: 'Error without code', passed: false }]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -498,7 +358,7 @@ describe('SelectGroupedActionsPageController', () => {
       const groupedActions = [
         {
           name: 'Test',
-          actions: [{ code: 'TEST1', description: 'Test Action', availableArea: { value: 5, unit: 'ha' } }]
+          actions: [{ code: 'TEST1', description: 'Test Action', availability: { value: 5, unit: 'ha' } }]
         }
       ]
       fetchGroupedActionsForParcel.mockResolvedValue({
@@ -510,8 +370,7 @@ describe('SelectGroupedActionsPageController', () => {
         landAction_2: ''
       }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const stateArg = controller.setState.mock.calls[0][1]
       expect(Object.keys(stateArg.landParcels['sheet1-parcel1'].actionsObj)).toHaveLength(1)
@@ -521,8 +380,7 @@ describe('SelectGroupedActionsPageController', () => {
     test('should update state and proceed on valid submission', async () => {
       mockRequest.payload = { landAction_1: 'CMOR1' }
 
-      const handler = controller.makePostRouteHandler()
-      const result = await handler(mockRequest, mockContext, mockH)
+      const result = await post()
 
       expect(controller.setState).toHaveBeenCalledWith(
         mockRequest,
@@ -548,8 +406,7 @@ describe('SelectGroupedActionsPageController', () => {
     test('should show errors when no actions selected', async () => {
       mockRequest.payload = {}
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -565,8 +422,7 @@ describe('SelectGroupedActionsPageController', () => {
         action: 'validate'
       }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(validateApplication).toHaveBeenCalledWith(
         {
@@ -574,7 +430,7 @@ describe('SelectGroupedActionsPageController', () => {
           crn: 'CRN123',
           state: expect.any(Object)
         },
-        userContext
+        USER_CONTEXT
       )
     })
 
@@ -588,8 +444,7 @@ describe('SelectGroupedActionsPageController', () => {
         errorMessages: [{ code: 'CMOR1', description: 'Invalid area', passed: false }]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -613,8 +468,7 @@ describe('SelectGroupedActionsPageController', () => {
         ]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -630,8 +484,7 @@ describe('SelectGroupedActionsPageController', () => {
         landAction_2: 'UPL1'
       }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(controller.setState).toHaveBeenCalledWith(
         mockRequest,
@@ -662,8 +515,7 @@ describe('SelectGroupedActionsPageController', () => {
         landAction_2: 'UPL1'
       }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const stateArg = controller.setState.mock.calls[0][1]
       expect(stateArg.landParcels['sheet1-parcel1'].actionsObj).toHaveProperty('UPL2')
@@ -683,8 +535,7 @@ describe('SelectGroupedActionsPageController', () => {
         landAction_2: 'CMOR1'
       }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const stateArg = controller.setState.mock.calls[0][1]
       expect(stateArg.landParcels['sheet1-parcel1'].actionsObj).toHaveProperty('CMOR1')
@@ -701,8 +552,7 @@ describe('SelectGroupedActionsPageController', () => {
         errorMessages: []
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(controller.proceed).toHaveBeenCalled()
     })
@@ -718,8 +568,7 @@ describe('SelectGroupedActionsPageController', () => {
         errorMessages: [{ code: 'UPL1', description: 'Error for UPL1', passed: false }]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -729,26 +578,12 @@ describe('SelectGroupedActionsPageController', () => {
       )
     })
 
-    test('should proceed without validation when action is not validate', async () => {
-      mockRequest.payload = {
-        landAction_1: 'CMOR1',
-        action: 'continue'
-      }
-
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
-
-      expect(validateApplication).not.toHaveBeenCalled()
-      expect(controller.proceed).toHaveBeenCalled()
-    })
-
     test('should preserve state properties when updating', async () => {
       mockContext.state.someProperty = 'value'
       mockContext.state.landParcels = {}
       mockRequest.payload = { landAction_1: 'CMOR1' }
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       const stateArg = controller.setState.mock.calls[0][1]
       expect(stateArg).toHaveProperty('someProperty')
@@ -769,8 +604,7 @@ describe('SelectGroupedActionsPageController', () => {
         ]
       })
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -794,8 +628,7 @@ describe('SelectGroupedActionsPageController', () => {
 
       validateApplication.mockRejectedValue(apiError)
 
-      const handler = controller.makePostRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-grouped-actions',
@@ -810,35 +643,13 @@ describe('SelectGroupedActionsPageController', () => {
       )
     })
 
-    test('should handle timeout when fetching available actions gracefully', async () => {
-      fetchGroupedActionsForParcel.mockRejectedValue(new Error('Operation timed out after 30000ms'))
+    test('should return the unauthorized response when the user does not own the selected land parcel', async () => {
+      controller.performAuthCheck.mockResolvedValue('failed auth check')
 
-      const handler = controller.makeGetRouteHandler()
-      await handler(mockRequest, mockContext, mockH)
+      const result = await post()
 
-      expect(mockH.view).toHaveBeenCalledWith(
-        'select-grouped-actions',
-        expect.objectContaining({
-          errors: [
-            {
-              text: 'Unable to find actions information for parcel, please try again later or contact the Rural Payments Agency.'
-            }
-          ]
-        })
-      )
-    })
-
-    describe('when the user does not own the land parcel', () => {
-      it('should return unauthorized response when user does not own the selected land parcel', async () => {
-        controller.performAuthCheck.mockResolvedValue('failed auth check')
-        mockRequest.query = { parcelId: 'sheet1-parcel1' }
-
-        const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
-
-        expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, ['sheet1-parcel1'])
-
-        expect(result).toEqual('failed auth check')
-      })
+      expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, ['sheet1-parcel1'])
+      expect(result).toEqual('failed auth check')
     })
   })
 })

--- a/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
+++ b/src/server/land-grants/controllers/select-land-parcel-page.controller.test.js
@@ -1,24 +1,21 @@
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
 import { vi } from 'vitest'
-import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
 import { debug } from '~/src/server/common/helpers/logging/log.js'
-import { setupControllerMocks } from '~/src/__mocks__/controller-mocks.js'
 import { fetchParcels } from '~/src/server/land-grants/services/land-grants.service.js'
 import SelectLandParcelPageController from './select-land-parcel-page.controller.js'
+import {
+  PARCELS_WITH_SIZE,
+  USER_CONTEXT,
+  makeLandGrantsRequest,
+  makeViewToolkit,
+  mockFormatParcelImplementations,
+  stubControllerMethods
+} from '~/src/server/land-grants/test-helpers.js'
 
-vi.mock('@defra/forms-engine-plugin/controllers/QuestionPageController.js', () => ({
-  QuestionPageController: class {
-    getViewModel() {}
-
-    makeGetRouteHandler() {
-      return async (request, context, h) => h.view('select-land-parcel', this.getViewModel(request, context))
-    }
-
-    makePostRouteHandler() {
-      return async (request, context, h) => h.view('select-land-parcel', this.getViewModel(request, context))
-    }
-  }
-}))
+vi.mock('@defra/forms-engine-plugin/controllers/QuestionPageController.js', async () => {
+  const { makeQuestionPageControllerMock } = await import('~/src/__mocks__')
+  return makeQuestionPageControllerMock('select-land-parcel')
+})
 
 vi.mock('~/src/server/task-list/task-list.helper.js', () => ({
   withTaskContext: (Base) => Base
@@ -37,26 +34,7 @@ vi.mock('~/src/server/land-grants/services/land-grants.service.js', () => ({
   fetchParcels: vi.fn()
 }))
 
-vi.mock('~/src/shared/format-parcel.js', () => ({
-  stringifyParcel: ({ parcelId, sheetId }) => `${sheetId}-${parcelId}`,
-  formatParcelReference: (parcel) => {
-    const [sheetId, parcelId] = typeof parcel === 'string' ? parcel.split('-') : [parcel.sheetId, parcel.parcelId]
-    return [sheetId, parcelId].filter((part) => part != null && part !== '').join(' ')
-  }
-}))
-
-const mockParcelsResponse = [
-  {
-    parcelId: '0155',
-    sheetId: 'SD7946',
-    area: { unit: 'ha', value: 4.0383 }
-  },
-  {
-    parcelId: '4509',
-    sheetId: 'SD7846',
-    area: { unit: 'sqm', value: 0.0633 }
-  }
-]
+vi.mock('~/src/shared/format-parcel.js')
 
 const controllerParcelsResponse = [
   {
@@ -74,36 +52,15 @@ const controllerParcelsResponse = [
 describe('SelectLandParcelPageController', () => {
   let controller
   let mockRequest
-  let mockResponseWithCode
   let mockContext
   let mockH
 
   const renderedViewMock = 'mock-rendered-view'
   const state = { landParcels: ['sheet123'] }
-
-  const setupRequest = () => ({
-    query: {},
-    logger: mockRequestLogger(),
-    auth: {
-      isAuthenticated: true,
-      credentials: {
-        token: 'defra-id-access-token',
-        sbi: '106284736',
-        crn: '1102838829',
-        name: 'John Doe',
-        organisationName: 'Farm 1',
-        role: 'admin',
-        sessionId: 'valid-session-id'
-      }
-    }
-  })
+  const post = () => controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+  const get = () => controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
 
   const setupContext = (state = {}) => ({ state })
-
-  const setupH = () => ({
-    view: vi.fn().mockReturnValue(renderedViewMock),
-    response: vi.fn().mockReturnValue(mockResponseWithCode)
-  })
 
   beforeEach(() => {
     const mockModelForViewModel = {
@@ -124,24 +81,17 @@ describe('SelectLandParcelPageController', () => {
       def: { metadata: { tasklist: {} } },
       getSection: vi.fn()
     }
-    const mockPageDef = {}
-    controller = new SelectLandParcelPageController(mockModel, mockPageDef)
-    setupControllerMocks(controller, { proceed: 'next', nextPath: '/next-page' })
-    controller.performAuthCheck = vi.fn().mockResolvedValue(null)
-
-    fetchParcels.mockResolvedValue(mockParcelsResponse)
-
-    mockRequest = setupRequest()
-    mockContext = setupContext({
-      sbi: 117235001,
-      customerReference: 1100598138
+    controller = stubControllerMethods(new SelectLandParcelPageController(mockModel, {}), {
+      proceed: 'next',
+      nextPath: '/next-page'
     })
 
-    mockResponseWithCode = {
-      code: vi.fn().mockReturnValue('final-response')
-    }
+    mockFormatParcelImplementations()
+    fetchParcels.mockResolvedValue(PARCELS_WITH_SIZE)
 
-    mockH = setupH()
+    mockRequest = makeLandGrantsRequest()
+    mockContext = setupContext({ sbi: 117235001, customerReference: 1100598138 })
+    mockH = makeViewToolkit(renderedViewMock)
   })
 
   afterEach(vi.clearAllMocks)
@@ -163,12 +113,9 @@ describe('SelectLandParcelPageController', () => {
 
   describe('GET route handler', () => {
     it('gets parcels info and renders view', async () => {
-      const result = await controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
+      const result = await get()
 
-      expect(fetchParcels).toHaveBeenCalledWith(mockRequest, {
-        defraIdToken: 'defra-id-access-token',
-        sbi: '106284736'
-      })
+      expect(fetchParcels).toHaveBeenCalledWith(mockRequest, USER_CONTEXT)
       expect(mockH.view).toHaveBeenCalledWith(
         'select-land-parcel',
         expect.objectContaining({
@@ -179,10 +126,14 @@ describe('SelectLandParcelPageController', () => {
       expect(result).toBe(renderedViewMock)
     })
 
-    it('handles missing parcels info', async () => {
-      fetchParcels.mockRejectedValue(new Error('not found'))
+    it.each([
+      ['the fetch rejects', () => fetchParcels.mockRejectedValue(new Error('not found'))],
+      ['the fetch times out', () => fetchParcels.mockRejectedValue(new Error('Operation timed out after 30000ms'))],
+      ['no parcels come back', () => fetchParcels.mockResolvedValue([])]
+    ])('renders the parcel-information error when %s', async (_case, arrange) => {
+      arrange()
 
-      const result = await controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
+      const result = await get()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-land-parcel',
@@ -198,7 +149,7 @@ describe('SelectLandParcelPageController', () => {
       const thrown = new Error('not found')
       fetchParcels.mockRejectedValue(thrown)
 
-      await controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
+      await get()
 
       const [logCode, messageOptions, loggedRequest] = debug.mock.calls[0]
       expect(logCode.level).toBe('error')
@@ -207,21 +158,6 @@ describe('SelectLandParcelPageController', () => {
       expect(messageOptions).toEqual({})
       expect(loggedRequest).toBe(mockRequest)
     })
-
-    it('handles empty parcels list info', async () => {
-      fetchParcels.mockResolvedValue([])
-
-      const result = await controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
-
-      expect(mockH.view).toHaveBeenCalledWith(
-        'select-land-parcel',
-        expect.objectContaining({
-          pageTitle: 'Select Land Parcel',
-          errors: ['Unable to find parcel information, please try again later or contact the Rural Payments Agency.']
-        })
-      )
-      expect(result).toBe(renderedViewMock)
-    })
   })
 
   describe('POST route handler', () => {
@@ -229,7 +165,7 @@ describe('SelectLandParcelPageController', () => {
       mockRequest.payload = state
       mockContext = setupContext({ existing: 'value' })
 
-      const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+      const result = await post()
 
       expect(controller.performAuthCheck).toHaveBeenCalledWith(mockRequest, mockH, [state.landParcels[0]])
       expect(controller.setState).not.toHaveBeenCalled()
@@ -237,23 +173,26 @@ describe('SelectLandParcelPageController', () => {
       expect(result).toBe('next')
     })
 
-    describe('when the user does not own the land parcel', () => {
-      it('should return unauthorized response when user does not own the selected land parcel', async () => {
-        mockRequest.payload = state
-        mockContext = setupContext({ existing: 'value' })
-        controller.performAuthCheck.mockResolvedValue('failed auth check')
+    it('should return the unauthorized response when the user does not own the selected land parcel', async () => {
+      mockRequest.payload = state
+      mockContext = setupContext({ existing: 'value' })
+      controller.performAuthCheck.mockResolvedValue('failed auth check')
 
-        const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+      const result = await post()
 
-        expect(result).toEqual('failed auth check')
-      })
+      expect(result).toEqual('failed auth check')
     })
 
-    it('sets an error if selectedLandParcel is not defined', async () => {
-      mockRequest.payload = { action: 'validate' }
+    it.each([
+      ['no parcel was selected', { action: 'validate' }, {}],
+      ['the selected parcel is blank', { action: 'validate', landParcels: [''] }, {}],
+      ['only the query carries a parcel id', { action: 'validate' }, { parcelId: 'queryParcel' }]
+    ])('shows the "select a parcel" error on validate when %s', async (_case, payload, query) => {
+      mockRequest.payload = payload
+      mockRequest.query = query
       mockContext = setupContext({ existing: 'value' })
 
-      const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+      const result = await post()
 
       expect(controller.setState).not.toHaveBeenCalled()
       expect(controller.proceed).not.toHaveBeenCalled()
@@ -264,40 +203,28 @@ describe('SelectLandParcelPageController', () => {
           errors: 'Select a land parcel'
         })
       )
-      expect(result).toBe('mock-rendered-view')
+      expect(result).toBe(renderedViewMock)
     })
 
-    it('handles missing selectedLandParcel in payload', async () => {
-      mockRequest.payload = {}
+    it.each([
+      ['the payload has no parcel', {}],
+      ['the payload is null', null]
+    ])('proceeds with an undefined parcel id when %s', async (_case, payload) => {
+      mockRequest.payload = payload
       mockContext = setupContext({})
 
-      const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+      const result = await post()
 
       expect(controller.setState).not.toHaveBeenCalled()
       expect(controller.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/next-page?parcelId=undefined')
       expect(result).toBe('next')
     })
 
-    it('should verify both action=validate AND selectedLandParcel conditions', async () => {
-      mockRequest.payload = { action: 'validate', landParcels: [''] }
-      mockContext = setupContext({ existing: 'value' })
-
-      const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
-
-      expect(mockH.view).toHaveBeenCalledWith(
-        'select-land-parcel',
-        expect.objectContaining({
-          errors: 'Select a land parcel'
-        })
-      )
-      expect(result).toBe('mock-rendered-view')
-    })
-
     it('should not show error when action is not validate even if selectedLandParcel missing', async () => {
       mockRequest.payload = { action: 'other', landParcels: [''] }
       mockContext = setupContext({})
 
-      await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).not.toHaveBeenCalledWith(
         'select-land-parcel',
@@ -308,37 +235,12 @@ describe('SelectLandParcelPageController', () => {
       expect(controller.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/next-page?parcelId=')
     })
 
-    it('should handle payload being null', async () => {
-      mockRequest.payload = null
-      mockContext = setupContext({})
-
-      const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
-
-      expect(controller.setState).not.toHaveBeenCalled()
-      expect(controller.proceed).toHaveBeenCalledWith(mockRequest, mockH, '/next-page?parcelId=undefined')
-      expect(result).toBe('next')
-    })
-
-    it('does not use query parcelId for validation', async () => {
-      mockRequest.query = { parcelId: 'queryParcel' }
-      mockRequest.payload = { action: 'validate' }
-
-      await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
-
-      expect(mockH.view).toHaveBeenCalledWith(
-        'select-land-parcel',
-        expect.objectContaining({
-          errors: 'Select a land parcel'
-        })
-      )
-    })
-
     it('should handle error when fetching parcels for validation error', async () => {
       mockRequest.payload = { action: 'validate' }
       mockContext = setupContext({ existing: 'value', landParcels: { 'SD7946-0155': { actionsObj: { ACTION1: {} } } } })
       fetchParcels.mockRejectedValue(new Error('Fetch error'))
 
-      const result = await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+      const result = await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-land-parcel',
@@ -347,7 +249,7 @@ describe('SelectLandParcelPageController', () => {
           parcels: []
         })
       )
-      expect(result).toBe('mock-rendered-view')
+      expect(result).toBe(renderedViewMock)
     })
 
     it('logs the caught error at error level when validation re-fetch fails', async () => {
@@ -356,7 +258,7 @@ describe('SelectLandParcelPageController', () => {
       mockContext = setupContext({ existing: 'value', landParcels: { 'SD7946-0155': { actionsObj: { ACTION1: {} } } } })
       fetchParcels.mockRejectedValue(thrown)
 
-      await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+      await post()
 
       const [logCode, messageOptions, loggedRequest] = debug.mock.calls[0]
       expect(logCode.level).toBe('error')
@@ -364,20 +266,6 @@ describe('SelectLandParcelPageController', () => {
       expect(logCode.messageFunc()).toBe('Error fetching parcels for validation error rendering')
       expect(messageOptions).toEqual({})
       expect(loggedRequest).toBe(mockRequest)
-    })
-
-    it('should handle timeout when fetching parcels gracefully', async () => {
-      fetchParcels.mockRejectedValue(new Error('Operation timed out after 30000ms'))
-
-      const result = await controller.makeGetRouteHandler()(mockRequest, mockContext, mockH)
-
-      expect(mockH.view).toHaveBeenCalledWith(
-        'select-land-parcel',
-        expect.objectContaining({
-          errors: ['Unable to find parcel information, please try again later or contact the Rural Payments Agency.']
-        })
-      )
-      expect(result).toBe(renderedViewMock)
     })
 
     it('should correctly calculate actions count', async () => {
@@ -388,7 +276,7 @@ describe('SelectLandParcelPageController', () => {
         }
       })
 
-      await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-land-parcel',
@@ -410,7 +298,7 @@ describe('SelectLandParcelPageController', () => {
         }
       })
 
-      await controller.makePostRouteHandler()(mockRequest, mockContext, mockH)
+      await post()
 
       expect(mockH.view).toHaveBeenCalledWith(
         'select-land-parcel',

--- a/src/server/land-grants/land-grants-actions.plugin.js
+++ b/src/server/land-grants/land-grants-actions.plugin.js
@@ -5,6 +5,7 @@ import { fetchAuthorisedParcelIds } from '~/src/server/land-grants/services/parc
 import { fetchActionsWithPlannedActions } from '~/src/server/land-grants/services/land-grants.service.js'
 import { COMPOUND_PARCEL_ID_PATTERN, parseLandParcel } from '~/src/shared/format-parcel.js'
 import { getLandGrantsUserContext } from '~/src/server/land-grants/services/land-grants-user-context.js'
+import { UNIT_TYPES } from '~/src/shared/unit-types.js'
 
 const plannedActionsValidation = {
   params: Joi.object({
@@ -16,7 +17,9 @@ const plannedActionsValidation = {
         Joi.object({
           actionCode: Joi.string().required(),
           quantity: Joi.number().required(),
-          unit: Joi.string().valid('ha', 'sqm').required()
+          unit: Joi.string()
+            .valid(...UNIT_TYPES)
+            .required()
         })
       )
       .required()
@@ -26,7 +29,7 @@ const plannedActionsValidation = {
 /**
  * Live action-availability refresh for the select-actions page. Given the
  * user's in-progress selection (plannedActions), recomputes each action's
- * availableArea so the client can grey out actions that are no longer
+ * availability so the client can grey out actions that are no longer
  * available with that combination, without a full page reload.
  * @param {Request} request
  * @param {ResponseToolkit} h

--- a/src/server/land-grants/land-grants-actions.plugin.test.js
+++ b/src/server/land-grants/land-grants-actions.plugin.test.js
@@ -4,6 +4,8 @@ import { landGrantsActionsPlugin } from './land-grants-actions.plugin.js'
 import { fetchAuthorisedParcelIds } from '~/src/server/land-grants/services/parcel-cache.js'
 import { fetchActionsWithPlannedActions } from '~/src/server/land-grants/services/land-grants.service.js'
 import { error } from '~/src/server/common/helpers/logging/log.js'
+import { UNIT_TYPES } from '~/src/shared/unit-types.js'
+import { USER_CONTEXT } from '~/src/server/land-grants/test-helpers.js'
 
 vi.mock('~/src/server/land-grants/services/parcel-cache.js', () => ({
   fetchAuthorisedParcelIds: vi.fn()
@@ -29,8 +31,8 @@ function makeServer() {
 function makeRequest({
   parcelId = 'SD7946-0155',
   plannedActions = [],
-  sbi = '106284736',
-  token = 'defra-id-access-token'
+  sbi = USER_CONTEXT.sbi,
+  token = USER_CONTEXT.defraIdToken
 } = {}) {
   return {
     params: { parcelId },
@@ -48,28 +50,41 @@ function makeH() {
 }
 
 describe('landGrantsActionsPlugin', () => {
+  let route
   let handler
+
+  const validatePlannedActionUnit = (unit) =>
+    route.options.validate.payload.validate({ plannedActions: [{ actionCode: 'UPL1', quantity: 5, unit }] }).error
 
   beforeEach(() => {
     const server = makeServer()
     landGrantsActionsPlugin.plugin.register(server)
-    handler = server._routes[0].handler
+    route = server._routes[0]
+    handler = route.handler
     vi.clearAllMocks()
   })
 
   it('registers a session-authed POST route', () => {
-    const server = makeServer()
-    landGrantsActionsPlugin.plugin.register(server)
-
-    expect(server._routes[0]).toMatchObject({
+    expect(route).toMatchObject({
       method: 'POST',
       path: '/api/land-grants/actions/{parcelId}',
       options: expect.objectContaining({ auth: { mode: 'required', strategy: 'session' } })
     })
   })
 
-  it('rejects with 403 when the parcel is not in the caller-authorised set', async () => {
-    fetchAuthorisedParcelIds.mockResolvedValue(['SD1111-0001'])
+  it.each(UNIT_TYPES)('accepts %s as a planned action unit', (unit) => {
+    expect(validatePlannedActionUnit(unit)).toBeUndefined()
+  })
+
+  it('rejects a planned action unit the API never reports', () => {
+    expect(validatePlannedActionUnit('furlong')).toBeDefined()
+  })
+
+  it.each([
+    ['the parcel is not in the caller-authorised set', ['SD1111-0001']],
+    ['the authorised-parcels lookup fails', null]
+  ])('rejects with 403 when %s', async (_case, authorisedParcelIds) => {
+    fetchAuthorisedParcelIds.mockResolvedValue(authorisedParcelIds)
     const request = makeRequest({ parcelId: 'SD7946-0155' })
     const h = makeH()
 
@@ -80,21 +95,10 @@ describe('landGrantsActionsPlugin', () => {
     expect(fetchActionsWithPlannedActions).not.toHaveBeenCalled()
   })
 
-  it('rejects with 403 when the authorised-parcels lookup fails', async () => {
-    fetchAuthorisedParcelIds.mockResolvedValue(null)
-    const request = makeRequest()
-    const h = makeH()
-
-    await handler(request, h)
-
-    expect(h._responseObj.code).toHaveBeenCalledWith(403)
-    expect(fetchActionsWithPlannedActions).not.toHaveBeenCalled()
-  })
-
   it('returns the recomputed actions for an authorised parcel', async () => {
     fetchAuthorisedParcelIds.mockResolvedValue(['SD7946-0155'])
     const plannedActions = [{ actionCode: 'CSAM3', quantity: 1.5, unit: 'ha' }]
-    const apiResult = { actions: [{ code: 'CSAM3', availableArea: { value: 1.5, unit: 'ha' } }] }
+    const apiResult = { actions: [{ code: 'CSAM3', availability: { value: 1.5, unit: 'ha' } }] }
     fetchActionsWithPlannedActions.mockResolvedValue(apiResult)
     const request = makeRequest({ parcelId: 'SD7946-0155', plannedActions })
     const h = makeH()
@@ -107,7 +111,7 @@ describe('landGrantsActionsPlugin', () => {
         sheetId: 'SD7946',
         plannedActions
       },
-      { defraIdToken: 'defra-id-access-token', sbi: '106284736' }
+      USER_CONTEXT
     )
     expect(h.response).toHaveBeenCalledWith(apiResult)
     expect(h._responseObj.code).toHaveBeenCalledWith(200)
@@ -117,7 +121,7 @@ describe('landGrantsActionsPlugin', () => {
     fetchAuthorisedParcelIds.mockResolvedValue(['SD7946-0155'])
     const upstreamError = Object.assign(new Error('quantity exceeds available area'), { status: 400 })
     fetchActionsWithPlannedActions.mockRejectedValue(upstreamError)
-    const request = makeRequest({ parcelId: 'SD7946-0155', sbi: '106284736' })
+    const request = makeRequest({ parcelId: 'SD7946-0155' })
     const h = makeH()
 
     await handler(request, h)
@@ -129,7 +133,7 @@ describe('landGrantsActionsPlugin', () => {
     fetchAuthorisedParcelIds.mockResolvedValue(['SD7946-0155'])
     const upstreamError = Object.assign(new Error('upstream down'), { status: 502 })
     fetchActionsWithPlannedActions.mockRejectedValue(upstreamError)
-    const request = makeRequest({ parcelId: 'SD7946-0155', sbi: '106284736' })
+    const request = makeRequest({ parcelId: 'SD7946-0155' })
     const h = makeH()
 
     await handler(request, h)

--- a/src/server/land-grants/mappers/state-to-gas-answers-mapper.test.js
+++ b/src/server/land-grants/mappers/state-to-gas-answers-mapper.test.js
@@ -1,30 +1,10 @@
 import { stateToLandGrantsGasAnswers } from '~/src/server/land-grants/mappers/state-to-gas-answers-mapper.js'
+import { configState } from '~/src/__mocks__/config-mocks.js'
 
-const configState = vi.hoisted(() => {
-  const defaults = new Map()
-  const values = new Map(defaults)
-
-  return {
-    set(key, value) {
-      values.set(key, value)
-    },
-    reset() {
-      values.clear()
-      for (const [k, v] of defaults) {
-        values.set(k, v)
-      }
-    },
-    get(key) {
-      return values.get(key)
-    }
-  }
+vi.mock('~/src/config/config.js', async () => {
+  const { mockConfigWithState } = await import('~/src/__mocks__/config-mocks.js')
+  return mockConfigWithState()
 })
-
-vi.mock('~/src/config/config.js', () => ({
-  config: {
-    get: vi.fn((key) => configState.get(key))
-  }
-}))
 
 vi.mock('~/src/server/common/helpers/logging/log.js', () => ({
   log: vi.fn()

--- a/src/server/land-grants/services/land-grants.client.js
+++ b/src/server/land-grants/services/land-grants.client.js
@@ -162,7 +162,7 @@ export async function parcelsGroups(parcelIds, baseUrl, userContext) {
  * @param {string} baseUrl
  * @param {LandGrantsUserContext} userContext
  * @param {PlannedAction[]} [plannedActions] - When given, the API recomputes each
- *   action's availableArea against these in-progress selections merged with existing
+ *   action's availability against these in-progress selections merged with existing
  *   agreements, rather than existing agreements alone.
  * @returns {Promise<ParcelResponse>}
  */

--- a/src/server/land-grants/services/land-grants.service.js
+++ b/src/server/land-grants/services/land-grants.service.js
@@ -202,7 +202,7 @@ export async function fetchActionsForParcel(parcel, userContext) {
 /**
  * Recomputes availability for a parcel's actions against an in-progress
  * selection, for the select-actions page's live availability refresh.
- * inputRequired is static per action (not affected by the recompute),
+ * availability.type is static per action (not affected by the recompute),
  * so it isn't returned here - the client already has it from initial render.
  * @param {{ parcelId: string, sheetId: string, plannedActions: PlannedAction[] }} params
  * @param {LandGrantsUserContext} userContext

--- a/src/server/land-grants/services/land-grants.service.js
+++ b/src/server/land-grants/services/land-grants.service.js
@@ -15,6 +15,8 @@ import {
   validate
 } from '~/src/server/land-grants/services/land-grants.client.js'
 import { formatAreaUnit } from '~/src/shared/format-area-unit.js'
+import { formatUnit } from '~/src/shared/format-unit.js'
+import { getAvailabilityLimit } from '~/src/shared/availability.js'
 import {
   getCachedParcel,
   getCachedSbiParcels,
@@ -71,18 +73,24 @@ export async function calculateLandActionsPayment(state, userContext) {
  * @param {ActionOption[]} actionsInGroup
  * @returns {ActionGroup}- Parcel data with actions
  */
-const createGroup = (name, actionsInGroup) => ({
-  name,
-  totalAvailableArea: {
-    unitFullName: formatAreaUnit(actionsInGroup[0]?.availableArea.unit),
-    unit: actionsInGroup[0]?.availableArea.unit,
-    value: Math.max(...actionsInGroup.map((item) => item.availableArea.value))
-  },
-  actions: actionsInGroup,
-  consents: getConsentTypes()
-    .filter((ct) => actionsInGroup.some((a) => /** @type {Record<string, unknown>} */ (a)[ct.apiField]))
-    .map((ct) => ct.key)
-})
+const createGroup = (name, actionsInGroup) => {
+  const availabilities = actionsInGroup.map((item) => item.availability).filter((a) => a != null)
+  const limited = availabilities.filter((a) => getAvailabilityLimit(a) != null)
+  const unitSource = limited[0] ?? availabilities[0]
+
+  return {
+    name,
+    totalAvailableArea: {
+      unitFullName: formatUnit(unitSource?.unit),
+      unit: unitSource?.unit ?? '',
+      value: limited.length ? Math.max(...limited.map((a) => /** @type {number} */ (a.value))) : undefined
+    },
+    actions: actionsInGroup,
+    consents: getConsentTypes()
+      .filter((ct) => actionsInGroup.some((a) => /** @type {Record<string, unknown>} */ (a)[ct.apiField]))
+      .map((ct) => ct.key)
+  }
+}
 
 /**
  * Shared fetch+cache logic behind fetchGroupedActionsForParcel (grouped)
@@ -164,7 +172,7 @@ function groupActions(actionsForParcel, enabledActions, groupDefinitions) {
 
 /**
  * Fetches available actions for a given parcel, grouped. When plannedActions
- * is given, each action's availableArea is recomputed against that
+ * is given, each action's availability is recomputed against that
  * combination and the cache is bypassed.
  * @param {{ parcelId?: string, sheetId?: string, enabledLandActions?: string[], plannedActions?: PlannedAction[] }} parcel
  * @param {LandGrantsUserContext} userContext
@@ -192,13 +200,13 @@ export async function fetchActionsForParcel(parcel, userContext) {
 }
 
 /**
- * Recomputes availableArea for a parcel's actions against an in-progress
+ * Recomputes availability for a parcel's actions against an in-progress
  * selection, for the select-actions page's live availability refresh.
- * availability.type is static per action (not affected by the recompute),
+ * inputRequired is static per action (not affected by the recompute),
  * so it isn't returned here - the client already has it from initial render.
  * @param {{ parcelId: string, sheetId: string, plannedActions: PlannedAction[] }} params
  * @param {LandGrantsUserContext} userContext
- * @returns {Promise<{ actions: Array<{ code: string, availableArea?: Size }> }>}
+ * @returns {Promise<{ actions: Array<{ code: string, availability?: ActionAvailability }> }>}
  * @throws {Error}
  */
 export async function fetchActionsWithPlannedActions({ parcelId, sheetId, plannedActions }, userContext) {
@@ -207,7 +215,7 @@ export async function fetchActionsWithPlannedActions({ parcelId, sheetId, planne
   const foundParcel = parcels?.find((p) => p.parcelId === parcelId && p.sheetId === sheetId)
   const actions = (foundParcel?.actions || []).map(mapAction).map((action) => ({
     code: action.code,
-    availableArea: action.availableArea
+    availability: action.availability
   }))
 
   return { actions }
@@ -380,7 +388,7 @@ function buildErrorMessagesFromResponse(actions = []) {
 }
 
 /**
- * @import { ActionOption, ActionGroup, ActionGroupDefinition, HydratedParcel, PlannedAction, ValidateApplicationResponse, ValidationAction, ErrorItem, Size, ParcelResponse } from '~/src/server/land-grants/types/land-grants.client.d.js'
+ * @import { ActionOption, ActionGroup, ActionGroupDefinition, HydratedParcel, PlannedAction, ValidateApplicationResponse, ValidationAction, ErrorItem, Size, ParcelResponse, ActionAvailability } from '~/src/server/land-grants/types/land-grants.client.d.js'
  * @import { PaymentCalculation } from '~/src/server/land-grants/types/payment.d.js'
  * @import { LandParcels } from '~/src/server/land-grants/types/form-state.d.js'
  * @import { AnyFormRequest } from '@defra/forms-engine-plugin/engine/types.js'

--- a/src/server/land-grants/services/land-grants.service.test.js
+++ b/src/server/land-grants/services/land-grants.service.test.js
@@ -569,9 +569,8 @@ describe('land-grants service', () => {
         [
           {
             code: 'UPL8',
-            availability: { value: null, unit: 'ha' },
-            description: 'No restriction',
-            inputRequired: true
+            availability: { value: null, unit: 'ha', type: 'partial' },
+            description: 'No restriction'
           },
           { code: 'UPL10', availability: { value: 8, unit: 'm' }, description: 'Shepherding livestock' }
         ],
@@ -589,9 +588,8 @@ describe('land-grants service', () => {
         [
           {
             code: 'UPL8',
-            availability: { value: null, unit: 'ha' },
-            description: 'No restriction',
-            inputRequired: true
+            availability: { value: null, unit: 'ha', type: 'partial' },
+            description: 'No restriction'
           }
         ],
         [{ name: 'Shepherding livestock on moorland', actions: ['UPL8'] }]
@@ -780,23 +778,21 @@ describe('land-grants service', () => {
       ])
     })
 
-    it.each([[true], [false], [undefined]])(
-      'should pass inputRequired through unchanged when it is %s',
-      async (inputRequired) => {
+    it.each(['partial', 'total', undefined])(
+      'should pass availability.type through unchanged when it is %s',
+      async (type) => {
         const mockApiResponse = parcelResponse([
           {
             code: 'CSAM3',
-            availability: { value: 10.5, unit: 'ha' },
-            description: 'Herbal leys',
-            ...(inputRequired !== undefined && { inputRequired })
+            availability: { value: 10.5, unit: 'ha', ...(type !== undefined && { type }) },
+            description: 'Herbal leys'
           }
         ])
         parcelsWithActions.mockResolvedValueOnce(mockApiResponse)
 
         const result = await fetchFlat(['CSAM3'])
 
-        expect(result.actions[0].inputRequired).toBe(inputRequired)
-        expect(result.actions[0].availability).toEqual({ value: 10.5, unit: 'ha' })
+        expect(result.actions[0].availability).toEqual({ value: 10.5, unit: 'ha', ...(type !== undefined && { type }) })
       }
     )
 
@@ -804,17 +800,15 @@ describe('land-grants service', () => {
       const mockApiResponse = parcelResponse([
         {
           code: 'CSAM3',
-          availability: { value: null, unit: 'ha' },
-          description: 'Herbal leys',
-          inputRequired: true
+          availability: { value: null, unit: 'ha', type: 'partial' },
+          description: 'Herbal leys'
         }
       ])
       parcelsWithActions.mockResolvedValueOnce(mockApiResponse)
 
       const result = await fetchFlat(['CSAM3'])
 
-      expect(result.actions[0].availability).toEqual({ value: null, unit: 'ha' })
-      expect(result.actions[0].inputRequired).toBe(true)
+      expect(result.actions[0].availability).toEqual({ value: null, unit: 'ha', type: 'partial' })
     })
 
     it('should return no actions when enabledLandActions is empty', async () => {

--- a/src/server/land-grants/services/land-grants.service.test.js
+++ b/src/server/land-grants/services/land-grants.service.test.js
@@ -22,6 +22,37 @@ import {
   validate
 } from '~/src/server/land-grants/services/land-grants.client.js'
 import { clearParcelCache } from '~/src/server/land-grants/services/parcel-cache.js'
+import { configState } from '~/src/__mocks__/config-mocks.js'
+
+const apiCMOR1 = {
+  code: 'CMOR1',
+  availability: { value: 10.5, unit: 'ha' },
+  description: 'Assess moorland and produce a written record'
+}
+const apiUPL8 = {
+  code: 'UPL8',
+  availability: { value: 12.0, unit: 'ha' },
+  description: 'Shepherding livestock on moorland'
+}
+const apiUPL10 = {
+  code: 'UPL10',
+  availability: { value: 8.0, unit: 'ha' },
+  description: 'Shepherding livestock on moorland'
+}
+// What the service returns for apiCMOR1 once landActionWithCode has appended the code.
+const mappedCMOR1 = { ...apiCMOR1, description: 'Assess moorland and produce a written record: CMOR1' }
+const fetchFlat = (enabled = enabledLandActions) =>
+  fetchActionsForParcel({ parcelId: 'PARCEL456', sheetId: 'SHEET123', enabledLandActions: enabled })
+const fetchGrouped = (enabled = enabledLandActions) =>
+  fetchGroupedActionsForParcel({ parcelId: 'PARCEL456', sheetId: 'SHEET123', enabledLandActions: enabled })
+const moorlandAndShepherdingGroups = [
+  { name: 'Assess moorland', actions: ['CMOR1'] },
+  { name: 'Shepherding livestock on moorland', actions: ['UPL8', 'UPL10'] }
+]
+const parcelResponse = (actions, groups) => ({
+  parcels: [{ parcelId: 'PARCEL456', sheetId: 'SHEET123', size: { value: 50.5, unit: 'ha' }, actions }],
+  ...(groups && { groups })
+})
 const mockApiEndpoint = 'https://land-grants-api'
 const enabledLandActions = ['CMOR1', 'UPL1', 'UPL2', 'UPL3', 'UPL8', 'UPL10', 'CLIG3']
 const mockUserContext = {
@@ -53,30 +84,12 @@ vi.mock('~/src/server/land-grants/services/land-grants.client.js', () => ({
 
 vi.mock('~/src/config/nunjucks/filters/format-currency.js')
 
-// Hoisted shared state + helpers that the mock will use
-const configState = vi.hoisted(() => {
-  const defaults = new Map([['landGrants.grantsServiceApiEndpoint', 'https://land-grants-api']])
-  const values = new Map(defaults)
-
-  return {
-    set(key, value) {
-      values.set(key, value)
-    },
-    reset() {
-      values.clear()
-      defaults.forEach((value, key) => values.set(key, value))
-    },
-    get(key) {
-      return values.get(key)
-    }
-  }
+vi.mock('~/src/config/config.js', async () => {
+  const { mockConfigWithState } = await import('~/src/__mocks__/config-mocks.js')
+  // Literal, not mockApiEndpoint: this factory runs during the import phase,
+  // before the module-level consts below are initialised.
+  return mockConfigWithState({ defaults: { 'landGrants.grantsServiceApiEndpoint': 'https://land-grants-api' } })
 })
-
-vi.mock('~/src/config/config.js', () => ({
-  config: {
-    get: vi.fn((key) => configState.get(key))
-  }
-}))
 
 vi.mock('~/src/server/common/services/consolidated-view/consolidated-view.service.js', () => ({
   fetchParcelsFromDal: vi.fn()
@@ -235,43 +248,28 @@ describe('land-grants service', () => {
     })
 
     it('should fetch and group available actions for a parcel successfully', async () => {
-      const mockApiResponse = {
-        parcels: [
+      const mockApiResponse = parcelResponse(
+        [
+          apiCMOR1,
           {
-            parcelId: 'PARCEL456',
-            sheetId: 'SHEET123',
-            size: { value: 50.5, unit: 'ha' },
-            actions: [
-              {
-                code: 'CMOR1',
-                availableArea: { value: 10.5, unit: 'ha' },
-                description: 'Assess moorland and produce a written record'
-              },
-              {
-                code: 'UPL1',
-                availableArea: { value: 20.75, unit: 'ha' },
-                description: 'Moderate livestock grazing on moorland'
-              },
-              {
-                code: 'UPL2',
-                availableArea: { value: 15.25, unit: 'ha' },
-                description: 'Moderate livestock grazing on moorland'
-              }
-            ]
+            code: 'UPL1',
+            availability: { value: 20.75, unit: 'ha' },
+            description: 'Moderate livestock grazing on moorland'
+          },
+          {
+            code: 'UPL2',
+            availability: { value: 15.25, unit: 'ha' },
+            description: 'Moderate livestock grazing on moorland'
           }
         ],
-        groups: [
+        [
           { name: 'Assess moorland', actions: ['CMOR1'] },
           { name: 'Livestock grazing on moorland', actions: ['UPL1', 'UPL2', 'UPL3'] }
         ]
-      }
+      )
       parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
 
-      const result = await fetchGroupedActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123',
-        enabledLandActions
-      })
+      const result = await fetchGrouped()
 
       expect(parcelsWithGroups).toHaveBeenCalledWith(['SHEET123-PARCEL456'], mockApiEndpoint, mockUserContext, [])
 
@@ -290,13 +288,7 @@ describe('land-grants service', () => {
               unitFullName: 'hectares',
               value: 10.5
             },
-            actions: [
-              {
-                code: 'CMOR1',
-                availableArea: { value: 10.5, unit: 'ha' },
-                description: 'Assess moorland and produce a written record: CMOR1'
-              }
-            ]
+            actions: [mappedCMOR1]
           },
           {
             name: 'Livestock grazing on moorland',
@@ -309,12 +301,12 @@ describe('land-grants service', () => {
             actions: [
               {
                 code: 'UPL1',
-                availableArea: { value: 20.75, unit: 'ha' },
+                availability: { value: 20.75, unit: 'ha' },
                 description: 'Moderate livestock grazing on moorland: UPL1'
               },
               {
                 code: 'UPL2',
-                availableArea: { value: 15.25, unit: 'ha' },
+                availability: { value: 15.25, unit: 'ha' },
                 description: 'Moderate livestock grazing on moorland: UPL2'
               }
             ]
@@ -323,58 +315,18 @@ describe('land-grants service', () => {
       })
     })
 
-    it('should return no actions when enabledLandActions is not present', async () => {
-      const mockApiResponse = {
-        parcels: [
-          {
-            parcelId: 'PARCEL456',
-            sheetId: 'SHEET123',
-            size: { value: 50.5, unit: 'ha' },
-            actions: [
-              {
-                code: 'CMOR1',
-                availableArea: { value: 10.5, unit: 'ha' },
-                description: 'Assess moorland and produce a written record'
-              }
-            ]
-          }
-        ],
-        groups: [{ name: 'Assess moorland', actions: ['CMOR1'] }]
-      }
-      parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
-
-      const result = await fetchGroupedActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123'
-      })
-
-      expect(result.actions).toEqual([])
-    })
-
-    it('should return no actions when enabledLandActions is empty', async () => {
-      const mockApiResponse = {
-        parcels: [
-          {
-            parcelId: 'PARCEL456',
-            sheetId: 'SHEET123',
-            size: { value: 50.5, unit: 'ha' },
-            actions: [
-              {
-                code: 'CMOR1',
-                availableArea: { value: 10.5, unit: 'ha' },
-                description: 'Assess moorland and produce a written record'
-              }
-            ]
-          }
-        ],
-        groups: [{ name: 'Assess moorland', actions: ['CMOR1'] }]
-      }
-      parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
+    it.each([
+      ['not present', undefined],
+      ['empty', []]
+    ])('should return no actions when enabledLandActions is %s', async (_case, enabled) => {
+      parcelsWithGroups.mockResolvedValueOnce(
+        parcelResponse([apiCMOR1], [{ name: 'Assess moorland', actions: ['CMOR1'] }])
+      )
 
       const result = await fetchGroupedActionsForParcel({
         parcelId: 'PARCEL456',
         sheetId: 'SHEET123',
-        enabledLandActions: []
+        enabledLandActions: enabled
       })
 
       expect(result.actions).toEqual([])
@@ -388,19 +340,15 @@ describe('land-grants service', () => {
             sheetId: 'SHEET123',
             size: { value: 30.0, unit: 'ha' },
             actions: [
-              {
-                code: 'CMOR1',
-                availableArea: { value: 10.5, unit: 'ha' },
-                description: 'Assess moorland and produce a written record'
-              },
+              apiCMOR1,
               {
                 code: 'UNKNOWN1',
-                availableArea: { value: 5.0, unit: 'ha' },
+                availability: { value: 5.0, unit: 'ha' },
                 description: 'description'
               },
               {
                 code: 'UNKNOWN2',
-                availableArea: { value: 3.5, unit: 'ha' },
+                availability: { value: 3.5, unit: 'ha' },
                 description: 'description'
               }
             ]
@@ -414,11 +362,7 @@ describe('land-grants service', () => {
 
       parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
 
-      const result = await fetchGroupedActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123',
-        enabledLandActions
-      })
+      const result = await fetchGrouped()
 
       expect(result).toEqual({
         parcel: {
@@ -435,13 +379,7 @@ describe('land-grants service', () => {
               unitFullName: 'hectares',
               value: 10.5
             },
-            actions: [
-              {
-                code: 'CMOR1',
-                availableArea: { value: 10.5, unit: 'ha' },
-                description: 'Assess moorland and produce a written record: CMOR1'
-              }
-            ]
+            actions: [mappedCMOR1]
           }
         ]
       })
@@ -479,11 +417,7 @@ describe('land-grants service', () => {
 
       parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
 
-      const result = await fetchGroupedActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123',
-        enabledLandActions
-      })
+      const result = await fetchGrouped()
 
       expect(result).toEqual({
         parcel: {
@@ -510,11 +444,7 @@ describe('land-grants service', () => {
 
       parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
 
-      const result = await fetchGroupedActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123',
-        enabledLandActions
-      })
+      const result = await fetchGrouped()
 
       expect(result).toEqual({
         parcel: {
@@ -536,17 +466,17 @@ describe('land-grants service', () => {
             actions: [
               {
                 code: 'UPL1',
-                availableArea: { value: 15.0, unit: 'ha' },
+                availability: { value: 15.0, unit: 'ha' },
                 description: 'Moderate livestock grazing on moorland'
               },
               {
                 code: 'UPL2',
-                availableArea: { value: 25.5, unit: 'ha' },
+                availability: { value: 25.5, unit: 'ha' },
                 description: 'Moderate livestock grazing on moorland'
               },
               {
                 code: 'UPL3',
-                availableArea: { value: 10.0, unit: 'ha' },
+                availability: { value: 10.0, unit: 'ha' },
                 description: 'Moderate livestock grazing on moorland'
               }
             ]
@@ -557,11 +487,7 @@ describe('land-grants service', () => {
 
       parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
 
-      const result = await fetchGroupedActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123',
-        enabledLandActions
-      })
+      const result = await fetchGrouped()
 
       expect(result).toEqual({
         parcel: {
@@ -581,17 +507,17 @@ describe('land-grants service', () => {
             actions: [
               {
                 code: 'UPL1',
-                availableArea: { value: 15.0, unit: 'ha' },
+                availability: { value: 15.0, unit: 'ha' },
                 description: 'Moderate livestock grazing on moorland: UPL1'
               },
               {
                 code: 'UPL2',
-                availableArea: { value: 25.5, unit: 'ha' },
+                availability: { value: 25.5, unit: 'ha' },
                 description: 'Moderate livestock grazing on moorland: UPL2'
               },
               {
                 code: 'UPL3',
-                availableArea: { value: 10.0, unit: 'ha' },
+                availability: { value: 10.0, unit: 'ha' },
                 description: 'Moderate livestock grazing on moorland: UPL3'
               }
             ]
@@ -611,176 +537,106 @@ describe('land-grants service', () => {
       ).rejects.toThrow('API error')
     })
 
-    describe('when enabledLandActions entries have surrounding spaces', () => {
-      it('should trim spaces and still match action codes correctly', async () => {
-        const mockApiResponse = {
-          parcels: [
-            {
-              parcelId: 'PARCEL456',
-              sheetId: 'SHEET123',
-              size: { value: 50.5, unit: 'ha' },
-              actions: [
-                {
-                  code: 'CMOR1',
-                  availableArea: { value: 10.5, unit: 'ha' },
-                  description: 'Assess moorland and produce a written record'
-                },
-                {
-                  code: 'UPL8',
-                  availableArea: { value: 12.0, unit: 'ha' },
-                  description: 'Shepherding livestock on moorland'
-                }
-              ]
-            }
-          ],
-          groups: [
-            { name: 'Assess moorland', actions: ['CMOR1'] },
-            { name: 'Shepherding livestock on moorland', actions: ['UPL8', 'UPL10'] }
-          ]
-        }
-        parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
+    it('should trim spaces from enabledLandActions entries and still match action codes', async () => {
+      parcelsWithGroups.mockResolvedValueOnce(parcelResponse([apiCMOR1, apiUPL8], moorlandAndShepherdingGroups))
 
-        const result = await fetchGroupedActionsForParcel({
-          parcelId: 'PARCEL456',
-          sheetId: 'SHEET123',
-          enabledLandActions: [' CMOR1 ', ' UPL8 ', ' UPL10 ']
-        })
+      const result = await fetchGrouped([' CMOR1 ', ' UPL8 ', ' UPL10 '])
 
-        expect(result.actions).toHaveLength(2)
-        expect(result.actions[0].name).toBe('Assess moorland')
-        expect(result.actions[1].name).toBe('Shepherding livestock on moorland')
-      })
+      expect(result.actions).toHaveLength(2)
+      expect(result.actions[0].name).toBe('Assess moorland')
+      expect(result.actions[1].name).toBe('Shepherding livestock on moorland')
     })
 
-    describe('when enabledLandActions does not include UPL8 and UPL10', () => {
-      it('should exclude UPL8 and UPL10 actions when they are not in enabledLandActions', async () => {
-        const mockApiResponse = {
-          parcels: [
-            {
-              parcelId: 'PARCEL456',
-              sheetId: 'SHEET123',
-              size: { value: 50.5, unit: 'ha' },
-              actions: [
-                {
-                  code: 'CMOR1',
-                  availableArea: { value: 10.5, unit: 'ha' },
-                  description: 'Assess moorland and produce a written record'
-                },
-                {
-                  code: 'UPL8',
-                  availableArea: { value: 12.0, unit: 'ha' },
-                  description: 'Shepherding livestock on moorland'
-                },
-                {
-                  code: 'UPL10',
-                  availableArea: { value: 8.0, unit: 'ha' },
-                  description: 'Shepherding livestock on moorland'
-                }
-              ]
-            }
-          ],
-          groups: [
-            { name: 'Assess moorland', actions: ['CMOR1'] },
-            { name: 'Shepherding livestock on moorland', actions: ['UPL8', 'UPL10'] }
-          ]
+    it('should exclude UPL8 and UPL10 actions when they are not in enabledLandActions', async () => {
+      parcelsWithGroups.mockResolvedValueOnce(
+        parcelResponse([apiCMOR1, apiUPL8, apiUPL10], moorlandAndShepherdingGroups)
+      )
+
+      const result = await fetchGrouped(['CMOR1'])
+
+      expect(result.actions).toEqual([
+        {
+          name: 'Assess moorland',
+          consents: [],
+          totalAvailableArea: { unit: 'ha', unitFullName: 'hectares', value: 10.5 },
+          actions: [mappedCMOR1]
         }
-        parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
-
-        const result = await fetchGroupedActionsForParcel({
-          parcelId: 'PARCEL456',
-          sheetId: 'SHEET123',
-          enabledLandActions: ['CMOR1']
-        })
-
-        expect(result.actions).toEqual([
-          {
-            name: 'Assess moorland',
-            consents: [],
-            totalAvailableArea: { unit: 'ha', unitFullName: 'hectares', value: 10.5 },
-            actions: [
-              {
-                code: 'CMOR1',
-                availableArea: { value: 10.5, unit: 'ha' },
-                description: 'Assess moorland and produce a written record: CMOR1'
-              }
-            ]
-          }
-        ])
-      })
+      ])
     })
 
-    describe('when enabledLandActions includes UPL8 and UPL10', () => {
-      it('should group UPL8 and UPL10 actions under Shepherding livestock on moorland', async () => {
-        const mockApiResponse = {
-          parcels: [
-            {
-              parcelId: 'PARCEL456',
-              sheetId: 'SHEET123',
-              size: { value: 50.5, unit: 'ha' },
-              actions: [
-                {
-                  code: 'CMOR1',
-                  availableArea: { value: 10.5, unit: 'ha' },
-                  description: 'Assess moorland and produce a written record'
-                },
-                {
-                  code: 'UPL8',
-                  availableArea: { value: 12.0, unit: 'ha' },
-                  description: 'Shepherding livestock on moorland'
-                },
-                {
-                  code: 'UPL10',
-                  availableArea: { value: 8.0, unit: 'ha' },
-                  description: 'Shepherding livestock on moorland'
-                }
-              ]
-            }
-          ],
-          groups: [
-            { name: 'Assess moorland', actions: ['CMOR1'] },
-            { name: 'Shepherding livestock on moorland', actions: ['UPL8', 'UPL10'] }
-          ]
-        }
-        parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
-
-        const result = await fetchGroupedActionsForParcel({
-          parcelId: 'PARCEL456',
-          sheetId: 'SHEET123',
-          enabledLandActions: ['CMOR1', 'UPL8', 'UPL10']
-        })
-
-        expect(result.actions).toEqual([
+    it('should build a group total from only the actions that carry a limit', async () => {
+      const mockApiResponse = parcelResponse(
+        [
           {
-            name: 'Assess moorland',
-            consents: [],
-            totalAvailableArea: { unit: 'ha', unitFullName: 'hectares', value: 10.5 },
-            actions: [
-              {
-                code: 'CMOR1',
-                availableArea: { value: 10.5, unit: 'ha' },
-                description: 'Assess moorland and produce a written record: CMOR1'
-              }
-            ]
+            code: 'UPL8',
+            availability: { value: null, unit: 'ha' },
+            description: 'No restriction',
+            inputRequired: true
           },
+          { code: 'UPL10', availability: { value: 8, unit: 'm' }, description: 'Shepherding livestock' }
+        ],
+        [{ name: 'Shepherding livestock on moorland', actions: ['UPL8', 'UPL10'] }]
+      )
+      parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
+
+      const result = await fetchGrouped(['UPL8', 'UPL10'])
+
+      expect(result.actions[0].totalAvailableArea).toEqual({ unit: 'm', unitFullName: 'metres', value: 8 })
+    })
+
+    it('should leave the group total absent when no action in the group has a limit', async () => {
+      const mockApiResponse = parcelResponse(
+        [
           {
-            name: 'Shepherding livestock on moorland',
-            consents: [],
-            totalAvailableArea: { unit: 'ha', unitFullName: 'hectares', value: 12.0 },
-            actions: [
-              {
-                code: 'UPL8',
-                availableArea: { value: 12.0, unit: 'ha' },
-                description: 'Shepherding livestock on moorland: UPL8'
-              },
-              {
-                code: 'UPL10',
-                availableArea: { value: 8.0, unit: 'ha' },
-                description: 'Shepherding livestock on moorland: UPL10'
-              }
-            ]
+            code: 'UPL8',
+            availability: { value: null, unit: 'ha' },
+            description: 'No restriction',
+            inputRequired: true
           }
-        ])
-      })
+        ],
+        [{ name: 'Shepherding livestock on moorland', actions: ['UPL8'] }]
+      )
+      parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
+
+      const result = await fetchGrouped(['UPL8'])
+
+      // A null value means "no restriction", not "nothing available" - reporting
+      // 0 here would tell the user the exact opposite of the truth.
+      expect(result.actions[0].totalAvailableArea).toEqual({ unit: 'ha', unitFullName: 'hectares', value: undefined })
+    })
+
+    it('should group UPL8 and UPL10 actions under Shepherding livestock on moorland', async () => {
+      parcelsWithGroups.mockResolvedValueOnce(
+        parcelResponse([apiCMOR1, apiUPL8, apiUPL10], moorlandAndShepherdingGroups)
+      )
+
+      const result = await fetchGrouped(['CMOR1', 'UPL8', 'UPL10'])
+
+      expect(result.actions).toEqual([
+        {
+          name: 'Assess moorland',
+          consents: [],
+          totalAvailableArea: { unit: 'ha', unitFullName: 'hectares', value: 10.5 },
+          actions: [mappedCMOR1]
+        },
+        {
+          name: 'Shepherding livestock on moorland',
+          consents: [],
+          totalAvailableArea: { unit: 'ha', unitFullName: 'hectares', value: 12.0 },
+          actions: [
+            {
+              code: 'UPL8',
+              availability: { value: 12.0, unit: 'ha' },
+              description: 'Shepherding livestock on moorland: UPL8'
+            },
+            {
+              code: 'UPL10',
+              availability: { value: 8.0, unit: 'ha' },
+              description: 'Shepherding livestock on moorland: UPL10'
+            }
+          ]
+        }
+      ])
     })
 
     describe('V2 - SSSI Consent required flag is enabled', () => {
@@ -790,46 +646,35 @@ describe('land-grants service', () => {
       })
 
       it('should fetch and group available actions for a parcel successfully', async () => {
-        const mockApiResponse = {
-          parcels: [
+        const mockApiResponse = parcelResponse(
+          [
             {
-              parcelId: 'PARCEL456',
-              sheetId: 'SHEET123',
-              size: { value: 50.5, unit: 'ha' },
-              actions: [
-                {
-                  code: 'CMOR1',
-                  availableArea: { value: 10.5, unit: 'ha' },
-                  description: 'Assess moorland and produce a written record',
-                  sssiConsentRequired: false
-                },
-                {
-                  code: 'UPL1',
-                  availableArea: { value: 20.75, unit: 'ha' },
-                  description: 'Moderate livestock grazing on moorland',
-                  sssiConsentRequired: false
-                },
-                {
-                  code: 'UPL2',
-                  availableArea: { value: 15.25, unit: 'ha' },
-                  description: 'Moderate livestock grazing on moorland',
-                  sssiConsentRequired: true
-                }
-              ]
+              code: 'CMOR1',
+              availability: { value: 10.5, unit: 'ha' },
+              description: 'Assess moorland and produce a written record',
+              sssiConsentRequired: false
+            },
+            {
+              code: 'UPL1',
+              availability: { value: 20.75, unit: 'ha' },
+              description: 'Moderate livestock grazing on moorland',
+              sssiConsentRequired: false
+            },
+            {
+              code: 'UPL2',
+              availability: { value: 15.25, unit: 'ha' },
+              description: 'Moderate livestock grazing on moorland',
+              sssiConsentRequired: true
             }
           ],
-          groups: [
+          [
             { name: 'Assess moorland', actions: ['CMOR1'] },
             { name: 'Livestock grazing on moorland', actions: ['UPL1', 'UPL2', 'UPL3'] }
           ]
-        }
+        )
         parcelsWithGroups.mockResolvedValueOnce(mockApiResponse)
 
-        const result = await fetchGroupedActionsForParcel({
-          parcelId: 'PARCEL456',
-          sheetId: 'SHEET123',
-          enabledLandActions
-        })
+        const result = await fetchGrouped()
 
         expect(parcelsWithGroups).toHaveBeenCalledWith(['SHEET123-PARCEL456'], mockApiEndpoint, mockUserContext, [])
 
@@ -851,7 +696,7 @@ describe('land-grants service', () => {
               actions: [
                 {
                   code: 'CMOR1',
-                  availableArea: { value: 10.5, unit: 'ha' },
+                  availability: { value: 10.5, unit: 'ha' },
                   description: 'Assess moorland and produce a written record: CMOR1',
                   sssiConsentRequired: false
                 }
@@ -868,13 +713,13 @@ describe('land-grants service', () => {
               actions: [
                 {
                   code: 'UPL1',
-                  availableArea: { value: 20.75, unit: 'ha' },
+                  availability: { value: 20.75, unit: 'ha' },
                   description: 'Moderate livestock grazing on moorland: UPL1',
                   sssiConsentRequired: false
                 },
                 {
                   code: 'UPL2',
-                  availableArea: { value: 15.25, unit: 'ha' },
+                  availability: { value: 15.25, unit: 'ha' },
                   description: 'Moderate livestock grazing on moorland: UPL2',
                   sssiConsentRequired: true
                 }
@@ -893,34 +738,17 @@ describe('land-grants service', () => {
     })
 
     it('should fetch a flat action list for a parcel, filtered by enabledLandActions', async () => {
-      const mockApiResponse = {
-        parcels: [
-          {
-            parcelId: 'PARCEL456',
-            sheetId: 'SHEET123',
-            size: { value: 50.5, unit: 'ha' },
-            actions: [
-              {
-                code: 'CMOR1',
-                availableArea: { value: 10.5, unit: 'ha' },
-                description: 'Assess moorland and produce a written record'
-              },
-              {
-                code: 'UNKNOWN1',
-                availableArea: { value: 5.0, unit: 'ha' },
-                description: 'description'
-              }
-            ]
-          }
-        ]
-      }
+      const mockApiResponse = parcelResponse([
+        apiCMOR1,
+        {
+          code: 'UNKNOWN1',
+          availability: { value: 5.0, unit: 'ha' },
+          description: 'description'
+        }
+      ])
       parcelsWithActions.mockResolvedValueOnce(mockApiResponse)
 
-      const result = await fetchActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123',
-        enabledLandActions
-      })
+      const result = await fetchFlat()
 
       expect(parcelsWithActions).toHaveBeenCalledWith(['SHEET123-PARCEL456'], mockApiEndpoint, mockUserContext, [])
       expect(result).toEqual({
@@ -929,38 +757,21 @@ describe('land-grants service', () => {
           sheetId: 'SHEET123',
           size: { value: 50.5, unit: 'ha', unitFullName: 'hectares' }
         },
-        actions: [
-          {
-            code: 'CMOR1',
-            availableArea: { value: 10.5, unit: 'ha' },
-            description: 'Assess moorland and produce a written record: CMOR1'
-          }
-        ]
+        actions: [mappedCMOR1]
       })
     })
 
     it('should sort enabled actions alphabetically by description', async () => {
-      parcelsWithActions.mockResolvedValueOnce({
-        parcels: [
-          {
-            parcelId: 'PARCEL456',
-            sheetId: 'SHEET123',
-            size: { value: 50.5, unit: 'ha' },
-            actions: [
-              { code: 'UPL2', description: 'Supplementary winter feeding' },
-              { code: 'UNKNOWN1', description: 'A disabled action' },
-              { code: 'CMOR1', description: 'Assess moorland and produce a written record' },
-              { code: 'UPL1', description: 'Moderate livestock grazing on moorland' }
-            ]
-          }
-        ]
-      })
+      parcelsWithActions.mockResolvedValueOnce(
+        parcelResponse([
+          { code: 'UPL2', description: 'Supplementary winter feeding' },
+          { code: 'UNKNOWN1', description: 'A disabled action' },
+          { code: 'CMOR1', description: 'Assess moorland and produce a written record' },
+          { code: 'UPL1', description: 'Moderate livestock grazing on moorland' }
+        ])
+      )
 
-      const result = await fetchActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123',
-        enabledLandActions
-      })
+      const result = await fetchFlat()
 
       expect(result.actions.map(({ description }) => description)).toEqual([
         'Assess moorland and produce a written record: CMOR1',
@@ -969,95 +780,48 @@ describe('land-grants service', () => {
       ])
     })
 
-    it.each([['partial']])(
-      'should pass availability.type through unchanged when it is %s',
-      async (availabilityType) => {
-        const mockApiResponse = {
-          parcels: [
-            {
-              parcelId: 'PARCEL456',
-              sheetId: 'SHEET123',
-              size: { value: 50.5, unit: 'ha' },
-              actions: [
-                {
-                  code: 'CSAM3',
-                  availableArea: { value: 10.5, unit: 'ha' },
-                  description: 'Herbal leys',
-                  availability: { type: availabilityType }
-                }
-              ]
-            }
-          ]
-        }
-        parcelsWithActions.mockResolvedValueOnce(mockApiResponse)
-
-        const result = await fetchActionsForParcel({
-          parcelId: 'PARCEL456',
-          sheetId: 'SHEET123',
-          enabledLandActions: ['CSAM3']
-        })
-
-        expect(result.actions[0].availability).toEqual({ type: availabilityType })
-        expect(result.actions[0].availableArea).toEqual({ value: 10.5, unit: 'ha' })
-      }
-    )
-
-    it.each([['total'], [undefined]])(
-      'should leave availability.type as %s when the API returns it that way',
-      async (availabilityType) => {
-        const mockApiResponse = {
-          parcels: [
-            {
-              parcelId: 'PARCEL456',
-              sheetId: 'SHEET123',
-              size: { value: 50.5, unit: 'ha' },
-              actions: [
-                {
-                  code: 'CMOR1',
-                  availableArea: { value: 8, unit: 'ha' },
-                  description: 'Assess moorland and produce a written record',
-                  ...(availabilityType && { availability: { type: availabilityType } })
-                }
-              ]
-            }
-          ]
-        }
-        parcelsWithActions.mockResolvedValueOnce(mockApiResponse)
-
-        const result = await fetchActionsForParcel({
-          parcelId: 'PARCEL456',
-          sheetId: 'SHEET123',
-          enabledLandActions
-        })
-
-        expect(result.actions[0].availability?.type).toBe(availabilityType)
-      }
-    )
-
-    it('should return no actions when enabledLandActions is empty', async () => {
-      const mockApiResponse = {
-        parcels: [
+    it.each([[true], [false], [undefined]])(
+      'should pass inputRequired through unchanged when it is %s',
+      async (inputRequired) => {
+        const mockApiResponse = parcelResponse([
           {
-            parcelId: 'PARCEL456',
-            sheetId: 'SHEET123',
-            size: { value: 50.5, unit: 'ha' },
-            actions: [
-              {
-                code: 'CMOR1',
-                availableArea: { value: 10.5, unit: 'ha' },
-                description: 'Assess moorland and produce a written record'
-              }
-            ]
+            code: 'CSAM3',
+            availability: { value: 10.5, unit: 'ha' },
+            description: 'Herbal leys',
+            ...(inputRequired !== undefined && { inputRequired })
           }
-        ]
+        ])
+        parcelsWithActions.mockResolvedValueOnce(mockApiResponse)
+
+        const result = await fetchFlat(['CSAM3'])
+
+        expect(result.actions[0].inputRequired).toBe(inputRequired)
+        expect(result.actions[0].availability).toEqual({ value: 10.5, unit: 'ha' })
       }
+    )
+
+    it('should pass a null availability value through unchanged', async () => {
+      const mockApiResponse = parcelResponse([
+        {
+          code: 'CSAM3',
+          availability: { value: null, unit: 'ha' },
+          description: 'Herbal leys',
+          inputRequired: true
+        }
+      ])
       parcelsWithActions.mockResolvedValueOnce(mockApiResponse)
 
-      const result = await fetchActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123',
-        enabledLandActions: []
-      })
+      const result = await fetchFlat(['CSAM3'])
+
+      expect(result.actions[0].availability).toEqual({ value: null, unit: 'ha' })
+      expect(result.actions[0].inputRequired).toBe(true)
+    })
+
+    it('should return no actions when enabledLandActions is empty', async () => {
+      const mockApiResponse = parcelResponse([apiCMOR1])
+      parcelsWithActions.mockResolvedValueOnce(mockApiResponse)
+
+      const result = await fetchFlat([])
 
       expect(result.actions).toEqual([])
     })
@@ -1068,11 +832,7 @@ describe('land-grants service', () => {
       }
       parcelsWithActions.mockResolvedValueOnce(mockApiResponse)
 
-      const result = await fetchActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123',
-        enabledLandActions
-      })
+      const result = await fetchFlat()
 
       expect(result).toEqual({
         parcel: {
@@ -1086,22 +846,7 @@ describe('land-grants service', () => {
   })
 
   describe('fetchActionsForParcel caching', () => {
-    const mockApiResponse = {
-      parcels: [
-        {
-          parcelId: 'PARCEL456',
-          sheetId: 'SHEET123',
-          size: { value: 50.5, unit: 'ha' },
-          actions: [
-            {
-              code: 'CMOR1',
-              availableArea: { value: 10.5, unit: 'ha' },
-              description: 'Assess moorland and produce a written record'
-            }
-          ]
-        }
-      ]
-    }
+    const mockApiResponse = parcelResponse([apiCMOR1])
 
     beforeEach(() => {
       clearParcelCache()
@@ -1130,11 +875,7 @@ describe('land-grants service', () => {
       parcelsWithGroups.mockResolvedValueOnce(groupedApiResponse)
 
       const flatResult = await fetchActionsForParcel({ parcelId: 'PARCEL456', sheetId: 'SHEET123', enabledLandActions })
-      const groupedResult = await fetchGroupedActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123',
-        enabledLandActions
-      })
+      const groupedResult = await fetchGrouped()
 
       expect(parcelsWithActions).toHaveBeenCalledTimes(1)
       expect(parcelsWithGroups).toHaveBeenCalledTimes(1)
@@ -1149,15 +890,15 @@ describe('land-grants service', () => {
       configState.reset()
     })
 
-    it('should recompute availableArea against plannedActions and return a flat action list', async () => {
+    it('should recompute availability against plannedActions and return a flat action list', async () => {
       const mockApiResponse = {
         parcels: [
           {
             parcelId: 'PARCEL456',
             sheetId: 'SHEET123',
             actions: [
-              { code: 'CMOR1', availableArea: { value: 8, unit: 'ha' }, description: 'Assess moorland' },
-              { code: 'UPL1', availableArea: { value: 0, unit: 'ha' }, description: 'Moderate grazing' }
+              { code: 'CMOR1', availability: { value: 8, unit: 'ha' }, description: 'Assess moorland' },
+              { code: 'UPL1', availability: { value: 0, unit: 'ha' }, description: 'Moderate grazing' }
             ]
           }
         ]
@@ -1179,8 +920,8 @@ describe('land-grants service', () => {
       )
       expect(result).toEqual({
         actions: [
-          { code: 'CMOR1', availableArea: { value: 8, unit: 'ha' } },
-          { code: 'UPL1', availableArea: { value: 0, unit: 'ha' } }
+          { code: 'CMOR1', availability: { value: 8, unit: 'ha' } },
+          { code: 'UPL1', availability: { value: 0, unit: 'ha' } }
         ]
       })
     })
@@ -1212,23 +953,7 @@ describe('land-grants service', () => {
   })
 
   describe('fetchGroupedActionsForParcel caching', () => {
-    const mockApiResponse = {
-      parcels: [
-        {
-          parcelId: 'PARCEL456',
-          sheetId: 'SHEET123',
-          size: { value: 50.5, unit: 'ha' },
-          actions: [
-            {
-              code: 'CMOR1',
-              availableArea: { value: 10.5, unit: 'ha' },
-              description: 'Assess moorland and produce a written record'
-            }
-          ]
-        }
-      ],
-      groups: [{ name: 'Assess moorland', actions: ['CMOR1'] }]
-    }
+    const mockApiResponse = parcelResponse([apiCMOR1], [{ name: 'Assess moorland', actions: ['CMOR1'] }])
 
     const parcelArgs = { parcelId: 'PARCEL456', sheetId: 'SHEET123', enabledLandActions: ['CMOR1'] }
 
@@ -1271,11 +996,7 @@ describe('land-grants service', () => {
       parcelsWithGroups.mockResolvedValue(mockApiResponse)
 
       await fetchGroupedActionsForParcel(parcelArgs)
-      await fetchGroupedActionsForParcel({
-        parcelId: 'PARCEL456',
-        sheetId: 'SHEET123',
-        enabledLandActions: ['UPL1']
-      })
+      await fetchGrouped(['UPL1'])
 
       expect(parcelsWithGroups).toHaveBeenCalledTimes(2)
     })
@@ -1309,6 +1030,11 @@ describe('land-grants service', () => {
 
   describe('fetchParcels', () => {
     const mockRequest = { auth: { credentials: { sbi: '106284736' } } }
+    const oneParcel = [{ parcelId: 'PARCEL1', sheetId: 'SHEET1' }]
+    const oneParcelSize = {
+      parcels: [{ parcelId: 'PARCEL1', sheetId: 'SHEET1', size: { total: 15.5, unit: 'ha' } }]
+    }
+    const oneParcelWithArea = [{ parcelId: 'PARCEL1', sheetId: 'SHEET1', area: { total: 15.5, unit: 'ha' } }]
 
     beforeEach(() => {
       clearParcelCache()
@@ -1413,35 +1139,26 @@ describe('land-grants service', () => {
     })
 
     it('should handle size API error', async () => {
-      const mockParcels = [{ parcelId: 'PARCEL1', sheetId: 'SHEET1' }]
-      fetchParcelsFromDal.mockResolvedValueOnce(mockParcels)
+      fetchParcelsFromDal.mockResolvedValueOnce(oneParcel)
       parcelsWithSize.mockRejectedValueOnce(new Error('Size API error'))
 
       await expect(fetchParcels(mockRequest)).rejects.toThrow('Size API error')
     })
 
     it('should return cached result on second call with same SBI', async () => {
-      const mockParcels = [{ parcelId: 'PARCEL1', sheetId: 'SHEET1' }]
-      const mockSizeResponse = {
-        parcels: [{ parcelId: 'PARCEL1', sheetId: 'SHEET1', size: { total: 15.5, unit: 'ha' } }]
-      }
-      fetchParcelsFromDal.mockResolvedValue(mockParcels)
-      parcelsWithSize.mockResolvedValue(mockSizeResponse)
+      fetchParcelsFromDal.mockResolvedValue(oneParcel)
+      parcelsWithSize.mockResolvedValue(oneParcelSize)
 
       await fetchParcels(mockRequest)
       const secondResult = await fetchParcels(mockRequest)
 
       expect(fetchParcelsFromDal).toHaveBeenCalledTimes(1)
-      expect(secondResult).toEqual([{ parcelId: 'PARCEL1', sheetId: 'SHEET1', area: { total: 15.5, unit: 'ha' } }])
+      expect(secondResult).toEqual(oneParcelWithArea)
     })
 
     it('should fetch separately for different SBIs', async () => {
-      const mockParcels = [{ parcelId: 'PARCEL1', sheetId: 'SHEET1' }]
-      const mockSizeResponse = {
-        parcels: [{ parcelId: 'PARCEL1', sheetId: 'SHEET1', size: { total: 15.5, unit: 'ha' } }]
-      }
-      fetchParcelsFromDal.mockResolvedValue(mockParcels)
-      parcelsWithSize.mockResolvedValue(mockSizeResponse)
+      fetchParcelsFromDal.mockResolvedValue(oneParcel)
+      parcelsWithSize.mockResolvedValue(oneParcelSize)
 
       const otherRequest = { auth: { credentials: { sbi: '999999999' } } }
 
@@ -1453,12 +1170,8 @@ describe('land-grants service', () => {
 
     it('should re-fetch after cache TTL expires', async () => {
       vi.useFakeTimers()
-      const mockParcels = [{ parcelId: 'PARCEL1', sheetId: 'SHEET1' }]
-      const mockSizeResponse = {
-        parcels: [{ parcelId: 'PARCEL1', sheetId: 'SHEET1', size: { total: 15.5, unit: 'ha' } }]
-      }
-      fetchParcelsFromDal.mockResolvedValue(mockParcels)
-      parcelsWithSize.mockResolvedValue(mockSizeResponse)
+      fetchParcelsFromDal.mockResolvedValue(oneParcel)
+      parcelsWithSize.mockResolvedValue(oneParcelSize)
 
       await fetchParcels(mockRequest)
       expect(fetchParcelsFromDal).toHaveBeenCalledTimes(1)
@@ -1472,19 +1185,15 @@ describe('land-grants service', () => {
     })
 
     it('should not cache failed API calls', async () => {
-      const mockParcels = [{ parcelId: 'PARCEL1', sheetId: 'SHEET1' }]
-      const mockSizeResponse = {
-        parcels: [{ parcelId: 'PARCEL1', sheetId: 'SHEET1', size: { total: 15.5, unit: 'ha' } }]
-      }
       fetchParcelsFromDal.mockRejectedValueOnce(new Error('API error'))
-      fetchParcelsFromDal.mockResolvedValueOnce(mockParcels)
-      parcelsWithSize.mockResolvedValueOnce(mockSizeResponse)
+      fetchParcelsFromDal.mockResolvedValueOnce(oneParcel)
+      parcelsWithSize.mockResolvedValueOnce(oneParcelSize)
 
       await expect(fetchParcels(mockRequest)).rejects.toThrow('API error')
 
       const result = await fetchParcels(mockRequest)
       expect(fetchParcelsFromDal).toHaveBeenCalledTimes(2)
-      expect(result).toEqual([{ parcelId: 'PARCEL1', sheetId: 'SHEET1', area: { total: 15.5, unit: 'ha' } }])
+      expect(result).toEqual(oneParcelWithArea)
     })
   })
 

--- a/src/server/land-grants/test-helpers.js
+++ b/src/server/land-grants/test-helpers.js
@@ -1,0 +1,91 @@
+// @ts-nocheck
+import { vi } from 'vitest'
+import { mockRequestLogger } from '~/src/__mocks__/logger-mocks.js'
+import { setupControllerMocks } from '~/src/__mocks__/controller-mocks.js'
+import { formatParcelReference, parseLandParcel, stringifyParcel } from '~/src/shared/format-parcel.js'
+
+export const CMOR1 = {
+  code: 'CMOR1',
+  description: 'Assess moorland and produce a written record: CMOR1',
+  availability: { unit: 'ha', value: 10 },
+  ratePerUnitGbp: 16,
+  ratePerAgreementPerYearGbp: 272
+}
+
+export const UPL1 = {
+  code: 'UPL1',
+  description: 'Moderate livestock grazing on moorland: UPL1',
+  availability: { unit: 'ha', value: 5 },
+  ratePerUnitGbp: 33
+}
+
+export const UPL2 = {
+  code: 'UPL2',
+  description: 'Heavy livestock grazing on moorland: UPL2',
+  availability: { unit: 'ha', value: 3 },
+  ratePerUnitGbp: 45
+}
+
+/** The credentials the controllers forward to the land-grants service. */
+export const USER_CONTEXT = { defraIdToken: 'defra-id-access-token', sbi: '106284736' }
+
+/** What `fetchParcels` resolves with for an authenticated caller. */
+export const PARCELS_WITH_SIZE = [
+  { parcelId: '0155', sheetId: 'SD7946', area: { unit: 'ha', value: 4.0383 } },
+  { parcelId: '4509', sheetId: 'SD7846', area: { unit: 'sqm', value: 0.0633 } }
+]
+
+/**
+ * A Hapi request as the land-grants controllers see it, post-authentication.
+ * @param {Record<string, unknown>} [overrides] merged over the defaults
+ */
+export const makeLandGrantsRequest = (overrides = {}) => ({
+  query: {},
+  logger: mockRequestLogger(),
+  auth: {
+    isAuthenticated: true,
+    credentials: {
+      token: USER_CONTEXT.defraIdToken,
+      sbi: USER_CONTEXT.sbi,
+      crn: 'CRN123',
+      name: 'John Doe',
+      organisationName: 'Farm 1',
+      role: 'admin',
+      sessionId: 'valid-session-id'
+    }
+  },
+  ...overrides
+})
+
+/** @param {string} [renderedView] value `h.view` resolves to */
+export const makeViewToolkit = (renderedView = 'rendered view') => ({
+  view: vi.fn().mockReturnValue(renderedView),
+  redirect: vi.fn()
+})
+
+/**
+ * Replace the base-class methods a land-grants page controller inherits, so a
+ * test can drive the handler without a real forms-engine model behind it.
+ * @param {object} controller
+ * @param {{ proceed?: string, nextPath?: string }} [options]
+ */
+export const stubControllerMethods = (controller, options = {}) => {
+  setupControllerMocks(controller, { proceed: 'redirected', nextPath: '/next-path', ...options })
+  controller.collection = { getErrors: vi.fn().mockReturnValue([]) }
+  controller.performAuthCheck = vi.fn().mockResolvedValue(null)
+  return controller
+}
+
+/**
+ * Give the auto-mocked `~/src/shared/format-parcel.js` its real-ish behaviour.
+ * Requires the calling test to have `vi.mock`ed that module.
+ * @param {{ sheetId?: string, parcelId?: string }} [parsedAs] what `parseLandParcel` returns
+ */
+export const mockFormatParcelImplementations = ({ sheetId = 'sheet1', parcelId = 'parcel1' } = {}) => {
+  parseLandParcel.mockReturnValue([sheetId, parcelId])
+  stringifyParcel.mockImplementation((parcel) => `${parcel.sheetId}-${parcel.parcelId}`)
+  formatParcelReference.mockImplementation((parcel) => {
+    const [sheet, id] = typeof parcel === 'string' ? parcel.split('-') : [parcel.sheetId, parcel.parcelId]
+    return [sheet, id].filter((part) => part != null && part !== '').join(' ')
+  })
+}

--- a/src/server/land-grants/types/land-grants.client.d.js
+++ b/src/server/land-grants/types/land-grants.client.d.js
@@ -13,17 +13,18 @@
 
 /**
  * An in-progress action selection sent to the parcels endpoint so it can recompute
- * availableArea against this planned combination merged with existing agreements.
+ * availability against this planned combination merged with existing agreements.
  * @typedef {object} PlannedAction
  * @property {string} actionCode
  * @property {number} quantity
- * @property {'ha'|'sqm'} unit
+ * @property {string} unit - Area or linear, depending on the action
  */
 
 /**
  * @typedef ActionGroup
  * @property {string} name
- * @property {Size} totalAvailableArea
+ * @property {{ value?: number, unit: string, unitFullName: string }} totalAvailableArea - The
+ *   largest availability in the group; `value` is absent when no action in it has a limit
  * @property {ActionOption[]} actions
  * @property {string[]} consents - Array of consent type keys required for this group (e.g., ['sssi', 'hefer'])
  */
@@ -42,10 +43,12 @@
  */
 
 /**
+ * How much of an action is still claimable. The API always sends this object -
+ * `unit` is always present, and a null `value` is how it says "no restriction"
+ * (paired, by contract, with the action requiring a typed quantity).
  * @typedef {object} ActionAvailability
- * @property {'total'|'partial'} [type] - How the user must enter a quantity relative to
- *   availableArea: 'total' (or unset) requires the full amount and shows no quantity input;
- *   'partial' shows a quantity input capped at availableArea
+ * @property {string} unit - Area, linear or count unit
+ * @property {number | null} value - Amount still claimable; null means no restriction
  */
 
 /**
@@ -55,12 +58,12 @@
  * @property {string} version - The action version
  * @property {boolean} [sssiConsentRequired] - If action needs SSSI consent
  * @property {boolean} [heferRequired] - If action needs HEFER report
- * @property {Size} availableArea - The available area for the action
+ * @property {ActionAvailability} [availability] - How much of the action is still claimable
+ * @property {boolean} [inputRequired] - Whether the user must type a quantity for this
+ *   action
  * @property {number} ratePerUnitGbp - The rate per unit in GBP
  * @property {number} ratePerAgreementPerYearGbp - The rate per agreement per year in GBP
  * @property {string} [guidanceUrl] - URL to the action's guidance page
- * @property {ActionAvailability} [availability] - Governs whether this action needs a
- *   user-typed quantity
  */
 
 /**

--- a/src/server/land-grants/types/land-grants.client.d.js
+++ b/src/server/land-grants/types/land-grants.client.d.js
@@ -45,10 +45,11 @@
 /**
  * How much of an action is still claimable. The API always sends this object -
  * `unit` is always present, and a null `value` is how it says "no restriction"
- * (paired, by contract, with the action requiring a typed quantity).
+ * while `type` controls whether the user must type a quantity.
  * @typedef {object} ActionAvailability
  * @property {string} unit - Area, linear or count unit
  * @property {number | null} value - Amount still claimable; null means no restriction
+ * @property {'total'|'partial'} [type] - 'partial' requires a typed quantity
  */
 
 /**
@@ -59,8 +60,6 @@
  * @property {boolean} [sssiConsentRequired] - If action needs SSSI consent
  * @property {boolean} [heferRequired] - If action needs HEFER report
  * @property {ActionAvailability} [availability] - How much of the action is still claimable
- * @property {boolean} [inputRequired] - Whether the user must type a quantity for this
- *   action
  * @property {number} ratePerUnitGbp - The rate per unit in GBP
  * @property {number} ratePerAgreementPerYearGbp - The rate per agreement per year in GBP
  * @property {string} [guidanceUrl] - URL to the action's guidance page

--- a/src/server/land-grants/types/select-actions-view-model.d.js
+++ b/src/server/land-grants/types/select-actions-view-model.d.js
@@ -10,12 +10,11 @@
  * @property {object} [availability] - How much of the action is still claimable
  * @property {number | null} [availability.value] - Amount still claimable; null means no restriction
  * @property {string} [availability.unit] - Unit, area, linear or count
+ * @property {'total'|'partial'} [availability.type] - 'partial' requires a typed quantity
  * @property {object} [staticAvailability] - The action's original, uncompeted availability (see mergeRecomputedAvailability)
  * @property {number | null} [staticAvailability.value] - Amount claimable; null means no restriction
  * @property {string} [staticAvailability.unit] - Unit, area, linear or count
  * @property {string} [guidanceUrl] - URL to the action's guidance page
- * @property {boolean} [inputRequired] - Whether the user must type a quantity for this
- *   action. See requiresQuantityInput in shared/action-quantity-type.js
  */
 
 /**

--- a/src/server/land-grants/types/select-actions-view-model.d.js
+++ b/src/server/land-grants/types/select-actions-view-model.d.js
@@ -7,16 +7,15 @@
  * @property {boolean} [sssiConsentRequired] - Action requires SSSI consent
  * @property {boolean} [heferRequired] - Action requires HEFER
  * @property {number} [ratePerAgreementPerYearGbp] - Additional payment per agreement per year
- * @property {object} [availableArea] - Available area for the action
- * @property {number} [availableArea.value] - Area value
- * @property {string} [availableArea.unit] - Area unit
- * @property {object} [staticAvailableArea] - The action's original, uncompeted available area (see mergeRecomputedAvailability)
- * @property {number} [staticAvailableArea.value] - Area value
- * @property {string} [staticAvailableArea.unit] - Area unit
+ * @property {object} [availability] - How much of the action is still claimable
+ * @property {number | null} [availability.value] - Amount still claimable; null means no restriction
+ * @property {string} [availability.unit] - Unit, area, linear or count
+ * @property {object} [staticAvailability] - The action's original, uncompeted availability (see mergeRecomputedAvailability)
+ * @property {number | null} [staticAvailability.value] - Amount claimable; null means no restriction
+ * @property {string} [staticAvailability.unit] - Unit, area, linear or count
  * @property {string} [guidanceUrl] - URL to the action's guidance page
- * @property {object} [availability] - Governs whether this action needs a user-typed quantity
- * @property {'total'|'partial'} [availability.type] - See requiresQuantityInput in
- *   shared/action-quantity-type.js
+ * @property {boolean} [inputRequired] - Whether the user must type a quantity for this
+ *   action. See requiresQuantityInput in shared/action-quantity-type.js
  */
 
 /**
@@ -39,11 +38,9 @@
  *   (flat page only)
  * @property {object} [hint] - Hint text configuration (grouped page)
  * @property {string} [hint.html] - HTML content for hint (grouped page)
- * @property {{ 'data-available-unit': string|undefined, 'data-total-available-area': number|undefined, 'data-available-area-type': string }} [attributes] -
+ * @property {{ 'data-available-unit': string|undefined, 'data-total-available-area': number|undefined }} [attributes] -
  *   Rendered onto the checkbox <input> (flat page only). `data-total-available-area` is set
  *   once and never touched client-side, so it stays the original full amount.
- *   `data-available-area-type` mirrors availability.type ('total' when unset) so the
- *   client can decide whether an action needs a typed quantity without re-deriving it.
  * @property {{ html: string }} [conditional] - Conditional reveal markup shown when checked/selected
  */
 

--- a/src/server/land-grants/validators/land-actions.validator.js
+++ b/src/server/land-grants/validators/land-actions.validator.js
@@ -73,7 +73,7 @@ export function validateSelectedActionQuantities(payload, actions) {
   const errors = []
 
   const applicableActions = actions.filter(
-    (action) => selectedCodes.has(action.code) && requiresQuantityInput(action.availability?.type)
+    (action) => selectedCodes.has(action.code) && requiresQuantityInput(action.inputRequired)
   )
 
   for (const action of applicableActions) {

--- a/src/server/land-grants/validators/land-actions.validator.js
+++ b/src/server/land-grants/validators/land-actions.validator.js
@@ -73,7 +73,7 @@ export function validateSelectedActionQuantities(payload, actions) {
   const errors = []
 
   const applicableActions = actions.filter(
-    (action) => selectedCodes.has(action.code) && requiresQuantityInput(action.inputRequired)
+    (action) => selectedCodes.has(action.code) && requiresQuantityInput(action.availability?.type)
   )
 
   for (const action of applicableActions) {

--- a/src/server/land-grants/validators/land-actions.validator.test.js
+++ b/src/server/land-grants/validators/land-actions.validator.test.js
@@ -104,7 +104,7 @@ describe('land-actions.validator', () => {
 
   describe('validateSelectedActionQuantities', () => {
     const actions = [
-      { code: 'CSAM3', description: 'Herbal leys', version: '1', inputRequired: true },
+      { code: 'CSAM3', description: 'Herbal leys', version: '1', availability: { type: 'partial' } },
       { code: 'CLIG3', description: 'Manage grassland', version: '1' }
     ]
 
@@ -132,7 +132,7 @@ describe('land-actions.validator', () => {
     it('should return multiple errors for multiple unconfirmed quantity-required actions', () => {
       const withSecondQuantity = [
         ...actions,
-        { code: 'UPL8', description: 'Low input', version: '1', inputRequired: true }
+        { code: 'UPL8', description: 'Low input', version: '1', availability: { type: 'partial' } }
       ]
       const payload = { landAction: ['CSAM3', 'UPL8'] }
 

--- a/src/server/land-grants/validators/land-actions.validator.test.js
+++ b/src/server/land-grants/validators/land-actions.validator.test.js
@@ -20,21 +20,11 @@ describe('land-actions.validator', () => {
       expect(result).toEqual(['landAction_1', 'landAction_2'])
     })
 
-    it('should return empty array when no action fields present', () => {
-      const payload = {
-        otherField: 'value',
-        anotherField: 'test'
-      }
-
-      const result = extractLandActionFields(payload, 'landAction_')
-
-      expect(result).toEqual([])
-    })
-
-    it('should handle empty payload', () => {
-      const result = extractLandActionFields({}, 'landAction_')
-
-      expect(result).toEqual([])
+    it.each([
+      ['no action fields are present', { otherField: 'value', anotherField: 'test' }],
+      ['the payload is empty', {}]
+    ])('should return empty array when %s', (_description, payload) => {
+      expect(extractLandActionFields(payload, 'landAction_')).toEqual([])
     })
 
     it('should work with different prefixes', () => {
@@ -62,60 +52,27 @@ describe('land-actions.validator', () => {
   })
 
   describe('validateLandActionsSelection', () => {
-    it('should return errors when no actions selected', () => {
-      const payload = {}
-
-      const result = validateLandActionsSelection(payload, 'landAction_')
-
-      expect(result).toEqual([{ text: 'Select at least one action', href: '#landAction_1' }])
+    it.each([
+      ['the payload is empty', {}],
+      ['the payload has a single non-matching field', { otherField: 'value' }],
+      ['no field matches the prefix', { otherField: 'value', anotherField: 'test', notAnAction: 'data' }]
+    ])('should return errors when %s', (_description, payload) => {
+      expect(validateLandActionsSelection(payload, 'landAction_')).toEqual([
+        { text: 'Select at least one action', href: '#landAction_1' }
+      ])
     })
 
-    it('should return errors when payload has no action fields', () => {
-      const payload = { otherField: 'value' }
-
-      const result = validateLandActionsSelection(payload, 'landAction_')
-
-      expect(result).toEqual([{ text: 'Select at least one action', href: '#landAction_1' }])
-    })
-
-    it('should return empty errors when actions are selected', () => {
-      const payload = { landAction_1: 'CMOR1' }
-
-      const result = validateLandActionsSelection(payload, 'landAction_')
-
-      expect(result).toEqual([])
-    })
-
-    it('should return empty errors when multiple actions selected', () => {
-      const payload = {
-        landAction_1: 'CMOR1',
-        landAction_2: 'UPL1',
-        landAction_3: 'SAM1'
-      }
-
-      const result = validateLandActionsSelection(payload, 'landAction_')
-
-      expect(result).toEqual([])
+    it.each([
+      ['one action is selected', { landAction_1: 'CMOR1' }],
+      ['multiple actions are selected', { landAction_1: 'CMOR1', landAction_2: 'UPL1', landAction_3: 'SAM1' }]
+    ])('should return empty errors when %s', (_description, payload) => {
+      expect(validateLandActionsSelection(payload, 'landAction_')).toEqual([])
     })
 
     it('should use correct href with custom prefix', () => {
-      const payload = {}
-
-      const result = validateLandActionsSelection(payload, 'customAction_')
+      const result = validateLandActionsSelection({}, 'customAction_')
 
       expect(result[0].href).toBe('#customAction_1')
-    })
-
-    it('should ignore fields that do not match prefix', () => {
-      const payload = {
-        otherField: 'value',
-        anotherField: 'test',
-        notAnAction: 'data'
-      }
-
-      const result = validateLandActionsSelection(payload, 'landAction_')
-
-      expect(result).toEqual([{ text: 'Select at least one action', href: '#landAction_1' }])
     })
   })
 
@@ -147,7 +104,7 @@ describe('land-actions.validator', () => {
 
   describe('validateSelectedActionQuantities', () => {
     const actions = [
-      { code: 'CSAM3', description: 'Herbal leys', version: '1', availability: { type: 'partial' } },
+      { code: 'CSAM3', description: 'Herbal leys', version: '1', inputRequired: true },
       { code: 'CLIG3', description: 'Manage grassland', version: '1' }
     ]
 
@@ -164,15 +121,7 @@ describe('land-actions.validator', () => {
       ])
     })
 
-    it('should not require a quantity for an action with no availability.type', () => {
-      const payload = { landAction: 'CLIG3' }
-
-      const result = validateSelectedActionQuantities(payload, actions)
-
-      expect(result).toEqual([])
-    })
-
-    it('should ignore quantity-required actions that were not selected', () => {
+    it('should not require a quantity for an action that does not need one, ignoring the unselected one that does', () => {
       const payload = { landAction: 'CLIG3' }
 
       const result = validateSelectedActionQuantities(payload, actions)
@@ -183,7 +132,7 @@ describe('land-actions.validator', () => {
     it('should return multiple errors for multiple unconfirmed quantity-required actions', () => {
       const withSecondQuantity = [
         ...actions,
-        { code: 'UPL8', description: 'Low input', version: '1', availability: { type: 'partial' } }
+        { code: 'UPL8', description: 'Low input', version: '1', inputRequired: true }
       ]
       const payload = { landAction: ['CSAM3', 'UPL8'] }
 

--- a/src/server/land-grants/view-models/select-actions.view-model.js
+++ b/src/server/land-grants/view-models/select-actions.view-model.js
@@ -156,7 +156,7 @@ export function mapActionToViewModel(
   const existingAction = addedActions.find((a) => a.code === action.code)
   const quantityValue = existingAction?.value ?? ''
   const checked = Boolean(existingAction)
-  const needsQuantity = requiresQuantityInput(action.inputRequired)
+  const needsQuantity = requiresQuantityInput(action.availability?.type)
   const hintHtml = getHintHtml(action, needsQuantity)
   const consents = getActionConsentKeys(action)
 
@@ -197,7 +197,7 @@ export function mapActionToViewModel(
  */
 export function getChosenAreaFieldsHtml(actions, addedActions) {
   return actions
-    .filter((action) => !requiresQuantityInput(action.inputRequired))
+    .filter((action) => !requiresQuantityInput(action.availability?.type))
     .map((action) => {
       const fieldName = getActionQuantityFieldName(action.code)
       const chosenArea = Number(addedActions.find((a) => a.code === action.code)?.value)

--- a/src/server/land-grants/view-models/select-actions.view-model.js
+++ b/src/server/land-grants/view-models/select-actions.view-model.js
@@ -9,6 +9,8 @@ import { govukFrontendPath, viewPaths } from '~/src/config/nunjucks/view-paths.j
 import { getActionQuantityFieldName } from '~/src/shared/action-quantity-field.js'
 import { requiresQuantityInput } from '~/src/shared/action-quantity-type.js'
 import { formatAreaUnit } from '~/src/shared/format-area-unit.js'
+import { formatUnit } from '~/src/shared/format-unit.js'
+import { getAvailabilityLimit } from '~/src/shared/availability.js'
 import { formatParcelReference } from '~/src/shared/format-parcel.js'
 import { SELECTED_ACTIONS_FIELD_NAME } from '~/src/server/land-grants/utils/selected-actions-field.js'
 import { getConsentTypes } from '~/src/server/land-grants/utils/consent-types.js'
@@ -24,7 +26,8 @@ const landGrantsViewEnv = new nunjucks.Environment(new nunjucks.FileSystemLoader
  * @param {string} actionCode
  * @param {string} actionName
  * @param {string} quantityValue
- * @param {number} maxQuantity
+ * @param {number} [maxQuantity] - Omitted when the action has no availability
+ *   restriction, which leaves the input unbounded and hintless
  * @param {string} [unit]
  * @param {string} [errorText] - Error message shown on the input when this action's
  *   quantity failed validation
@@ -39,7 +42,7 @@ function getQuantityConditional(actionCode, actionName, quantityValue, maxQuanti
       quantityValue,
       maxQuantity,
       unit,
-      unitFullName: formatAreaUnit(unit),
+      unitFullName: formatUnit(unit),
       errorText
     })
   }
@@ -71,14 +74,14 @@ function getCheckboxItemId(actionCode, isFirst) {
 }
 
 /**
- * An action's original, uncompeted total - availableArea may have been
+ * An action's original, uncompeted total - availability may have been
  * overwritten by a recompute against other actions in this submission (see
  * mergeRecomputedAvailability), which isn't a safe standalone ceiling.
  * @param {Action} action
- * @returns {{ value?: number, unit?: string } | undefined}
+ * @returns {{ value?: number | null, unit?: string } | undefined}
  */
-function getStaticAvailableArea(action) {
-  return action.staticAvailableArea ?? action.availableArea
+function getStaticAvailability(action) {
+  return action.staticAvailability ?? action.availability
 }
 
 /**
@@ -126,9 +129,10 @@ function getHintHtml(action, needsQuantity) {
     : ''
   const requirementLineText = requirementText ? `<br>${requirementText}` : ''
   const rateText = `Payment rate per year: £${action.ratePerUnitGbp?.toFixed(2)}/ha${agreementRateText}${requirementLineText}`
+  const limit = getAvailabilityLimit(action.availability)
   const availabilityHintHtml =
-    !needsQuantity && action.availableArea
-      ? `<br><span id="${getActionQuantityFieldName(action.code)}-hint">${action.availableArea.value} ${formatAreaUnit(action.availableArea.unit)} available</span>`
+    !needsQuantity && limit != null
+      ? `<br><span id="${getActionQuantityFieldName(action.code)}-hint">${limit} ${formatUnit(action.availability?.unit)} available</span>`
       : ''
   return `${rateText}${availabilityHintHtml}`
 }
@@ -152,8 +156,7 @@ export function mapActionToViewModel(
   const existingAction = addedActions.find((a) => a.code === action.code)
   const quantityValue = existingAction?.value ?? ''
   const checked = Boolean(existingAction)
-  const availabilityType = action.availability?.type
-  const needsQuantity = requiresQuantityInput(availabilityType)
+  const needsQuantity = requiresQuantityInput(action.inputRequired)
   const hintHtml = getHintHtml(action, needsQuantity)
   const consents = getActionConsentKeys(action)
 
@@ -164,10 +167,9 @@ export function mapActionToViewModel(
     checked,
     consents,
     attributes: {
-      'data-available-unit': action.availableArea?.unit,
+      'data-available-unit': action.availability?.unit,
       // A non-quantity action's pass/fail threshold - static, never touched by the client.
-      'data-total-available-area': getStaticAvailableArea(action)?.value,
-      'data-available-area-type': availabilityType ?? 'total',
+      'data-total-available-area': getAvailabilityLimit(getStaticAvailability(action)),
       // Stamped per-checkbox (not a single form-wide flag) so protection survives
       // until THIS action is directly interacted with, not just the first refresh.
       ...(checked && hasErrors && { 'data-error-on-load': 'true' })
@@ -177,8 +179,8 @@ export function mapActionToViewModel(
         action.code,
         action.description,
         quantityValue,
-        action.availableArea?.value ?? 0,
-        action.availableArea?.unit,
+        getAvailabilityLimit(action.availability),
+        action.availability?.unit,
         quantityErrorsByCode[action.code]
       )
     })
@@ -195,7 +197,7 @@ export function mapActionToViewModel(
  */
 export function getChosenAreaFieldsHtml(actions, addedActions) {
   return actions
-    .filter((action) => !requiresQuantityInput(action.availability?.type))
+    .filter((action) => !requiresQuantityInput(action.inputRequired))
     .map((action) => {
       const fieldName = getActionQuantityFieldName(action.code)
       const chosenArea = Number(addedActions.find((a) => a.code === action.code)?.value)
@@ -243,7 +245,7 @@ export function getParcelSummaryList(sheetId, parcelId, size) {
  * @returns {boolean}
  */
 function isVisibleOnInitialLoad(action, addedActions) {
-  if (getStaticAvailableArea(action)?.value !== 0) {
+  if (getAvailabilityLimit(getStaticAvailability(action)) !== 0) {
     return true
   }
   return addedActions.some((a) => a.code === action.code)

--- a/src/server/land-grants/view-models/select-actions.view-model.test.js
+++ b/src/server/land-grants/view-models/select-actions.view-model.test.js
@@ -18,8 +18,7 @@ describe('select-actions.view-model', () => {
   const csam3 = (availability) => ({
     code: 'CSAM3',
     description: 'Herbal leys: CSAM3',
-    inputRequired: true,
-    availability
+    availability: { ...availability, type: 'partial' }
   })
 
   describe('mapActionToViewModel', () => {
@@ -263,8 +262,7 @@ describe('select-actions.view-model', () => {
         code: 'UPL2',
         description: 'Heavy livestock grazing on moorland',
         ratePerUnitGbp: 45,
-        inputRequired: true,
-        availability: { value: 3, unit: 'ha' }
+        availability: { value: 3, unit: 'ha', type: 'partial' }
       }
 
       const result = mapActionToViewModel(action, [])
@@ -439,8 +437,7 @@ describe('select-actions.view-model', () => {
         {
           code: 'CSAM3',
           description: 'Herbal leys: CSAM3',
-          inputRequired: true,
-          availability: { value: 5, unit: 'ha' }
+          availability: { value: 5, unit: 'ha', type: 'partial' }
         },
         { code: 'SAM2', description: 'Action 2', ratePerUnitGbp: 200 }
       ]
@@ -572,7 +569,7 @@ describe('select-actions.view-model', () => {
     })
 
     it('should skip a quantity-required action', () => {
-      const actions = [{ code: 'CSAM3', description: 'Herbal leys', inputRequired: true }]
+      const actions = [{ code: 'CSAM3', description: 'Herbal leys', availability: { type: 'partial' } }]
 
       const html = getChosenAreaFieldsHtml(actions, [])
 

--- a/src/server/land-grants/view-models/select-actions.view-model.test.js
+++ b/src/server/land-grants/view-models/select-actions.view-model.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { configState } from '~/src/__mocks__/config-mocks.js'
 import {
   mapActionToViewModel,
   mapActionsToViewModel,
@@ -7,28 +8,20 @@ import {
   getParcelSummaryList
 } from './select-actions.view-model.js'
 
-const configState = vi.hoisted(() => {
-  const values = new Map()
-  return {
-    set(key, value) {
-      values.set(key, value)
-    },
-    reset() {
-      values.clear()
-    },
-    get(key) {
-      return values.get(key) ?? false
-    }
-  }
+vi.mock('~/src/config/config.js', async () => {
+  const { mockConfigWithState } = await import('~/src/__mocks__/config-mocks.js')
+  return mockConfigWithState({ fallback: false })
 })
 
-vi.mock('~/src/config/config.js', () => ({
-  config: {
-    get: (key) => configState.get(key)
-  }
-}))
-
 describe('select-actions.view-model', () => {
+  const sam1 = (extra) => ({ code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5, ...extra })
+  const csam3 = (availability) => ({
+    code: 'CSAM3',
+    description: 'Herbal leys: CSAM3',
+    inputRequired: true,
+    availability
+  })
+
   describe('mapActionToViewModel', () => {
     it('should map action with rate per unit only', () => {
       const action = {
@@ -48,16 +41,13 @@ describe('select-actions.view-model', () => {
         consents: [],
         attributes: {
           'data-available-unit': undefined,
-          'data-total-available-area': undefined,
-          'data-available-area-type': 'total'
+          'data-total-available-area': undefined
         }
       })
     })
 
     it('should render just the description with no guidance link when no guidance URL is set', () => {
-      const action = { code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5 }
-
-      const result = mapActionToViewModel(action, [])
+      const result = mapActionToViewModel(sam1(), [])
 
       expect(result.html).toContain('Test Action 1')
       expect(result.html).not.toContain('<a')
@@ -121,30 +111,6 @@ describe('select-actions.view-model', () => {
       const result = mapActionToViewModel(action, [], {}, true)
 
       expect(result.id).toBe('landAction')
-    })
-
-    it('should append a "read guidance" link next to the description when the action provides a guidance URL', () => {
-      const action = {
-        code: 'SAM1',
-        description: 'Test Action 1',
-        ratePerUnitGbp: 100.5,
-        guidanceUrl: 'https://www.gov.uk/guidance/sam1'
-      }
-
-      const result = mapActionToViewModel(action, [])
-
-      expect(result.html).toContain('Test Action 1')
-      expect(result.html).toContain('href="https://www.gov.uk/guidance/sam1"')
-      expect(result.html).toContain('read guidance')
-      expect(result.html).toContain('<span class="select-actions-hint">Payment rate per year: £100.50/ha</span>')
-    })
-
-    it('should not append a guidance link when the action has no guidance URL', () => {
-      const action = { code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5 }
-
-      const result = mapActionToViewModel(action, [])
-
-      expect(result.html).not.toContain('Guidance for')
     })
 
     it('should map action with rate per unit and per agreement', () => {
@@ -231,87 +197,48 @@ describe('select-actions.view-model', () => {
       )
     })
 
-    it('should not show any requirement text when neither flag is set', () => {
-      const action = { code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5 }
+    it.each([
+      ['SAM1', true],
+      ['SAM2', false]
+    ])('should mark action as checked only when it is in addedActions (%s)', (addedCode, expected) => {
+      const result = mapActionToViewModel(sam1(), [{ code: addedCode, description: 'Test Action' }])
 
-      const result = mapActionToViewModel(action, [])
-
-      expect(result.html).toBe(
-        'Test Action 1<span class="select-actions-hint">Payment rate per year: £100.50/ha</span>'
-      )
-    })
-
-    it('should mark action as checked when already added', () => {
-      const action = { code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5 }
-      const addedActions = [{ code: 'SAM1', description: 'Test Action 1' }]
-
-      const result = mapActionToViewModel(action, addedActions)
-
-      expect(result.checked).toBe(true)
-    })
-
-    it('should not mark action as checked when not added', () => {
-      const action = { code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5 }
-      const addedActions = [{ code: 'SAM2', description: 'Test Action 2' }]
-
-      const result = mapActionToViewModel(action, addedActions)
-
-      expect(result.checked).toBe(false)
+      expect(result.checked).toBe(expected)
     })
 
     // Stamped per-checkbox (not a single form-wide flag) so the client can keep
     // protecting THIS action's rejected value even after other actions refresh.
-    it('should mark a checked action with data-error-on-load when the page is redisplaying a rejected submission', () => {
-      const action = { code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5 }
-      const addedActions = [{ code: 'SAM1', description: 'Test Action 1' }]
+    it.each([
+      [true, true, 'true'],
+      [false, true, undefined],
+      [true, false, undefined]
+    ])(
+      'should stamp data-error-on-load only when checked (%s) and the page has errors (%s)',
+      (checked, hasErrors, expected) => {
+        const addedActions = checked ? [{ code: 'SAM1', description: 'Test Action 1' }] : []
 
-      const result = mapActionToViewModel(action, addedActions, {}, false, true)
+        const result = mapActionToViewModel(sam1(), addedActions, {}, false, hasErrors)
 
-      expect(result.attributes['data-error-on-load']).toBe('true')
-    })
-
-    it('should not mark an unchecked action with data-error-on-load, even when the page has errors', () => {
-      const action = { code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5 }
-
-      const result = mapActionToViewModel(action, [], {}, false, true)
-
-      expect(result.attributes['data-error-on-load']).toBeUndefined()
-    })
-
-    it('should not mark a checked action with data-error-on-load when the page has no errors', () => {
-      const action = { code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5 }
-      const addedActions = [{ code: 'SAM1', description: 'Test Action 1' }]
-
-      const result = mapActionToViewModel(action, addedActions, {}, false, false)
-
-      expect(result.attributes['data-error-on-load']).toBeUndefined()
-    })
-
-    it('should not set a conditional when action does not require a quantity', () => {
-      const action = { code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5 }
-
-      const result = mapActionToViewModel(action, [])
-
-      expect(result.conditional).toBeUndefined()
-    })
+        expect(result.attributes['data-error-on-load']).toBe(expected)
+      }
+    )
 
     // The client-side availability refresh needs the full available area for every
     // action, not just ones with a quantity input - this is the only place it's
     // rendered into the DOM for actions without one.
-    it('should render availableArea as data attributes even when the action has no quantity input', () => {
+    it('should render availability as data attributes even when the action has no quantity input', () => {
       const action = {
         code: 'SAM1',
         description: 'Test Action 1',
         ratePerUnitGbp: 100.5,
-        availableArea: { value: 12.5, unit: 'ha' }
+        availability: { value: 12.5, unit: 'ha' }
       }
 
       const result = mapActionToViewModel(action, [])
 
       expect(result.attributes).toEqual({
         'data-available-unit': 'ha',
-        'data-total-available-area': 12.5,
-        'data-available-area-type': 'total'
+        'data-total-available-area': 12.5
       })
     })
 
@@ -323,7 +250,7 @@ describe('select-actions.view-model', () => {
         code: 'CLIG3',
         description: 'Manage grassland with very low nutrient inputs',
         ratePerUnitGbp: 151,
-        availableArea: { value: 12.5, unit: 'ha' }
+        availability: { value: 12.5, unit: 'ha' }
       }
 
       const result = mapActionToViewModel(action, [])
@@ -331,21 +258,13 @@ describe('select-actions.view-model', () => {
       expect(result.html).toContain('<span id="landActionQuantity_CLIG3-hint">12.5 hectares available</span>')
     })
 
-    it('should not show an availability hint for a non-quantity action when availableArea is missing', () => {
-      const action = { code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5 }
-
-      const result = mapActionToViewModel(action, [])
-
-      expect(result.html).not.toContain('available</span>')
-    })
-
     it('should not duplicate the availability hint for a quantity-required action (it has its own inside the conditional)', () => {
       const action = {
         code: 'UPL2',
         description: 'Heavy livestock grazing on moorland',
         ratePerUnitGbp: 45,
-        availability: { type: 'partial' },
-        availableArea: { value: 3, unit: 'ha' }
+        inputRequired: true,
+        availability: { value: 3, unit: 'ha' }
       }
 
       const result = mapActionToViewModel(action, [])
@@ -353,25 +272,13 @@ describe('select-actions.view-model', () => {
       expect(result.html).not.toContain('landActionQuantity_UPL2-hint')
     })
 
-    it('should leave the availableArea data attributes undefined when availableArea is missing', () => {
-      const action = { code: 'SAM1', description: 'Test Action 1', ratePerUnitGbp: 100.5 }
-
-      const result = mapActionToViewModel(action, [])
-
-      expect(result.attributes).toEqual({
-        'data-available-unit': undefined,
-        'data-total-available-area': undefined,
-        'data-available-area-type': 'total'
-      })
-    })
-
-    it('should render data-total-available-area from staticAvailableArea when present, not the (possibly competed) availableArea', () => {
+    it('should render data-total-available-area from staticAvailability when present, not the (possibly competed) availability', () => {
       const action = {
         code: 'CSAM3',
         description: 'Herbal leys',
         ratePerUnitGbp: 224,
-        availableArea: { value: 0, unit: 'ha' },
-        staticAvailableArea: { value: 0.3271, unit: 'ha' }
+        availability: { value: 0, unit: 'ha' },
+        staticAvailability: { value: 0.3271, unit: 'ha' }
       }
 
       const result = mapActionToViewModel(action, [])
@@ -379,145 +286,111 @@ describe('select-actions.view-model', () => {
       expect(result.attributes['data-total-available-area']).toBe(0.3271)
     })
 
-    it('should set a conditional reveal when action requires a max quantity', () => {
+    it('should render the conditional input with its field id, max attribute and availability hint', () => {
+      const result = mapActionToViewModel(csam3({ value: 18.5673, unit: 'ha' }), [])
+
+      expect(result.conditional.html).toContain('landActionQuantity_CSAM3')
+      expect(result.conditional.html).toContain('max="18.5673"')
+      expect(result.conditional.html).toContain('18.5673 hectares available')
+    })
+
+    it('should render the conditional unbounded and hintless, keeping the unit, when the availability value is null', () => {
+      const result = mapActionToViewModel(csam3({ value: null, unit: 'ha' }), [])
+
+      expect(result.conditional.html).toContain('landActionQuantity_CSAM3')
+      expect(result.conditional.html).not.toContain('max=')
+      expect(result.conditional.html).not.toContain('id="landActionQuantity_CSAM3-hint"')
+      expect(result.conditional.html).toContain('>ha<')
+      expect(result.attributes['data-total-available-area']).toBeUndefined()
+      expect(result.attributes['data-available-unit']).toBe('ha')
+    })
+
+    it('should not render a "null available" hint for a non-quantity action with no limit', () => {
       const action = {
-        code: 'CSAM3',
-        description: 'Herbal leys: CSAM3',
-        availability: { type: 'partial' },
-        availableArea: { value: 18.5673, unit: 'ha' }
+        code: 'CLIG3',
+        description: 'Test',
+        ratePerUnitGbp: 12,
+        availability: { value: null, unit: 'ha' }
       }
 
       const result = mapActionToViewModel(action, [])
 
-      expect(result.conditional.html).toContain('landActionQuantity_CSAM3')
+      expect(result.html).not.toContain('landActionQuantity_CLIG3-hint')
+      expect(result.html).not.toContain('null')
+    })
+
+    it('should keep an action with a null availability value visible on initial load', () => {
+      const [item] = mapActionsToViewModel([csam3({ value: null, unit: 'ha' })], [])
+
+      expect(item.value).toBe('CSAM3')
     })
 
     it('should pre-fill the conditional input with the previously added action value', () => {
-      const action = {
-        code: 'CSAM3',
-        description: 'Herbal leys: CSAM3',
-        availability: { type: 'partial' },
-        availableArea: { value: 18.5673, unit: 'ha' }
-      }
       const addedActions = [{ code: 'CSAM3', description: 'Herbal leys: CSAM3', value: '3.25' }]
 
-      const result = mapActionToViewModel(action, addedActions)
+      const result = mapActionToViewModel(csam3({ value: 18.5673, unit: 'ha' }), addedActions)
 
       expect(result.conditional.html).toContain('value="3.25"')
     })
 
     it('should show the available area unit as a suffix on the conditional input', () => {
-      const action = {
-        code: 'CSAM3',
-        description: 'Herbal leys: CSAM3',
-        availability: { type: 'partial' },
-        availableArea: { value: 10, unit: 'ha' }
-      }
-
-      const result = mapActionToViewModel(action, [])
+      const result = mapActionToViewModel(csam3({ value: 10, unit: 'ha' }), [])
 
       expect(result.conditional.html).toContain('govuk-input__suffix')
       expect(result.conditional.html).toContain('>ha<')
     })
 
-    it('should set the max attribute and available-quantity hint on the conditional input', () => {
-      const action = {
-        code: 'CSAM3',
-        description: 'Herbal leys: CSAM3',
-        availability: { type: 'partial' },
-        availableArea: { value: 18.5673, unit: 'ha' }
-      }
-
-      const result = mapActionToViewModel(action, [])
-
-      expect(result.conditional.html).toContain('max="18.5673"')
-      expect(result.conditional.html).toContain('18.5673 hectares available')
-    })
-
     it('should still show the conditional, hint and max attribute when available area is 0', () => {
-      const action = {
-        code: 'CSAM3',
-        description: 'Herbal leys: CSAM3',
-        availability: { type: 'partial' },
-        availableArea: { value: 0, unit: 'ha' }
-      }
-
-      const result = mapActionToViewModel(action, [])
+      const result = mapActionToViewModel(csam3({ value: 0, unit: 'ha' }), [])
 
       expect(result.conditional).toBeDefined()
       expect(result.conditional.html).toContain('max="0"')
       expect(result.conditional.html).toContain('0 hectares available')
     })
 
-    it('should render the full unit name in the hint via formatAreaUnit', () => {
-      const action = {
-        code: 'CSAM3',
-        description: 'Herbal leys: CSAM3',
-        availability: { type: 'partial' },
-        availableArea: { value: 5, unit: 'sqm' }
+    it.each([[null], [undefined]])(
+      'should leave the input unbounded, hintless and suffix-less when availability is %j',
+      (availability) => {
+        const result = mapActionToViewModel(csam3(availability), [])
+
+        expect(result.conditional).toBeDefined()
+        expect(result.conditional.html).not.toContain('max=')
+        expect(result.conditional.html).not.toContain('available</div>')
+        expect(result.conditional.html).not.toContain('govuk-input__suffix')
+        expect(result.attributes['data-total-available-area']).toBeUndefined()
       }
+    )
 
-      const result = mapActionToViewModel(action, [])
+    it.each([
+      [{ value: 120, unit: 'm' }, '120 metres available'],
+      [{ value: 5, unit: 'sqm' }, '5 square metres available']
+    ])('should render the full unit name in the hint for %j', (availability, expected) => {
+      const result = mapActionToViewModel(csam3(availability), [])
 
-      expect(result.conditional.html).toContain('5 square metres available')
-    })
-
-    it('should not throw and omit the suffix when availableArea/unit is missing', () => {
-      const action = {
-        code: 'CSAM3',
-        description: 'Herbal leys: CSAM3',
-        availability: { type: 'partial' }
-      }
-
-      const result = mapActionToViewModel(action, [])
-
-      expect(result.conditional).toBeDefined()
-      expect(result.conditional.html).not.toContain('govuk-input__suffix')
+      expect(result.conditional.html).toContain(expected)
     })
 
     it('should highlight the quantity input with the given error text when this action has a quantity error', () => {
-      const action = {
-        code: 'CSAM3',
-        description: 'Herbal leys: CSAM3',
-        availability: { type: 'partial' },
-        availableArea: { value: 5, unit: 'ha' }
-      }
-
-      const result = mapActionToViewModel(action, [], { CSAM3: 'The amount of land must be no more than 5' })
+      const result = mapActionToViewModel(csam3({ value: 5, unit: 'ha' }), [], {
+        CSAM3: 'The amount of land must be no more than 5'
+      })
 
       expect(result.conditional.html).toContain('govuk-input--error')
       expect(result.conditional.html).toContain('The amount of land must be no more than 5')
     })
 
-    it('should not highlight the quantity input when a different action has the error', () => {
-      const action = {
-        code: 'CSAM3',
-        description: 'Herbal leys: CSAM3',
-        availability: { type: 'partial' },
-        availableArea: { value: 5, unit: 'ha' }
+    it.each([[{ UPL2: 'Some other error' }], [{}]])(
+      'should not highlight the quantity input when this action has no error (%j)',
+      (quantityErrorsByCode) => {
+        const result = mapActionToViewModel(csam3({ value: 5, unit: 'ha' }), [], quantityErrorsByCode)
+
+        expect(result.conditional.html).not.toContain('govuk-input--error')
       }
-
-      const result = mapActionToViewModel(action, [], { UPL2: 'Some other error' })
-
-      expect(result.conditional.html).not.toContain('govuk-input--error')
-    })
-
-    it('should not highlight the quantity input when no quantity errors are given', () => {
-      const action = {
-        code: 'CSAM3',
-        description: 'Herbal leys: CSAM3',
-        availability: { type: 'partial' },
-        availableArea: { value: 5, unit: 'ha' }
-      }
-
-      const result = mapActionToViewModel(action, [])
-
-      expect(result.conditional.html).not.toContain('govuk-input--error')
-    })
+    )
   })
 
   describe('mapActionsToViewModel', () => {
-    it('should map a flat list of actions', () => {
+    it('should map a flat list of actions, giving only the first item the bare field name as its id', () => {
       const actions = [
         { code: 'SAM1', description: 'Action 1', ratePerUnitGbp: 100 },
         { code: 'SAM2', description: 'Action 2', ratePerUnitGbp: 200 },
@@ -528,17 +401,6 @@ describe('select-actions.view-model', () => {
 
       expect(result).toHaveLength(3)
       expect(result.map((item) => item.value)).toEqual(['SAM1', 'SAM2', 'SAM3'])
-    })
-
-    it('should give only the first item the bare field name as its id', () => {
-      const actions = [
-        { code: 'SAM1', description: 'Action 1', ratePerUnitGbp: 100 },
-        { code: 'SAM2', description: 'Action 2', ratePerUnitGbp: 200 },
-        { code: 'SAM3', description: 'Action 3', ratePerUnitGbp: 150 }
-      ]
-
-      const result = mapActionsToViewModel(actions, [])
-
       expect(result.map((item) => item.id)).toEqual(['landAction', 'landAction-SAM2', 'landAction-SAM3'])
     })
 
@@ -577,8 +439,8 @@ describe('select-actions.view-model', () => {
         {
           code: 'CSAM3',
           description: 'Herbal leys: CSAM3',
-          availability: { type: 'partial' },
-          availableArea: { value: 5, unit: 'ha' }
+          inputRequired: true,
+          availability: { value: 5, unit: 'ha' }
         },
         { code: 'SAM2', description: 'Action 2', ratePerUnitGbp: 200 }
       ]
@@ -588,25 +450,26 @@ describe('select-actions.view-model', () => {
       expect(result.find((item) => item.value === 'CSAM3').conditional.html).toContain('govuk-input--error')
     })
 
-    it('should omit an action with 0 available area from the initial render', () => {
+    it('should omit an action with 0 available area, moving the bare field name id to the first visible item', () => {
       const actions = [
-        { code: 'SAM1', description: 'Action 1', ratePerUnitGbp: 100, availableArea: { value: 0, unit: 'ha' } },
-        { code: 'SAM2', description: 'Action 2', ratePerUnitGbp: 200, availableArea: { value: 5, unit: 'ha' } }
+        { code: 'SAM1', description: 'Action 1', ratePerUnitGbp: 100, availability: { value: 0, unit: 'ha' } },
+        { code: 'SAM2', description: 'Action 2', ratePerUnitGbp: 200, availability: { value: 5, unit: 'ha' } }
       ]
 
       const result = mapActionsToViewModel(actions, [])
 
       expect(result.map((item) => item.value)).toEqual(['SAM2'])
+      expect(result[0].id).toBe('landAction')
     })
 
-    it('should not omit an action with a competed 0 availableArea when its staticAvailableArea is non-zero', () => {
+    it('should not omit an action with a competed 0 availability when its staticAvailability is non-zero', () => {
       const actions = [
         {
           code: 'CLIG3',
           description: 'Manage grassland',
           ratePerUnitGbp: 151,
-          availableArea: { value: 0, unit: 'ha' },
-          staticAvailableArea: { value: 0.3271, unit: 'ha' }
+          availability: { value: 0, unit: 'ha' },
+          staticAvailability: { value: 0.3271, unit: 'ha' }
         }
       ]
 
@@ -618,7 +481,7 @@ describe('select-actions.view-model', () => {
 
     it('should still render an action with 0 available area when it was already added', () => {
       const actions = [
-        { code: 'SAM1', description: 'Action 1', ratePerUnitGbp: 100, availableArea: { value: 0, unit: 'ha' } }
+        { code: 'SAM1', description: 'Action 1', ratePerUnitGbp: 100, availability: { value: 0, unit: 'ha' } }
       ]
       const addedActions = [{ code: 'SAM1', description: 'Action 1' }]
 
@@ -628,23 +491,12 @@ describe('select-actions.view-model', () => {
       expect(result[0].checked).toBe(true)
     })
 
-    it('should not omit an action with no availableArea at all', () => {
+    it('should not omit an action with no availability at all', () => {
       const actions = [{ code: 'SAM1', description: 'Action 1', ratePerUnitGbp: 100 }]
 
       const result = mapActionsToViewModel(actions, [])
 
       expect(result.map((item) => item.value)).toEqual(['SAM1'])
-    })
-
-    it('should assign the bare field name id to the first visible item, skipping omitted actions', () => {
-      const actions = [
-        { code: 'SAM1', description: 'Action 1', ratePerUnitGbp: 100, availableArea: { value: 0, unit: 'ha' } },
-        { code: 'SAM2', description: 'Action 2', ratePerUnitGbp: 200, availableArea: { value: 5, unit: 'ha' } }
-      ]
-
-      const result = mapActionsToViewModel(actions, [])
-
-      expect(result[0].id).toBe('landAction')
     })
   })
 
@@ -708,7 +560,7 @@ describe('select-actions.view-model', () => {
   })
 
   describe('getChosenAreaFieldsHtml', () => {
-    it('should render a hidden field for a non-quantity action', () => {
+    it('should render a hidden field for a non-quantity action, defaulting to 0 with no saved chosen area', () => {
       const actions = [{ code: 'CMOR1', description: 'Moorland record' }]
 
       const html = getChosenAreaFieldsHtml(actions, [])
@@ -716,10 +568,11 @@ describe('select-actions.view-model', () => {
       expect(html).toContain('type="hidden"')
       expect(html).toContain('id="landActionQuantity_CMOR1"')
       expect(html).toContain('name="landActionQuantity_CMOR1"')
+      expect(html).toContain('value="0"')
     })
 
     it('should skip a quantity-required action', () => {
-      const actions = [{ code: 'CSAM3', description: 'Herbal leys', availability: { type: 'partial' } }]
+      const actions = [{ code: 'CSAM3', description: 'Herbal leys', inputRequired: true }]
 
       const html = getChosenAreaFieldsHtml(actions, [])
 
@@ -733,14 +586,6 @@ describe('select-actions.view-model', () => {
       const html = getChosenAreaFieldsHtml(actions, addedActions)
 
       expect(html).toContain('value="1.3008"')
-    })
-
-    it('should default to 0 when there is no saved chosen area', () => {
-      const actions = [{ code: 'CMOR1', description: 'Moorland record' }]
-
-      const html = getChosenAreaFieldsHtml(actions, [])
-
-      expect(html).toContain('value="0"')
     })
   })
 

--- a/src/server/land-grants/view-state/land-parcel.view-state.js
+++ b/src/server/land-grants/view-state/land-parcel.view-state.js
@@ -3,6 +3,7 @@ import { getConsentTypes } from '../utils/consent-types.js'
 import { getActionQuantityFieldName } from '~/src/shared/action-quantity-field.js'
 import { getSelectedActionCodes } from '../utils/selected-actions-field.js'
 import { requiresQuantityInput } from '~/src/shared/action-quantity-type.js'
+import { getAvailabilityLimit } from '~/src/shared/availability.js'
 
 /**
  * Manages state operations for land parcels and their actions.
@@ -36,7 +37,7 @@ export function buildNewState(state, actionsObj, parcel) {
  * @returns {boolean}
  */
 function hasSubmittedQuantity(payload, actionInfo) {
-  const quantityOverride = requiresQuantityInput(actionInfo.availability?.type)
+  const quantityOverride = requiresQuantityInput(actionInfo.inputRequired)
     ? payload[getActionQuantityFieldName(actionInfo.code)]
     : null
   return quantityOverride !== null && quantityOverride !== undefined && quantityOverride !== ''
@@ -60,7 +61,7 @@ export function hasSubmittedNonZeroQuantity(payload, actionInfo) {
  * Builds the state entry for a single selected action, applying its submitted
  * quantity override when it requires one, otherwise falling back to its
  * available area. actionInfo must already be recomputed against the full
- * submission, or a non-quantity action's availableArea here is its
+ * submission, or a non-quantity action's availability here is its
  * uncompeted total, not what's left once a sibling's claim is accounted for.
  * @param {object} payload - Form payload
  * @param {Action} actionInfo - The action's data from the API
@@ -78,22 +79,22 @@ function buildActionStateEntry(payload, actionInfo) {
     value: Number(
       hasQuantityOverride
         ? payload[getActionQuantityFieldName(actionInfo.code)]
-        : (actionInfo?.availableArea?.value ?? 0)
+        : (getAvailabilityLimit(actionInfo?.availability) ?? 0)
     ),
-    unit: actionInfo?.availableArea?.unit ?? ''
+    unit: actionInfo?.availability?.unit ?? ''
   }
 }
 
 /**
- * Overlays freshly recomputed availableArea (keyed by code, from
+ * Overlays freshly recomputed availability (keyed by code, from
  * fetchActionsWithPlannedActions) onto the full action list from the initial
- * fetch - everything else (description, version, consents, availability, etc.)
+ * fetch - everything else (description, version, consents, inputRequired, etc.)
  * still comes from the original fetch, and an action missing from the
- * recompute keeps its original values. The action's first-seen availableArea
- * is preserved as staticAvailableArea, since the recomputed value competes
+ * recompute keeps its original values. The action's first-seen availability
+ * is preserved as staticAvailability, since the recomputed value competes
  * against whatever else is in this submission (see mapActionToViewModel).
  * @param {Array<Action>} actions - Flat list from the initial fetch
- * @param {Array<{ code: string, availableArea?: object }>} recomputed
+ * @param {Array<{ code: string, availability?: object }>} recomputed
  * @returns {Array<Action>}
  */
 export function mergeRecomputedAvailability(actions, recomputed) {
@@ -104,8 +105,8 @@ export function mergeRecomputedAvailability(actions, recomputed) {
     return match
       ? {
           ...action,
-          availableArea: match.availableArea,
-          staticAvailableArea: action.staticAvailableArea ?? action.availableArea
+          availability: match.availability,
+          staticAvailability: action.staticAvailability ?? action.availability
         }
       : action
   })
@@ -180,7 +181,7 @@ export function addSelectedActionsToState(state, payload, actions, parcel) {
     actions,
     parcel,
     (actionInfo, formPayload) =>
-      !requiresQuantityInput(actionInfo.availability?.type) || hasSubmittedNonZeroQuantity(formPayload, actionInfo)
+      !requiresQuantityInput(actionInfo.inputRequired) || hasSubmittedNonZeroQuantity(formPayload, actionInfo)
   )
 }
 
@@ -203,7 +204,7 @@ export function getAddedActionsFromPayload(payload, actions, prevAddedActions = 
     .map((actionInfo) => ({
       code: actionInfo.code,
       description: actionInfo.description,
-      value: requiresQuantityInput(actionInfo.availability?.type)
+      value: requiresQuantityInput(actionInfo.inputRequired)
         ? (payload[getActionQuantityFieldName(actionInfo.code)] ?? '')
         : (prevAddedActions.find((a) => a.code === actionInfo.code)?.value ?? '')
     }))
@@ -326,13 +327,13 @@ export function findActionInfoFromState(landParcels, parcelKey, action) {
  * @property {string} version - Action version
  * @property {string[]} [consents] - Array of consent type keys required (e.g., ['sssi', 'hefer'])
  * @property {string} [guidanceUrl] - URL to the action's guidance page
- * @property {object} [availability] - Governs whether this action needs a user-typed quantity
- * @property {'total'|'partial'} [availability.type] - See requiresQuantityInput in
- *   shared/action-quantity-type.js
- * @property {object} [availableArea] - Available area for the action
- * @property {number} [availableArea.value] - Area value
- * @property {string} [availableArea.unit] - Area unit
- * @property {object} [staticAvailableArea] - The action's original, uncompeted available area (see mergeRecomputedAvailability)
- * @property {number} [staticAvailableArea.value] - Area value
- * @property {string} [staticAvailableArea.unit] - Area unit
+ * @property {boolean} [inputRequired] - Whether the user must type a quantity for this
+ *   action. See requiresQuantityInput in shared/action-quantity-type.js
+ * @property {object} [availability] - How much of the action is still claimable
+ * @property {number | null} [availability.value] - Amount still claimable. 0 means not
+ *   compatible with what is already selected; null means no restriction
+ * @property {string} [availability.unit] - Unit, area, linear or count
+ * @property {object} [staticAvailability] - The action's original, uncompeted availability (see mergeRecomputedAvailability)
+ * @property {number | null} [staticAvailability.value] - Amount claimable; null means no restriction
+ * @property {string} [staticAvailability.unit] - Unit, area, linear or count
  */

--- a/src/server/land-grants/view-state/land-parcel.view-state.js
+++ b/src/server/land-grants/view-state/land-parcel.view-state.js
@@ -37,7 +37,7 @@ export function buildNewState(state, actionsObj, parcel) {
  * @returns {boolean}
  */
 function hasSubmittedQuantity(payload, actionInfo) {
-  const quantityOverride = requiresQuantityInput(actionInfo.inputRequired)
+  const quantityOverride = requiresQuantityInput(actionInfo.availability?.type)
     ? payload[getActionQuantityFieldName(actionInfo.code)]
     : null
   return quantityOverride !== null && quantityOverride !== undefined && quantityOverride !== ''
@@ -88,7 +88,7 @@ function buildActionStateEntry(payload, actionInfo) {
 /**
  * Overlays freshly recomputed availability (keyed by code, from
  * fetchActionsWithPlannedActions) onto the full action list from the initial
- * fetch - everything else (description, version, consents, inputRequired, etc.)
+ * fetch - everything else (description, version, consents, availability.type, etc.)
  * still comes from the original fetch, and an action missing from the
  * recompute keeps its original values. The action's first-seen availability
  * is preserved as staticAvailability, since the recomputed value competes
@@ -105,7 +105,7 @@ export function mergeRecomputedAvailability(actions, recomputed) {
     return match
       ? {
           ...action,
-          availability: match.availability,
+          availability: { ...match.availability, type: action.availability?.type },
           staticAvailability: action.staticAvailability ?? action.availability
         }
       : action
@@ -181,7 +181,7 @@ export function addSelectedActionsToState(state, payload, actions, parcel) {
     actions,
     parcel,
     (actionInfo, formPayload) =>
-      !requiresQuantityInput(actionInfo.inputRequired) || hasSubmittedNonZeroQuantity(formPayload, actionInfo)
+      !requiresQuantityInput(actionInfo.availability?.type) || hasSubmittedNonZeroQuantity(formPayload, actionInfo)
   )
 }
 
@@ -204,7 +204,7 @@ export function getAddedActionsFromPayload(payload, actions, prevAddedActions = 
     .map((actionInfo) => ({
       code: actionInfo.code,
       description: actionInfo.description,
-      value: requiresQuantityInput(actionInfo.inputRequired)
+      value: requiresQuantityInput(actionInfo.availability?.type)
         ? (payload[getActionQuantityFieldName(actionInfo.code)] ?? '')
         : (prevAddedActions.find((a) => a.code === actionInfo.code)?.value ?? '')
     }))
@@ -327,12 +327,11 @@ export function findActionInfoFromState(landParcels, parcelKey, action) {
  * @property {string} version - Action version
  * @property {string[]} [consents] - Array of consent type keys required (e.g., ['sssi', 'hefer'])
  * @property {string} [guidanceUrl] - URL to the action's guidance page
- * @property {boolean} [inputRequired] - Whether the user must type a quantity for this
- *   action. See requiresQuantityInput in shared/action-quantity-type.js
  * @property {object} [availability] - How much of the action is still claimable
  * @property {number | null} [availability.value] - Amount still claimable. 0 means not
  *   compatible with what is already selected; null means no restriction
  * @property {string} [availability.unit] - Unit, area, linear or count
+ * @property {'total'|'partial'} [availability.type] - 'partial' requires a typed quantity
  * @property {object} [staticAvailability] - The action's original, uncompeted availability (see mergeRecomputedAvailability)
  * @property {number | null} [staticAvailability.value] - Amount claimable; null means no restriction
  * @property {string} [staticAvailability.unit] - Unit, area, linear or count

--- a/src/server/land-grants/view-state/land-parcel.view-state.test.js
+++ b/src/server/land-grants/view-state/land-parcel.view-state.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { configState } from '~/src/__mocks__/config-mocks.js'
 import {
   buildNewState,
   addActionsToExistingState,
@@ -12,26 +13,10 @@ import {
   mergeRecomputedAvailability
 } from './land-parcel.view-state.js'
 
-const configState = vi.hoisted(() => {
-  const values = new Map()
-  return {
-    set(key, value) {
-      values.set(key, value)
-    },
-    reset() {
-      values.clear()
-    },
-    get(key) {
-      return values.get(key) ?? false
-    }
-  }
+vi.mock('~/src/config/config.js', async () => {
+  const { mockConfigWithState } = await import('~/src/__mocks__/config-mocks.js')
+  return mockConfigWithState({ fallback: false })
 })
-
-vi.mock('~/src/config/config.js', () => ({
-  config: {
-    get: (key) => configState.get(key)
-  }
-}))
 
 describe('land-parcel-state.manager', () => {
   describe('buildNewState', () => {
@@ -99,8 +84,8 @@ describe('land-parcel-state.manager', () => {
       {
         name: 'Group 1',
         actions: [
-          { code: 'SAM1', description: 'Action 1', availableArea: { value: '10', unit: 'ha' } },
-          { code: 'SAM2', description: 'Action 2', availableArea: { value: '5', unit: 'ha' } }
+          { code: 'SAM1', description: 'Action 1', availability: { value: '10', unit: 'ha' } },
+          { code: 'SAM2', description: 'Action 2', availability: { value: '5', unit: 'ha' } }
         ]
       }
     ]
@@ -133,7 +118,7 @@ describe('land-parcel-state.manager', () => {
               code: 'CMOR1',
               description: 'Moorland Assessment',
               sssiConsentRequired: true,
-              availableArea: { value: '10', unit: 'ha' }
+              availability: { value: '10', unit: 'ha' }
             }
           ]
         }
@@ -163,7 +148,7 @@ describe('land-parcel-state.manager', () => {
               code: 'SAM1',
               description: 'Action 1',
               sssiConsentRequired: false,
-              availableArea: { value: '10', unit: 'ha' }
+              availability: { value: '10', unit: 'ha' }
             }
           ]
         }
@@ -192,7 +177,7 @@ describe('land-parcel-state.manager', () => {
       expect(result).toEqual({})
     })
 
-    it('should handle actions without availableArea', () => {
+    it('should handle actions without availability', () => {
       const actionsWithoutArea = [
         {
           name: 'Group 1',
@@ -234,8 +219,8 @@ describe('land-parcel-state.manager', () => {
             {
               code: 'CSAM3',
               description: 'Herbal leys: CSAM3',
-              availability: { type: 'partial' },
-              availableArea: { value: 18.5673, unit: 'ha' }
+              inputRequired: true,
+              availability: { value: 18.5673, unit: 'ha' }
             }
           ]
         }
@@ -281,8 +266,8 @@ describe('land-parcel-state.manager', () => {
               {
                 code: 'CSAM3',
                 description: 'Herbal leys: CSAM3',
-                availability: { type: 'partial' },
-                availableArea: { value: 0, unit: 'ha' }
+                inputRequired: true,
+                availability: { value: 0, unit: 'ha' }
               }
             ]
           }
@@ -310,8 +295,8 @@ describe('land-parcel-state.manager', () => {
 
   describe('addSelectedActionsToState', () => {
     const actions = [
-      { code: 'SAM1', description: 'Action 1', availableArea: { value: '10', unit: 'ha' } },
-      { code: 'SAM2', description: 'Action 2', availableArea: { value: '5', unit: 'ha' } }
+      { code: 'SAM1', description: 'Action 1', availability: { value: '10', unit: 'ha' } },
+      { code: 'SAM2', description: 'Action 2', availability: { value: '5', unit: 'ha' } }
     ]
 
     it('should create state from a single selected action (payload value is a string)', () => {
@@ -364,8 +349,8 @@ describe('land-parcel-state.manager', () => {
         {
           code: 'CSAM3',
           description: 'Herbal leys: CSAM3',
-          availability: { type: 'partial' },
-          availableArea: { value: 18.5673, unit: 'ha' }
+          inputRequired: true,
+          availability: { value: 18.5673, unit: 'ha' }
         }
       ]
       const state = {}
@@ -385,8 +370,8 @@ describe('land-parcel-state.manager', () => {
         {
           code: 'CSAM3',
           description: 'Herbal leys: CSAM3',
-          availability: { type: 'partial' },
-          availableArea: { value: 18.5673, unit: 'ha' }
+          inputRequired: true,
+          availability: { value: 18.5673, unit: 'ha' }
         }
       ]
       const state = {}
@@ -406,8 +391,8 @@ describe('land-parcel-state.manager', () => {
         {
           code: 'CSAM3',
           description: 'Herbal leys: CSAM3',
-          availability: { type: 'partial' },
-          availableArea: { value: 18.5673, unit: 'ha' }
+          inputRequired: true,
+          availability: { value: 18.5673, unit: 'ha' }
         }
       ]
       const state = {}
@@ -421,12 +406,12 @@ describe('land-parcel-state.manager', () => {
 
     it('should still save a non-quantity action alongside a skipped quantity-required one', () => {
       const actionsWithQuantity = [
-        { code: 'SAM1', description: 'Action 1', availableArea: { value: '10', unit: 'ha' } },
+        { code: 'SAM1', description: 'Action 1', availability: { value: '10', unit: 'ha' } },
         {
           code: 'CSAM3',
           description: 'Herbal leys: CSAM3',
-          availability: { type: 'partial' },
-          availableArea: { value: 18.5673, unit: 'ha' }
+          inputRequired: true,
+          availability: { value: 18.5673, unit: 'ha' }
         }
       ]
       const state = {}
@@ -476,32 +461,12 @@ describe('land-parcel-state.manager', () => {
       expect(result).toEqual([{ code: 'CSAM3', description: 'Herbal leys: CSAM3', value: '3.25' }])
     })
 
-    it('should return empty array when parcel has no actions', () => {
-      const state = {
-        landParcels: {
-          'AB1234-5678': { actionsObj: {} }
-        }
-      }
-
-      const result = getAddedActionsForStateParcel(state, 'AB1234-5678')
-
-      expect(result).toEqual([])
-    })
-
-    it('should return empty array when parcel does not exist', () => {
-      const state = { landParcels: {} }
-
-      const result = getAddedActionsForStateParcel(state, 'AB1234-5678')
-
-      expect(result).toEqual([])
-    })
-
-    it('should return empty array when state has no landParcels', () => {
-      const state = {}
-
-      const result = getAddedActionsForStateParcel(state, 'AB1234-5678')
-
-      expect(result).toEqual([])
+    it.each([
+      ['parcel has no actions', { landParcels: { 'AB1234-5678': { actionsObj: {} } } }],
+      ['parcel does not exist', { landParcels: {} }],
+      ['state has no landParcels', {}]
+    ])('should return empty array when %s', (_case, state) => {
+      expect(getAddedActionsForStateParcel(state, 'AB1234-5678')).toEqual([])
     })
   })
 
@@ -616,26 +581,12 @@ describe('land-parcel-state.manager', () => {
   })
 
   describe('hasLandParcels', () => {
-    it('should return true when parcels exist', () => {
-      const state = {
-        landParcels: {
-          'AB1234-5678': { actionsObj: {} }
-        }
-      }
-
-      expect(hasLandParcels(state)).toBe(true)
-    })
-
-    it('should return false when landParcels is empty', () => {
-      const state = { landParcels: {} }
-
-      expect(hasLandParcels(state)).toBe(false)
-    })
-
-    it('should return false when landParcels does not exist', () => {
-      const state = {}
-
-      expect(hasLandParcels(state)).toBe(false)
+    it.each([
+      ['parcels exist', { landParcels: { 'AB1234-5678': { actionsObj: {} } } }, true],
+      ['landParcels is empty', { landParcels: {} }, false],
+      ['landParcels does not exist', {}, false]
+    ])('should return %s -> %s', (_case, state, expected) => {
+      expect(hasLandParcels(state)).toBe(expected)
     })
   })
 
@@ -654,85 +605,89 @@ describe('land-parcel-state.manager', () => {
       expect(result).toEqual({ description: 'Action 1', value: '10' })
     })
 
-    it('should return null when action does not exist', () => {
-      const landParcels = {
-        'AB1234-5678': {
-          actionsObj: { SAM1: {} }
-        }
-      }
-
-      const result = findActionInfoFromState(landParcels, 'AB1234-5678', 'NON_EXISTENT')
-
-      expect(result).toBeNull()
-    })
-
-    it('should return null when parcel does not exist', () => {
-      const landParcels = {}
-
-      const result = findActionInfoFromState(landParcels, 'AB1234-5678', 'SAM1')
-
-      expect(result).toBeNull()
+    it.each([
+      ['action does not exist', { 'AB1234-5678': { actionsObj: { SAM1: {} } } }, 'NON_EXISTENT'],
+      ['parcel does not exist', {}, 'SAM1']
+    ])('should return null when %s', (_case, landParcels, code) => {
+      expect(findActionInfoFromState(landParcels, 'AB1234-5678', code)).toBeNull()
     })
   })
 
   describe('mergeRecomputedAvailability', () => {
-    it('should overwrite availableArea from the recomputed match, leaving availability untouched', () => {
+    it('should overwrite availability from the recomputed match, leaving inputRequired untouched', () => {
       const actions = [
         {
           code: 'CSAM3',
           description: 'Herbal leys',
-          availableArea: { value: 0.3271, unit: 'ha' },
-          availability: { type: 'partial' }
+          availability: { value: 0.3271, unit: 'ha' },
+          inputRequired: true
         }
       ]
-      const recomputed = [{ code: 'CSAM3', availableArea: { value: 0, unit: 'ha' } }]
+      const recomputed = [{ code: 'CSAM3', availability: { value: 0, unit: 'ha' } }]
 
       const result = mergeRecomputedAvailability(actions, recomputed)
 
-      expect(result[0].availableArea).toEqual({ value: 0, unit: 'ha' })
-      expect(result[0].availability).toEqual({ type: 'partial' })
+      expect(result[0].availability).toEqual({ value: 0, unit: 'ha' })
+      expect(result[0].inputRequired).toBe(true)
     })
 
-    it("should preserve the action's original availableArea as staticAvailableArea", () => {
-      const actions = [{ code: 'CSAM3', description: 'Herbal leys', availableArea: { value: 0.3271, unit: 'ha' } }]
-      const recomputed = [{ code: 'CSAM3', availableArea: { value: 0, unit: 'ha' } }]
-
-      const result = mergeRecomputedAvailability(actions, recomputed)
-
-      expect(result[0].staticAvailableArea).toEqual({ value: 0.3271, unit: 'ha' })
-      expect(result[0].availableArea).toEqual({ value: 0, unit: 'ha' })
-    })
-
-    it('should not overwrite an already-set staticAvailableArea on a second recompute pass', () => {
+    it('should overwrite availability with a null value when the recompute reports no restriction', () => {
       const actions = [
         {
           code: 'CSAM3',
           description: 'Herbal leys',
-          availableArea: { value: 0, unit: 'ha' },
-          staticAvailableArea: { value: 0.3271, unit: 'ha' }
+          availability: { value: 0.3271, unit: 'ha' },
+          inputRequired: true
         }
       ]
-      const recomputed = [{ code: 'CSAM3', availableArea: { value: 0.1, unit: 'ha' } }]
+      const recomputed = [{ code: 'CSAM3', availability: { value: null, unit: 'ha' } }]
 
       const result = mergeRecomputedAvailability(actions, recomputed)
 
-      expect(result[0].staticAvailableArea).toEqual({ value: 0.3271, unit: 'ha' })
+      expect(result[0].availability).toEqual({ value: null, unit: 'ha' })
+      expect(result[0].staticAvailability).toEqual({ value: 0.3271, unit: 'ha' })
+    })
+
+    it("should preserve the action's original availability as staticAvailability", () => {
+      const actions = [{ code: 'CSAM3', description: 'Herbal leys', availability: { value: 0.3271, unit: 'ha' } }]
+      const recomputed = [{ code: 'CSAM3', availability: { value: 0, unit: 'ha' } }]
+
+      const result = mergeRecomputedAvailability(actions, recomputed)
+
+      expect(result[0].staticAvailability).toEqual({ value: 0.3271, unit: 'ha' })
+      expect(result[0].availability).toEqual({ value: 0, unit: 'ha' })
+    })
+
+    it('should not overwrite an already-set staticAvailability on a second recompute pass', () => {
+      const actions = [
+        {
+          code: 'CSAM3',
+          description: 'Herbal leys',
+          availability: { value: 0, unit: 'ha' },
+          staticAvailability: { value: 0.3271, unit: 'ha' }
+        }
+      ]
+      const recomputed = [{ code: 'CSAM3', availability: { value: 0.1, unit: 'ha' } }]
+
+      const result = mergeRecomputedAvailability(actions, recomputed)
+
+      expect(result[0].staticAvailability).toEqual({ value: 0.3271, unit: 'ha' })
     })
 
     it('should keep the original action unchanged when no recomputed match exists for its code', () => {
-      const actions = [{ code: 'CSAM3', description: 'Herbal leys', availableArea: { value: 0.3271, unit: 'ha' } }]
+      const actions = [{ code: 'CSAM3', description: 'Herbal leys', availability: { value: 0.3271, unit: 'ha' } }]
 
       const result = mergeRecomputedAvailability(actions, [])
 
       expect(result[0]).toEqual(actions[0])
-      expect(result[0].staticAvailableArea).toBeUndefined()
+      expect(result[0].staticAvailability).toBeUndefined()
     })
   })
 
   describe('getAddedActionsFromPayload', () => {
     it('should use the payload value for a quantity-required action', () => {
       const payload = { landAction: 'CSAM3', landActionQuantity_CSAM3: '0.2' }
-      const actions = [{ code: 'CSAM3', description: 'Herbal leys', availability: { type: 'partial' } }]
+      const actions = [{ code: 'CSAM3', description: 'Herbal leys', inputRequired: true }]
 
       const result = getAddedActionsFromPayload(payload, actions)
 
@@ -743,7 +698,7 @@ describe('land-parcel-state.manager', () => {
       const payload = { landAction: ['CMOR1', 'CSAM3'], landActionQuantity_CSAM3: '0.2' }
       const actions = [
         { code: 'CMOR1', description: 'Moorland record' },
-        { code: 'CSAM3', description: 'Herbal leys', availability: { type: 'partial' } }
+        { code: 'CSAM3', description: 'Herbal leys', inputRequired: true }
       ]
       const prevAddedActions = [{ code: 'CMOR1', value: 0.1572 }]
 

--- a/src/server/land-grants/view-state/land-parcel.view-state.test.js
+++ b/src/server/land-grants/view-state/land-parcel.view-state.test.js
@@ -219,8 +219,7 @@ describe('land-parcel-state.manager', () => {
             {
               code: 'CSAM3',
               description: 'Herbal leys: CSAM3',
-              inputRequired: true,
-              availability: { value: 18.5673, unit: 'ha' }
+              availability: { value: 18.5673, unit: 'ha', type: 'partial' }
             }
           ]
         }
@@ -266,8 +265,7 @@ describe('land-parcel-state.manager', () => {
               {
                 code: 'CSAM3',
                 description: 'Herbal leys: CSAM3',
-                inputRequired: true,
-                availability: { value: 0, unit: 'ha' }
+                availability: { value: 0, unit: 'ha', type: 'partial' }
               }
             ]
           }
@@ -349,8 +347,7 @@ describe('land-parcel-state.manager', () => {
         {
           code: 'CSAM3',
           description: 'Herbal leys: CSAM3',
-          inputRequired: true,
-          availability: { value: 18.5673, unit: 'ha' }
+          availability: { value: 18.5673, unit: 'ha', type: 'partial' }
         }
       ]
       const state = {}
@@ -370,8 +367,7 @@ describe('land-parcel-state.manager', () => {
         {
           code: 'CSAM3',
           description: 'Herbal leys: CSAM3',
-          inputRequired: true,
-          availability: { value: 18.5673, unit: 'ha' }
+          availability: { value: 18.5673, unit: 'ha', type: 'partial' }
         }
       ]
       const state = {}
@@ -391,8 +387,7 @@ describe('land-parcel-state.manager', () => {
         {
           code: 'CSAM3',
           description: 'Herbal leys: CSAM3',
-          inputRequired: true,
-          availability: { value: 18.5673, unit: 'ha' }
+          availability: { value: 18.5673, unit: 'ha', type: 'partial' }
         }
       ]
       const state = {}
@@ -410,8 +405,7 @@ describe('land-parcel-state.manager', () => {
         {
           code: 'CSAM3',
           description: 'Herbal leys: CSAM3',
-          inputRequired: true,
-          availability: { value: 18.5673, unit: 'ha' }
+          availability: { value: 18.5673, unit: 'ha', type: 'partial' }
         }
       ]
       const state = {}
@@ -614,21 +608,20 @@ describe('land-parcel-state.manager', () => {
   })
 
   describe('mergeRecomputedAvailability', () => {
-    it('should overwrite availability from the recomputed match, leaving inputRequired untouched', () => {
+    it('should overwrite availability from the recomputed match, preserving its static type', () => {
       const actions = [
         {
           code: 'CSAM3',
           description: 'Herbal leys',
-          availability: { value: 0.3271, unit: 'ha' },
-          inputRequired: true
+          availability: { value: 0.3271, unit: 'ha', type: 'partial' }
         }
       ]
       const recomputed = [{ code: 'CSAM3', availability: { value: 0, unit: 'ha' } }]
 
       const result = mergeRecomputedAvailability(actions, recomputed)
 
-      expect(result[0].availability).toEqual({ value: 0, unit: 'ha' })
-      expect(result[0].inputRequired).toBe(true)
+      expect(result[0].availability).toEqual({ value: 0, unit: 'ha', type: 'partial' })
+      expect(result[0].staticAvailability.type).toBe('partial')
     })
 
     it('should overwrite availability with a null value when the recompute reports no restriction', () => {
@@ -636,16 +629,15 @@ describe('land-parcel-state.manager', () => {
         {
           code: 'CSAM3',
           description: 'Herbal leys',
-          availability: { value: 0.3271, unit: 'ha' },
-          inputRequired: true
+          availability: { value: 0.3271, unit: 'ha', type: 'partial' }
         }
       ]
       const recomputed = [{ code: 'CSAM3', availability: { value: null, unit: 'ha' } }]
 
       const result = mergeRecomputedAvailability(actions, recomputed)
 
-      expect(result[0].availability).toEqual({ value: null, unit: 'ha' })
-      expect(result[0].staticAvailability).toEqual({ value: 0.3271, unit: 'ha' })
+      expect(result[0].availability).toEqual({ value: null, unit: 'ha', type: 'partial' })
+      expect(result[0].staticAvailability).toEqual({ value: 0.3271, unit: 'ha', type: 'partial' })
     })
 
     it("should preserve the action's original availability as staticAvailability", () => {
@@ -687,7 +679,7 @@ describe('land-parcel-state.manager', () => {
   describe('getAddedActionsFromPayload', () => {
     it('should use the payload value for a quantity-required action', () => {
       const payload = { landAction: 'CSAM3', landActionQuantity_CSAM3: '0.2' }
-      const actions = [{ code: 'CSAM3', description: 'Herbal leys', inputRequired: true }]
+      const actions = [{ code: 'CSAM3', description: 'Herbal leys', availability: { type: 'partial' } }]
 
       const result = getAddedActionsFromPayload(payload, actions)
 
@@ -698,7 +690,7 @@ describe('land-parcel-state.manager', () => {
       const payload = { landAction: ['CMOR1', 'CSAM3'], landActionQuantity_CSAM3: '0.2' }
       const actions = [
         { code: 'CMOR1', description: 'Moorland record' },
-        { code: 'CSAM3', description: 'Herbal leys', inputRequired: true }
+        { code: 'CSAM3', description: 'Herbal leys', availability: { type: 'partial' } }
       ]
       const prevAddedActions = [{ code: 'CMOR1', value: 0.1572 }]
 

--- a/src/server/land-grants/views/select-grouped-actions.html
+++ b/src/server/land-grants/views/select-grouped-actions.html
@@ -91,7 +91,9 @@
                     html: consentHintHtml
                   }) }}
                 {% endif %}
-                <p class="govuk-body">Total available area: {{ group.totalAvailableArea.value }} {{ group.totalAvailableArea.unitFullName }}</p>
+                {% if group.totalAvailableArea.value != undefined %}
+                  <p class="govuk-body">Total available area: {{ group.totalAvailableArea.value }} {{ group.totalAvailableArea.unitFullName }}</p>
+                {% endif %}
               {% endset %}
 
               {% if group.actions.length == 1 %}

--- a/src/shared/action-quantity-type.js
+++ b/src/shared/action-quantity-type.js
@@ -1,15 +1,13 @@
 /**
- * Whether an action needs a user-typed quantity: 'partial' does, 'total'
- * (or unset) doesn't. Shared so server (action.availability.type) and
- * client (its DOM mirror, data-available-area-type) agree.
+ * Whether an action needs a user-typed quantity, as declared by the API's
+ * inputRequired flag. By contract an action whose availability.value is null
+ * (no restriction) always sets the flag - there is no amount to fall back to.
  */
-
-export const QUANTITY_INPUT_AREA_TYPES = ['partial']
 
 /**
- * @param {string | undefined | null} availabilityType
+ * @param {boolean | undefined | null} inputRequired
  * @returns {boolean}
  */
-export function requiresQuantityInput(availabilityType) {
-  return QUANTITY_INPUT_AREA_TYPES.includes(availabilityType ?? '')
+export function requiresQuantityInput(inputRequired) {
+  return inputRequired === true
 }

--- a/src/shared/action-quantity-type.js
+++ b/src/shared/action-quantity-type.js
@@ -1,13 +1,15 @@
 /**
- * Whether an action needs a user-typed quantity, as declared by the API's
- * inputRequired flag. By contract an action whose availability.value is null
- * (no restriction) always sets the flag - there is no amount to fall back to.
+ * Whether an action needs a user-typed quantity: 'partial' does, 'total'
+ * (or unset) doesn't. This remains the agreed contract until the separate
+ * quantity-input work is delivered.
  */
 
+export const QUANTITY_INPUT_AREA_TYPES = ['partial']
+
 /**
- * @param {boolean | undefined | null} inputRequired
+ * @param {string | undefined | null} availabilityType
  * @returns {boolean}
  */
-export function requiresQuantityInput(inputRequired) {
-  return inputRequired === true
+export function requiresQuantityInput(availabilityType) {
+  return QUANTITY_INPUT_AREA_TYPES.includes(availabilityType ?? '')
 }

--- a/src/shared/action-quantity-type.test.js
+++ b/src/shared/action-quantity-type.test.js
@@ -1,0 +1,16 @@
+import { requiresQuantityInput } from './action-quantity-type.js'
+
+describe('requiresQuantityInput', () => {
+  // Deliberately `=== true`, not truthiness: only the API's own boolean flag
+  // may put a quantity input on the page.
+  it.each([
+    [true, true],
+    [false, false],
+    [undefined, false],
+    [null, false],
+    ['true', false],
+    [1, false]
+  ])('reads %j as %j', (inputRequired, expected) => {
+    expect(requiresQuantityInput(inputRequired)).toBe(expected)
+  })
+})

--- a/src/shared/action-quantity-type.test.js
+++ b/src/shared/action-quantity-type.test.js
@@ -1,16 +1,14 @@
 import { requiresQuantityInput } from './action-quantity-type.js'
 
 describe('requiresQuantityInput', () => {
-  // Deliberately `=== true`, not truthiness: only the API's own boolean flag
-  // may put a quantity input on the page.
   it.each([
-    [true, true],
-    [false, false],
+    ['partial', true],
+    ['total', false],
     [undefined, false],
     [null, false],
-    ['true', false],
+    ['PARTIAL', false],
     [1, false]
-  ])('reads %j as %j', (inputRequired, expected) => {
-    expect(requiresQuantityInput(inputRequired)).toBe(expected)
+  ])('reads %j as %j', (availabilityType, expected) => {
+    expect(requiresQuantityInput(availabilityType)).toBe(expected)
   })
 })

--- a/src/shared/availability.js
+++ b/src/shared/availability.js
@@ -1,0 +1,8 @@
+/**
+ * The action's claimable ceiling, or undefined when it has no restriction.
+ * @param {{ value?: number | null, unit?: string } | null} [availability]
+ * @returns {number | undefined}
+ */
+export function getAvailabilityLimit(availability) {
+  return availability?.value ?? undefined
+}

--- a/src/shared/availability.test.js
+++ b/src/shared/availability.test.js
@@ -1,0 +1,13 @@
+import { getAvailabilityLimit } from './availability.js'
+
+describe('getAvailabilityLimit', () => {
+  it.each([
+    [{ value: 18.5, unit: 'ha' }, 18.5],
+    [{ value: 0, unit: 'ha' }, 0],
+    [{ value: null, unit: 'ha' }, undefined],
+    [null, undefined],
+    [undefined, undefined]
+  ])('reads %j as %j', (availability, expected) => {
+    expect(getAvailabilityLimit(availability)).toBe(expected)
+  })
+})

--- a/src/shared/format-unit.js
+++ b/src/shared/format-unit.js
@@ -1,0 +1,16 @@
+import { formatAreaUnit } from './format-area-unit.js'
+import { formatLinearUnit } from './format-linear-unit.js'
+
+/**
+ * Format a unit abbreviation that may be either area (e.g. "ha") or linear
+ * (e.g. "m"). Actions are sized in one or the other depending on the action,
+ * so callers holding an action's unit can't pick a formatter up front.
+ * Both formatters return their input unchanged when they don't recognise it,
+ * which is how the linear lookup is distinguished from a miss.
+ * @param {string} abbrev - Unit abbreviation
+ * @returns {string} - full unit name, or the abbreviation if unrecognised
+ */
+export function formatUnit(abbrev = '') {
+  const linear = formatLinearUnit(abbrev)
+  return linear === abbrev ? formatAreaUnit(abbrev) : linear
+}

--- a/src/shared/format-unit.test.js
+++ b/src/shared/format-unit.test.js
@@ -1,0 +1,15 @@
+import { formatUnit } from './format-unit.js'
+
+describe('formatUnit', () => {
+  it.each([
+    ['ha', 'hectares'],
+    ['sqm', 'square metres'],
+    ['m', 'metres'],
+    ['km', 'kilometres'],
+    [' KM ', 'kilometres'],
+    ['widgets', 'widgets'],
+    [undefined, '']
+  ])('formats %j as %j', (abbrev, expected) => {
+    expect(formatUnit(abbrev)).toBe(expected)
+  })
+})

--- a/src/shared/unit-types.js
+++ b/src/shared/unit-types.js
@@ -1,0 +1,5 @@
+/**
+ * Units the land-grants API measures an action's availability in area,
+ * linear, or a plain count.
+ */
+export const UNIT_TYPES = ['ha', 'sqm', 'm', 'count']


### PR DESCRIPTION
The Land Grants parcels API replaced `action.availableArea` with `action.availability` (`0` means not compatible, `null` means no restriction), driven by actions now being measured in linear metres as well as area, caught by the PACT test. Migrates the type definitions, service, view model, view state, validator, controllers, plugin and client script to the new shape, adds shared `getAvailabilityLimit`/`formatUnit`/`UNIT_TYPES` helpers, and widens the planned-actions unit allowlist beyond `ha`/`sqm`. `inputRequired` is adopted at the same time because the quantity-input decision previously read `availability.type`, the same key the API repurposes.