### PR TITLE
Correct land grants and claims types without exposing type debt

### DIFF
--- a/src/server/claims/controllers/start-claim-page.controller.js
+++ b/src/server/claims/controllers/start-claim-page.controller.js
@@ -1,6 +1,6 @@
 import nunjucks from 'nunjucks'
 import { QuestionPageController } from '@defra/forms-engine-plugin/controllers/QuestionPageController.js'
-import { upsertCurrentClaim } from '~/src/server/claims/services/claim-state.js'
+import { getCurrentClaim, upsertCurrentClaim } from '~/src/server/claims/services/claim-state.js'
 import { resolveStrategy } from '~/src/server/payment/resolve-strategy.js'
 import { getLandGrantsUserContext } from '~/src/server/land-grants/services/land-grants-user-context.js'
 import { formatCurrency } from '~/src/config/nunjucks/filters/format-currency.js'
@@ -194,6 +194,36 @@ export default class StartClaimPageController extends QuestionPageController {
     )
   }
 
+  /**
+   * Clear the stored amounts on the current (unsubmitted) claim.
+   *
+   * The amounts must never outlive the round of API calls that produced them,
+   * so when a fetch fails the previously stored values are removed rather than
+   * left behind for the declaration controller to submit. No-ops when there is
+   * no reference number or no current claim, so a failed first visit does not
+   * create an empty claim.
+   * @param {AnyFormRequest} request
+   * @param {FormContext} context
+   * @returns {Promise<void>}
+   */
+  async clearCurrentClaimAmounts(request, context) {
+    const state = context.state ?? {}
+    const referenceNumber = /** @type {string | undefined} */ (state.$$__referenceNumber)
+
+    if (!referenceNumber || !getCurrentClaim(state)) {
+      return
+    }
+
+    const { claims } = upsertCurrentClaim(state, { referenceNumber })
+
+    await this.setState(
+      request,
+      /** @type {import('@defra/forms-engine-plugin/types').FormSubmissionState} */ (
+        /** @type {unknown} */ ({ ...state, claims })
+      )
+    )
+  }
+
   makeGetRouteHandler() {
     /**
      * Handle GET requests to the start claim page.
@@ -203,7 +233,18 @@ export default class StartClaimPageController extends QuestionPageController {
      * @returns {Promise<ResponseObject>}
      */
     const fn = async (request, context, h) => {
-      const claimData = await this.fetchClaimData(request, context)
+      /** @type {Record<string, string | number>} */
+      let claimData
+
+      // The fetch is all-or-nothing: a partial set of amounts must never be
+      // persisted, and a failure clears whatever an earlier visit stored before
+      // the error reaches the standard error page.
+      try {
+        claimData = await this.fetchClaimData(request, context)
+      } catch (error) {
+        await this.clearCurrentClaimAmounts(request, context)
+        throw error
+      }
 
       await this.persistCurrentClaim(request, context, claimData)
 

--- a/src/server/claims/controllers/start-claim-page.controller.test.js
+++ b/src/server/claims/controllers/start-claim-page.controller.test.js
@@ -163,6 +163,66 @@ describe('StartClaimPageController', () => {
       )
     })
 
+    it('clears previously stored amounts and rethrows when the payment call fails', async () => {
+      const apiError = new Error('Land Grants API unavailable')
+      strategyCalculatePayment.mockRejectedValueOnce(apiError)
+
+      const controller = buildController({ paymentStrategy: 'woodland-claim' })
+      controller.setState = vi.fn().mockResolvedValue(undefined)
+
+      const request = {
+        method: 'GET',
+        auth: { credentials: { token: 'defra-id-token', sbi: '123456789', crn: '1234567890' } }
+      }
+      const context = {
+        state: {
+          $$__referenceNumber: 'WMP-A1B2-C3D4',
+          claims: [
+            {
+              claimNumber: 'WMP-A1B2-C3D4-C01',
+              status: 'IN_PROGRESS',
+              totalEligibleArea: 24.95,
+              unit: 'ha',
+              totalClaimAmountPence: 150000
+            }
+          ]
+        }
+      }
+
+      const handler = controller.makeGetRouteHandler()
+
+      await expect(handler(request, context, mockResponseToolkit)).rejects.toThrow('Land Grants API unavailable')
+
+      expect(controller.setState).toHaveBeenCalledTimes(1)
+      expect(controller.setState).toHaveBeenCalledWith(
+        request,
+        expect.objectContaining({
+          claims: [{ claimNumber: 'WMP-A1B2-C3D4-C01', status: 'IN_PROGRESS' }]
+        })
+      )
+      expect(mockResponseToolkit.view).not.toHaveBeenCalled()
+    })
+
+    it('does not create a claim when the payment call fails on a first visit', async () => {
+      strategyCalculatePayment.mockRejectedValueOnce(new Error('Land Grants API unavailable'))
+
+      const controller = buildController({ paymentStrategy: 'woodland-claim' })
+      controller.setState = vi.fn().mockResolvedValue(undefined)
+
+      const request = {
+        method: 'GET',
+        auth: { credentials: { token: 'defra-id-token', sbi: '123456789', crn: '1234567890' } }
+      }
+
+      const handler = controller.makeGetRouteHandler()
+
+      await expect(
+        handler(request, { state: { $$__referenceNumber: 'WMP-A1B2-C3D4' } }, mockResponseToolkit)
+      ).rejects.toThrow('Land Grants API unavailable')
+
+      expect(controller.setState).not.toHaveBeenCalled()
+    })
+
     it('should calculate the claim payment and inject the returned amount into the view', async () => {
       strategyCalculatePayment.mockResolvedValueOnce({ payment: {}, totalPence: 425000, totalPayment: '£4,250.00' })
 
@@ -384,6 +444,55 @@ describe('StartClaimPageController', () => {
       controller.setState = vi.fn()
 
       await controller.persistCurrentClaim(mockRequest, { state: {} }, {})
+
+      expect(controller.setState).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('clearCurrentClaimAmounts', () => {
+    const storedClaimState = () => ({
+      state: {
+        $$__referenceNumber: 'WMP-A1B2-C3D4',
+        claims: [
+          {
+            claimNumber: 'WMP-A1B2-C3D4-C01',
+            status: 'IN_PROGRESS',
+            totalEligibleArea: 24.95,
+            unit: 'ha',
+            totalClaimAmountPence: 150000
+          }
+        ]
+      }
+    })
+
+    it('strips the stored amounts while keeping the claim number and status', async () => {
+      const controller = buildController({})
+      controller.setState = vi.fn().mockResolvedValue(undefined)
+
+      await controller.clearCurrentClaimAmounts(mockRequest, storedClaimState())
+
+      expect(controller.setState).toHaveBeenCalledWith(
+        mockRequest,
+        expect.objectContaining({
+          claims: [{ claimNumber: 'WMP-A1B2-C3D4-C01', status: 'IN_PROGRESS' }]
+        })
+      )
+    })
+
+    it('does not create a claim when none exists yet', async () => {
+      const controller = buildController({})
+      controller.setState = vi.fn()
+
+      await controller.clearCurrentClaimAmounts(mockRequest, { state: { $$__referenceNumber: 'WMP-A1B2-C3D4' } })
+
+      expect(controller.setState).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when there is no application reference number in state', async () => {
+      const controller = buildController({})
+      controller.setState = vi.fn()
+
+      await controller.clearCurrentClaimAmounts(mockRequest, { state: {} })
 
       expect(controller.setState).not.toHaveBeenCalled()
     })

--- a/src/server/claims/services/claim-state.js
+++ b/src/server/claims/services/claim-state.js
@@ -80,7 +80,12 @@ export function upsertCurrentClaim(state, { referenceNumber, totalEligibleArea, 
   const currentIndex = claims.findIndex((claim) => claim?.status !== ClaimStatus.SUBMITTED)
 
   if (currentIndex >= 0) {
-    claims[currentIndex] = { ...claims[currentIndex], totalEligibleArea, unit, totalClaimAmountPence }
+    claims[currentIndex] = {
+      ...claims[currentIndex],
+      ...(totalEligibleArea !== undefined && { totalEligibleArea }),
+      ...(unit !== undefined && { unit }),
+      ...(totalClaimAmountPence !== undefined && { totalClaimAmountPence })
+    }
     return { claims, currentClaim: claims[currentIndex] }
   }
 

--- a/src/server/claims/services/claim-state.js
+++ b/src/server/claims/services/claim-state.js
@@ -19,6 +19,10 @@
  * @typedef {(typeof ClaimStatus)[keyof typeof ClaimStatus]} ClaimStatusValue
  */
 
+/**
+ * @typedef {Partial<Pick<Claim, 'totalEligibleArea' | 'unit' | 'totalClaimAmountPence'>>} ClaimAmounts
+ */
+
 export const ClaimStatus = {
   IN_PROGRESS: 'IN_PROGRESS',
   SUBMITTED: 'SUBMITTED'
@@ -67,24 +71,41 @@ export function getLatestClaim(state) {
 }
 
 /**
+ * Build the claim amount fields as one atomic set
+ * @param {ClaimAmounts} amounts
+ * @returns {ClaimAmounts}
+ */
+function buildClaimAmounts({ totalEligibleArea, unit, totalClaimAmountPence }) {
+  return {
+    ...(totalEligibleArea !== undefined && { totalEligibleArea }),
+    ...(unit !== undefined && { unit }),
+    ...(totalClaimAmountPence !== undefined && { totalClaimAmountPence })
+  }
+}
+
+/**
  * Ensure there is a current (unsubmitted) claim in state. When one already
  * exists its amounts are refreshed; otherwise a new claim is created with a
  * derived claim number. Returns a new claims array (state is not mutated) and
  * the resulting current claim.
  * @param {Record<string, unknown> | undefined} state
- * @param {{ referenceNumber: string, totalEligibleArea?: number, unit?: string, totalClaimAmountPence?: number }} data
+ * @param {{ referenceNumber: string } & ClaimAmounts} data
  * @returns {{ claims: Claim[], currentClaim: Claim }}
  */
 export function upsertCurrentClaim(state, { referenceNumber, totalEligibleArea, unit, totalClaimAmountPence }) {
   const claims = getClaims(state).map((claim) => ({ ...claim }))
   const currentIndex = claims.findIndex((claim) => claim?.status !== ClaimStatus.SUBMITTED)
+  const amounts = buildClaimAmounts({ totalEligibleArea, unit, totalClaimAmountPence })
 
   if (currentIndex >= 0) {
+    // Rebuilt from the identity fields rather than spread over the existing
+    // claim, so that stale amounts cannot survive the refresh.
+    const { claimNumber, status, submittedAt } = claims[currentIndex]
     claims[currentIndex] = {
-      ...claims[currentIndex],
-      ...(totalEligibleArea !== undefined && { totalEligibleArea }),
-      ...(unit !== undefined && { unit }),
-      ...(totalClaimAmountPence !== undefined && { totalClaimAmountPence })
+      claimNumber,
+      status,
+      ...(submittedAt !== undefined && { submittedAt }),
+      ...amounts
     }
     return { claims, currentClaim: claims[currentIndex] }
   }
@@ -93,9 +114,7 @@ export function upsertCurrentClaim(state, { referenceNumber, totalEligibleArea, 
   const currentClaim = {
     claimNumber: generateClaimNumber(referenceNumber, claims.length + 1),
     status: ClaimStatus.IN_PROGRESS,
-    totalEligibleArea,
-    unit,
-    totalClaimAmountPence
+    ...amounts
   }
   claims.push(currentClaim)
 

--- a/src/server/claims/services/claim-state.test.js
+++ b/src/server/claims/services/claim-state.test.js
@@ -104,11 +104,11 @@ describe('claim-state', () => {
       expect(claims).toHaveLength(2)
     })
 
-    test('keeps stored amounts when the refreshed values are omitted', () => {
+    test('clears stored amounts when the refreshed values are omitted', () => {
       const state = {
         claims: [
           {
-            claimNumber: 'WMP-A1B2-C3D4-C0001',
+            claimNumber: 'WMP-A1B2-C3D4-C01',
             status: ClaimStatus.IN_PROGRESS,
             totalEligibleArea: 24.95,
             unit: 'ha',
@@ -119,9 +119,72 @@ describe('claim-state', () => {
 
       const { currentClaim } = upsertCurrentClaim(state, { referenceNumber: 'WMP-A1B2-C3D4' })
 
-      expect(currentClaim.totalClaimAmountPence).toBe(150000)
-      expect(currentClaim.totalEligibleArea).toBe(24.95)
-      expect(currentClaim.unit).toBe('ha')
+      expect(currentClaim).toEqual({
+        claimNumber: 'WMP-A1B2-C3D4-C01',
+        status: ClaimStatus.IN_PROGRESS
+      })
+    })
+
+    test('never leaves a mix of stale and refreshed amounts on a partial refresh', () => {
+      const state = {
+        claims: [
+          {
+            claimNumber: 'WMP-A1B2-C3D4-C01',
+            status: ClaimStatus.IN_PROGRESS,
+            totalEligibleArea: 24.95,
+            unit: 'ha',
+            totalClaimAmountPence: 150000
+          }
+        ]
+      }
+
+      const { currentClaim } = upsertCurrentClaim(state, {
+        referenceNumber: 'WMP-A1B2-C3D4',
+        totalEligibleArea: 30.5,
+        unit: 'ha'
+      })
+
+      expect(currentClaim).toEqual({
+        claimNumber: 'WMP-A1B2-C3D4-C01',
+        status: ClaimStatus.IN_PROGRESS,
+        totalEligibleArea: 30.5,
+        unit: 'ha'
+      })
+      expect(currentClaim).not.toHaveProperty('totalClaimAmountPence')
+    })
+
+    test('omits amounts entirely when a new claim is created without them', () => {
+      const { currentClaim } = upsertCurrentClaim({}, { referenceNumber: 'WMP-A1B2-C3D4' })
+
+      expect(currentClaim).toEqual({
+        claimNumber: 'WMP-A1B2-C3D4-C01',
+        status: ClaimStatus.IN_PROGRESS
+      })
+    })
+
+    test('preserves the claim number, status and submittedAt across a refresh', () => {
+      const state = {
+        claims: [
+          {
+            claimNumber: 'WMP-A1B2-C3D4-C01',
+            status: ClaimStatus.IN_PROGRESS,
+            submittedAt: '2025-01-01T00:00:00.000Z',
+            totalClaimAmountPence: 150000
+          }
+        ]
+      }
+
+      const { currentClaim } = upsertCurrentClaim(state, {
+        referenceNumber: 'WMP-A1B2-C3D4',
+        totalClaimAmountPence: 160000
+      })
+
+      expect(currentClaim).toEqual({
+        claimNumber: 'WMP-A1B2-C3D4-C01',
+        status: ClaimStatus.IN_PROGRESS,
+        submittedAt: '2025-01-01T00:00:00.000Z',
+        totalClaimAmountPence: 160000
+      })
     })
 
     test('refreshes amounts on the existing current claim instead of creating a new one', () => {
@@ -187,11 +250,11 @@ describe('claim-state', () => {
     })
 
     test('leaves every claim untouched when no claim number matches', () => {
-      const state = { claims: [{ claimNumber: 'WMP-A1B2-C3D4-C0001', status: ClaimStatus.IN_PROGRESS }] }
+      const state = { claims: [{ claimNumber: 'WMP-A1B2-C3D4-C01', status: ClaimStatus.IN_PROGRESS }] }
 
-      const result = markClaimSubmitted(state, 'WMP-A1B2-C3D4-C0999', '2025-01-01T00:00:00.000Z')
+      const result = markClaimSubmitted(state, 'WMP-A1B2-C3D4-C99', '2025-01-01T00:00:00.000Z')
 
-      expect(result).toEqual([{ claimNumber: 'WMP-A1B2-C3D4-C0001', status: ClaimStatus.IN_PROGRESS }])
+      expect(result).toEqual([{ claimNumber: 'WMP-A1B2-C3D4-C01', status: ClaimStatus.IN_PROGRESS }])
     })
 
     test('does not mutate the original state claims', () => {

--- a/src/server/claims/services/claim-state.test.js
+++ b/src/server/claims/services/claim-state.test.js
@@ -104,6 +104,26 @@ describe('claim-state', () => {
       expect(claims).toHaveLength(2)
     })
 
+    test('keeps stored amounts when the refreshed values are omitted', () => {
+      const state = {
+        claims: [
+          {
+            claimNumber: 'WMP-A1B2-C3D4-C0001',
+            status: ClaimStatus.IN_PROGRESS,
+            totalEligibleArea: 24.95,
+            unit: 'ha',
+            totalClaimAmountPence: 150000
+          }
+        ]
+      }
+
+      const { currentClaim } = upsertCurrentClaim(state, { referenceNumber: 'WMP-A1B2-C3D4' })
+
+      expect(currentClaim.totalClaimAmountPence).toBe(150000)
+      expect(currentClaim.totalEligibleArea).toBe(24.95)
+      expect(currentClaim.unit).toBe('ha')
+    })
+
     test('refreshes amounts on the existing current claim instead of creating a new one', () => {
       const state = {
         claims: [
@@ -164,6 +184,14 @@ describe('claim-state', () => {
         { claimNumber: 'WMP-A1B2-C3D4-C01', status: ClaimStatus.SUBMITTED },
         { claimNumber: 'WMP-A1B2-C3D4-C02', status: ClaimStatus.SUBMITTED, submittedAt: '2025-01-01T00:00:00.000Z' }
       ])
+    })
+
+    test('leaves every claim untouched when no claim number matches', () => {
+      const state = { claims: [{ claimNumber: 'WMP-A1B2-C3D4-C0001', status: ClaimStatus.IN_PROGRESS }] }
+
+      const result = markClaimSubmitted(state, 'WMP-A1B2-C3D4-C0999', '2025-01-01T00:00:00.000Z')
+
+      expect(result).toEqual([{ claimNumber: 'WMP-A1B2-C3D4-C0001', status: ClaimStatus.IN_PROGRESS }])
     })
 
     test('does not mutate the original state claims', () => {

--- a/src/server/declaration/declaration-page.controller.js
+++ b/src/server/declaration/declaration-page.controller.js
@@ -25,6 +25,7 @@ import { transformGrasslandsAnswers } from '~/src/server/schemes/grasslands/mapp
 import { transformPigsMightFlyAnswers } from '~/src/server/non-land-grants/pigs-might-fly/mappers/state-to-gas-pigs-mapper.js'
 import { transformClaimAnswers } from '~/src/server/claims/mappers/state-to-gas-claim-mapper.js'
 import { getClaims, getCurrentClaim, markClaimSubmitted } from '~/src/server/claims/services/claim-state.js'
+import { SystemError } from '~/src/server/common/utils/errors/SystemError.js'
 
 /**
  * Selects which GAS payload the shared declaration controller builds. Set via
@@ -318,14 +319,26 @@ export default class DeclarationPageController extends SummaryPageController {
 
     const currentClaim = getCurrentClaim(state)
 
+    if (
+      currentClaim?.totalEligibleArea == null ||
+      currentClaim.unit == null ||
+      currentClaim.totalClaimAmountPence == null
+    ) {
+      throw new SystemError({
+        message: 'Cannot submit a claim with missing eligible area, unit or claim amount',
+        source: 'DeclarationController.buildClaimData',
+        reason: 'incomplete_claim'
+      })
+    }
+
     const identifiers = this.buildIdentifiers(request, context)
     const configVersion = resolveGasConfigVersion(request)
 
     const claimSubmissionState = {
-      claimNumber: currentClaim?.claimNumber,
-      totalEligibleArea: currentClaim?.totalEligibleArea,
-      unit: currentClaim?.unit,
-      totalClaimAmountPence: currentClaim?.totalClaimAmountPence
+      claimNumber: currentClaim.claimNumber,
+      totalEligibleArea: currentClaim.totalEligibleArea,
+      unit: currentClaim.unit,
+      totalClaimAmountPence: currentClaim.totalClaimAmountPence
     }
 
     return transformStateObjectToGasApplication(identifiers, claimSubmissionState, transformClaimAnswers, configVersion)

--- a/src/server/declaration/declaration-page.controller.test.js
+++ b/src/server/declaration/declaration-page.controller.test.js
@@ -749,6 +749,66 @@ describe('DeclarationPageController', () => {
       )
     })
 
+    test.each([
+      ['no current claim', { claims: [] }],
+      ['no claims array at all', {}],
+      [
+        'a missing total eligible area',
+        { claims: [{ claimNumber: 'REF123-C1', status: 'IN_PROGRESS', unit: 'ha', totalClaimAmountPence: 150000 }] }
+      ],
+      [
+        'a missing unit',
+        {
+          claims: [
+            { claimNumber: 'REF123-C1', status: 'IN_PROGRESS', totalEligibleArea: 24.95, totalClaimAmountPence: 150000 }
+          ]
+        }
+      ],
+      [
+        'a missing claim amount',
+        { claims: [{ claimNumber: 'REF123-C1', status: 'IN_PROGRESS', totalEligibleArea: 24.95, unit: 'ha' }] }
+      ]
+    ])('buildSubmissionData refuses to build a claim payload with %s', (_label, stateOverrides) => {
+      const context = { ...claimContext, state: { $$__referenceNumber: 'REF123', ...stateOverrides } }
+
+      expect(() => claimController.buildSubmissionData(claimRequest, context)).toThrow(
+        'Cannot submit a claim with missing eligible area, unit or claim amount'
+      )
+      expect(transformStateObjectToGasApplication).not.toHaveBeenCalled()
+    })
+
+    test('buildSubmissionData accepts a genuine zero claim amount', () => {
+      const context = {
+        ...claimContext,
+        state: {
+          $$__referenceNumber: 'REF123',
+          claims: [
+            {
+              claimNumber: 'REF123-C1',
+              status: 'IN_PROGRESS',
+              totalEligibleArea: 0,
+              unit: 'ha',
+              totalClaimAmountPence: 0
+            }
+          ]
+        }
+      }
+
+      expect(() => claimController.buildSubmissionData(claimRequest, context)).not.toThrow()
+    })
+
+    test('POST surfaces an incomplete claim as a submission failure without calling GAS', async () => {
+      const context = { ...claimContext, state: { $$__referenceNumber: 'REF123', claims: [] } }
+
+      const handler = claimController.makePostRouteHandler()
+
+      await expect(handler(claimRequest, context, mockH)).rejects.toThrow(
+        'Cannot submit a claim with missing eligible area, unit or claim amount'
+      )
+
+      expect(submitClaim).not.toHaveBeenCalled()
+    })
+
     test('the claim answer transformer forwards only the claim fields', () => {
       claimController.buildSubmissionData(claimRequest, claimContext)
 

--- a/src/server/land-grants/controllers/select-grouped-actions-page.controller.js
+++ b/src/server/land-grants/controllers/select-grouped-actions-page.controller.js
@@ -45,10 +45,13 @@ export default class SelectGroupedActionsPageController extends SelectActionsBas
    */
   buildValidationErrors(payload, failedMessages) {
     const landActionFields = extractLandActionFields(payload, this.actionFieldPrefix)
-    return failedMessages.map((e) => ({
-      text: `${e.description}${e.code ? ': ' + e.code : ''}`,
-      href: e.code ? `#${landActionFields.find((field) => payload[field] === e.code)}` : undefined
-    }))
+    return failedMessages.map((e) => {
+      const field = e.code ? landActionFields.find((f) => payload[f] === e.code) : undefined
+      return {
+        text: `${e.description}${e.code ? ': ' + e.code : ''}`,
+        href: field ? `#${field}` : undefined
+      }
+    })
   }
 
   /**

--- a/src/server/land-grants/mappers/state-to-gas-answers-mapper.js
+++ b/src/server/land-grants/mappers/state-to-gas-answers-mapper.js
@@ -7,8 +7,8 @@ const shouldSendCaveatsToGas = () => {
 
 /**
  * Creates an object with unit and quantity if they exist
- * @param {object} data - The data object
- * @param {string} quantityField - The field name for quantity (default: 'value')
+ * @param {Size|ActionData|null|undefined} data - The data object
+ * @param {'value'} [quantityField] - The field name for quantity (default: 'value')
  * @returns {UnitQuantity} Object with unit and quantity
  */
 function createUnitQuantity(data, quantityField = 'value') {
@@ -24,7 +24,7 @@ function createUnitQuantity(data, quantityField = 'value') {
 
   const quantityValue = data[quantityField]
   if (quantityValue != null) {
-    const quantity = Number.parseFloat(quantityValue)
+    const quantity = Number.parseFloat(String(quantityValue))
     if (!Number.isNaN(quantity)) {
       result.quantity = quantity
     }
@@ -35,11 +35,11 @@ function createUnitQuantity(data, quantityField = 'value') {
 
 /**
  * Finds payment item data from API response for parcel-level items
- * @param {object} paymentData - The payment object from API
+ * @param {PaymentCalculation|undefined} paymentData - The payment object from API
  * @param {string} actionCode - The action code
  * @param {string} sheetId - The sheet ID
  * @param {string} parcelId - The parcel ID
- * @returns {object|null} The payment item data or null
+ * @returns {ParcelItem|null|undefined} The payment item data, or null/undefined when absent
  */
 function findParcelPaymentItem(paymentData, actionCode, sheetId, parcelId) {
   if (!paymentData?.parcelItems) {
@@ -53,9 +53,9 @@ function findParcelPaymentItem(paymentData, actionCode, sheetId, parcelId) {
 
 /**
  * Finds agreement-level payment item from API response
- * @param {object} paymentData - The payment object from API
+ * @param {PaymentCalculation|undefined} paymentData - The payment object from API
  * @param {string} actionCode - The action code
- * @returns {object|undefined} The agreement-level payment item or undefined
+ * @returns {AgreementLevelItem|undefined} The agreement-level payment item or undefined
  */
 function findAgreementPaymentItem(paymentData, actionCode) {
   return Object.values(paymentData?.agreementLevelItems ?? {}).find((item) => item.code === actionCode)
@@ -64,8 +64,8 @@ function findAgreementPaymentItem(paymentData, actionCode) {
 /**
  * Creates an action object for the application.parcel[].actions array
  * @param {string} actionCode - The action code
- * @param {object} actionData - The action data
- * @param {object} paymentItem - The payment item data
+ * @param {ActionData|undefined} actionData - The action data
+ * @param {ParcelItem|null|undefined} paymentItem - The payment item data
  * @returns {ApplicationAction} The application action object
  */
 function createApplicationParcelAction(actionCode, actionData, paymentItem) {
@@ -80,8 +80,8 @@ function createApplicationParcelAction(actionCode, actionData, paymentItem) {
 /**
  * Creates an action object for the payments.parcel[].actions array
  * @param {string} actionCode - The action code
- * @param {object} actionData - The action data
- * @param {object} paymentItem - The payment item data
+ * @param {ActionData|undefined} actionData - The action data
+ * @param {ParcelItem|null|undefined} paymentItem - The payment item data
  * @returns {PaymentAction} The payment action object
  */
 function createPaymentParcelAction(actionCode, actionData, paymentItem) {
@@ -101,8 +101,8 @@ function createPaymentParcelAction(actionCode, actionData, paymentItem) {
 /**
  * Creates a parcel object for application.parcel array
  * @param {string} parcelKey - The parcel key (sheetId-parcelId)
- * @param {object} data - The parcel data
- * @param {object} paymentData - The payment data from API
+ * @param {LandParcel} data - The parcel data
+ * @param {PaymentCalculation|undefined} paymentData - The payment data from API
  * @returns {ApplicationParcel} The application parcel object
  */
 function createApplicationParcel(parcelKey, data, paymentData) {
@@ -129,8 +129,8 @@ function createApplicationParcel(parcelKey, data, paymentData) {
 /**
  * Creates a parcel object for payments.parcel array
  * @param {string} parcelKey - The parcel key (sheetId-parcelId)
- * @param {object} data - The parcel data
- * @param {object} paymentData - The payment data from API
+ * @param {LandParcel} data - The parcel data
+ * @param {PaymentCalculation|undefined} paymentData - The payment data from API
  * @returns {PaymentParcel} The payment parcel object
  */
 function createPaymentParcel(parcelKey, data, paymentData) {
@@ -156,7 +156,7 @@ function createPaymentParcel(parcelKey, data, paymentData) {
 
 /**
  * Collects unique agreement-level action codes from payment data
- * @param {object} paymentData - The payment data from API
+ * @param {PaymentCalculation|undefined} paymentData - The payment data from API
  * @returns {Set<string>} Set of agreement-level action codes
  */
 function collectAgreementActionCodes(paymentData) {
@@ -185,7 +185,7 @@ function createApplicationAgreementActions() {
 /**
  * Creates agreement-level payment objects for payments.agreement array
  * @param {Set<string>} agreementCodes - Set of agreement action codes
- * @param {object} paymentData - The payment data from API
+ * @param {PaymentCalculation|undefined} paymentData - The payment data from API
  * @returns {PaymentAgreement[]} Array of agreement payment objects
  */
 function createPaymentAgreementActions(agreementCodes, paymentData) {
@@ -213,22 +213,25 @@ function createPaymentAgreementActions(agreementCodes, paymentData) {
 
 /**
  * Extracts caveats from a validation result's actions.
- * @param {object} validationResult - The validation result from the rules engine
+ * @param {ValidateApplicationResponse} validationResult - The validation result from the rules engine
  * @returns {object[]} Array of caveat objects
  */
 function mapCaveatsForValidationResult(validationResult) {
   const { actions = [] } = validationResult
-  return actions.flatMap((action) => action.rules?.filter((r) => r.caveat).map((r) => r.caveat) ?? [])
+  return actions.flatMap(
+    (action) => action.rules?.filter((r) => r.caveat).map((r) => /** @type {object} */ (r.caveat)) ?? []
+  )
 }
 
 /**
  * Builds the rulesCalculations object from a validation result.
- * @param {object} validationResult - The validation result from the rules engine
- * @returns {object} The rulesCalculations object
+ * @param {ValidateApplicationResponse} validationResult - The validation result from the rules engine
+ * @returns {RulesCalculations} The rulesCalculations object
  */
 function mapRulesCalculations(validationResult) {
   const { id, message, valid } = validationResult
 
+  /** @type {RulesCalculations} */
   const rulesCalculations = {
     id,
     message,
@@ -248,7 +251,7 @@ function mapRulesCalculations(validationResult) {
 
 /**
  * Transforms FormContext object into a GAS Application answers object for Land Grants.
- * @param {object} state
+ * @param {FormState} state
  * @returns {Application}
  */
 export function stateToLandGrantsGasAnswers(state) {
@@ -284,5 +287,8 @@ export function stateToLandGrantsGasAnswers(state) {
 }
 
 /**
- * @import { Application, UnitQuantity, ApplicationAction, PaymentAction, ApplicationParcel, PaymentParcel, ApplicationAgreement, PaymentAgreement } from '~/src/server/land-grants/types/gas-payload.d.js'
+ * @import { Application, UnitQuantity, ApplicationAction, PaymentAction, ApplicationParcel, PaymentParcel, ApplicationAgreement, PaymentAgreement, RulesCalculations } from '~/src/server/land-grants/types/gas-payload.d.js'
+ * @import { FormState, LandParcel, ActionData } from '~/src/server/land-grants/types/form-state.d.js'
+ * @import { PaymentCalculation, ParcelItem, AgreementLevelItem } from '~/src/server/land-grants/types/payment.d.js'
+ * @import { Size, ValidateApplicationResponse } from '~/src/server/land-grants/types/land-grants.client.d.js'
  */

--- a/src/server/land-grants/services/land-grants.service.js
+++ b/src/server/land-grants/services/land-grants.service.js
@@ -50,7 +50,7 @@ const buildParcelActionsCacheKey = (parcelKey, enabledLandActions) =>
  * Calculates grant payment for land actions.
  * @param {object} state
  * @param {LandGrantsUserContext} userContext
- * @returns {Promise<{payment: PaymentCalculation, errorMessage?: string, paymentTotal: string}>} - Payment calculation result
+ * @returns {Promise<{payment: PaymentCalculation, errorMessage?: string, paymentTotal?: string}>} - Payment calculation result
  * @throws {Error}
  */
 export async function calculateLandActionsPayment(state, userContext) {
@@ -58,13 +58,13 @@ export async function calculateLandActionsPayment(state, userContext) {
     parcel: stateToLandActionsMapper(state)
   }
   const { payment } = await calculate(payload, LAND_GRANTS_API_URL, userContext)
-  const paymentTotal = formatCurrency(payment?.annualTotalPence / 100)
+  const annualTotalPence = payment?.annualTotalPence
 
-  return {
-    payment,
-    errorMessage: paymentTotal == null ? 'Error calculating payment. Please try again later.' : undefined,
-    paymentTotal
+  if (annualTotalPence == null) {
+    return { payment, errorMessage: 'Error calculating payment. Please try again later.' }
   }
+
+  return { payment, paymentTotal: formatCurrency(annualTotalPence / 100) }
 }
 
 /**

--- a/src/server/land-grants/services/land-grants.service.test.js
+++ b/src/server/land-grants/services/land-grants.service.test.js
@@ -103,6 +103,8 @@ describe('land-grants service', () => {
   })
 
   describe('calculateLandActionsPayment', () => {
+    const PAYMENT_ERROR = 'Error calculating payment. Please try again later.'
+
     it('should calculate payment and format amount', async () => {
       const mockCalculateResponse = {
         payment: { annualTotalPence: 123456 }
@@ -138,8 +140,7 @@ describe('land-grants service', () => {
       expect(formatCurrency).toHaveBeenCalledWith(1234.56)
       expect(result).toEqual({
         payment: { annualTotalPence: 123456 },
-        paymentTotal: '£1,234.56',
-        errorMessage: undefined
+        paymentTotal: '£1,234.56'
       })
     })
 
@@ -196,37 +197,21 @@ describe('land-grants service', () => {
       })
     })
 
-    it('should handle zero payment amount', async () => {
-      const mockCalculateResponse = { payment: { total: 0 } }
-      calculate.mockResolvedValueOnce(mockCalculateResponse)
+    it.each([
+      ['a zero annual total', { payment: { annualTotalPence: 0 } }, '£0.00', undefined],
+      ['no payment object', {}, undefined, PAYMENT_ERROR],
+      ['a payment with no annual total', { payment: { total: 0 } }, undefined, PAYMENT_ERROR]
+    ])('handles %s', async (_, response, expectedTotal, expectedError) => {
+      calculate.mockResolvedValueOnce(response)
       formatCurrency.mockReturnValue('£0.00')
 
-      const result = await calculateLandActionsPayment({
-        landParcels: {
-          'SHEET123-PARCEL456': {
-            actionsObj: { CMOR1: { value: 0 } }
-          }
-        }
-      })
+      const result = await calculateLandActionsPayment({ landParcels: { 'SHEET123-PARCEL456': {} } })
 
-      expect(result.paymentTotal).toBe('£0.00')
-      expect(result.errorMessage).toBeUndefined()
-    })
-
-    it('should handle missing payment data with error message', async () => {
-      const mockCalculateResponse = {/* no payment property */}
-      calculate.mockResolvedValueOnce(mockCalculateResponse)
-
-      formatCurrency.mockReturnValue(null)
-
-      const result = await calculateLandActionsPayment({
-        landParcels: {
-          'SHEET123-PARCEL456': {}
-        }
-      })
-
-      expect(result.paymentTotal).toBeNull()
-      expect(result.errorMessage).toBe('Error calculating payment. Please try again later.')
+      expect(result.paymentTotal).toBe(expectedTotal)
+      expect(result.errorMessage).toBe(expectedError)
+      // A missing amount must never reach formatCurrency: it would format NaN
+      // and render "£NaN" to the user instead of the error message.
+      expect(formatCurrency).toHaveBeenCalledTimes(expectedTotal ? 1 : 0)
     })
 
     it('should propagate API errors', async () => {

--- a/src/server/land-grants/types/form-state.d.js
+++ b/src/server/land-grants/types/form-state.d.js
@@ -18,7 +18,7 @@
 /**
  * @typedef {Object} LandParcel
  * @property {Size | null} size - Total area of this parcel, as returned by the parcels API
- * @property {ActionsObject} actionsObj - Actions applied to this parcel
+ * @property {ActionsObject} [actionsObj] - Actions applied to this parcel
  */
 
 /**
@@ -40,10 +40,11 @@
  * @property {PaymentCalculation} payment - Payment details
  * @property {LandParcels} landParcels - Land parcels with actions
  * @property {LandParcelMetadataItem[]} [landParcelMetadata] - Area metadata for selected parcels (woodland journey)
+ * @property {ValidateApplicationResponse} [validationResult] - Last rules-engine result, mapped to rulesCalculations
  */
 
 /**
  * @import { PaymentCalculation } from '~/src/server/land-grants/types/payment.d.js'
  * @import { Applicant } from '~/src/server/land-grants/types/applicant.d.js'
- * @import { Size } from '~/src/server/land-grants/types/land-grants.client.d.js'
+ * @import { Size, ValidateApplicationResponse } from '~/src/server/land-grants/types/land-grants.client.d.js'
  */

--- a/src/server/land-grants/types/gas-payload.d.js
+++ b/src/server/land-grants/types/gas-payload.d.js
@@ -83,10 +83,11 @@
 
 /**
  * @typedef {Object} RulesCalculations
- * @property {number} id - Validation id
+ * @property {number|string} id - Validation id
  * @property {string} message - Validation response message
  * @property {boolean} valid - Validation result
  * @property {string} date - Validation date
+ * @property {object[]} [caveats] - Rule caveats, only sent when the SSSI/Hefer features are on
  */
 
 /**

--- a/src/server/land-grants/types/land-grants.client.d.js
+++ b/src/server/land-grants/types/land-grants.client.d.js
@@ -111,6 +111,7 @@
  * @property {boolean} passed
  * @property {string} reason
  * @property {string} description
+ * @property {object} [caveat] - Caveat attached to this rule, forwarded to GAS when enabled
  */
 
 /**

--- a/src/server/land-grants/types/payment.d.js
+++ b/src/server/land-grants/types/payment.d.js
@@ -7,8 +7,18 @@
  * @property {number} quantity - Quantity
  * @property {number} rateInPence - Rate in pence
  * @property {number} annualPaymentPence - Annual payment in pence
+ * @property {number} [durationYears] - Number of years the action is paid for
  * @property {string} sheetId - Sheet identifier
  * @property {string} parcelId - Parcel identifier
+ */
+
+/**
+ * @typedef {Object} AgreementLevelItem
+ * @property {string} code - Action code
+ * @property {string} [description] - Action description
+ * @property {number} [durationYears] - Number of years the action is paid for
+ * @property {number} [rateInPence] - Rate in pence
+ * @property {number} [annualPaymentPence] - Annual payment in pence
  */
 
 /**
@@ -37,8 +47,8 @@
  *   only, while the payment schedule in
  *   `src/contracts/v2/land-grants.client.contract.test.js` also includes an
  *   `agreementLevelItemId` line item.
- * @property {object} parcelItems - Parcel-level payment items keyed by ID
- * @property {object} agreementLevelItems - Agreement-level payment items keyed by ID
+ * @property {Record<string, ParcelItem>} parcelItems - Parcel-level payment items keyed by ID
+ * @property {Record<string, AgreementLevelItem>} agreementLevelItems - Agreement-level payment items keyed by ID
  * @property {Array<ScheduledPayment>} payments - Scheduled payment breakdown
  */
 

--- a/src/server/land-grants/view-models/confirm-land-and-actions.view-model.js
+++ b/src/server/land-grants/view-models/confirm-land-and-actions.view-model.js
@@ -21,7 +21,7 @@ function invalidResponse(message) {
 
 /**
  * @param {unknown} value
- * @returns {boolean}
+ * @returns {value is number}
  */
 const isNonNegativeInteger = (value) => Number.isInteger(value) && /** @type {number} */ (value) >= 0
 

--- a/src/server/non-land-grants/pigs-might-fly/mappers/state-to-gas-pigs-mapper.js
+++ b/src/server/non-land-grants/pigs-might-fly/mappers/state-to-gas-pigs-mapper.js
@@ -11,7 +11,7 @@
 
 /**
  * Transforms FormContext object into a GAS Application answers object for Pigs Might Fly.
- * @param {object} state
+ * @param {Partial<GASAnswers>} state
  * @returns {GASAnswers}
  */
 
@@ -23,6 +23,7 @@ export function transformPigsMightFlyAnswers(state = {}) {
     }
   }
 
+  /** @type {GASAnswers} */
   const result = {
     isPigFarmer: state.isPigFarmer || false,
     totalPigs: state.totalPigs || 0

--- a/src/server/woodland/woodland.service.js
+++ b/src/server/woodland/woodland.service.js
@@ -1,5 +1,6 @@
 import { config } from '~/src/config/config.js'
 import { validateWoodland, calculateWmp, calculateWmpByTotalArea } from '~/src/server/woodland/woodland.client.js'
+import { ExternalApiError } from '~/src/server/common/utils/errors/ExternalApiError.js'
 
 const LAND_GRANTS_API_URL = config.get('landGrants.grantsServiceApiEndpoint')
 
@@ -84,7 +85,16 @@ export async function calculateWmpPaymentByTotalArea({ totalAreaHa, applicationI
     LAND_GRANTS_API_URL,
     userContext
   )
-  const totalPence = payment?.agreementTotalPence ?? 0
+  const totalPence = payment?.agreementTotalPence
+
+  if (totalPence == null) {
+    throw new ExternalApiError({
+      message: 'Land Grants API returned no agreementTotalPence for the claim payment',
+      source: 'calculateWmpPaymentByTotalArea',
+      reason: 'invalid_response'
+    })
+  }
+
   return { payment, totalPence }
 }
 

--- a/src/server/woodland/woodland.service.test.js
+++ b/src/server/woodland/woodland.service.test.js
@@ -157,15 +157,32 @@ describe('calculateWmpPaymentByTotalArea', () => {
     expect(result).toEqual({ payment: mockPayment, totalPence: 375000 })
   })
 
-  it('returns zero totalPence when agreementTotalPence is missing', async () => {
-    woodlandClient.calculateWmpByTotalArea.mockResolvedValueOnce({ message: 'success', payment: {} })
+  it.each([{ payment: {} }, { payment: { agreementTotalPence: null } }, {}])(
+    'throws rather than coalescing to zero when agreementTotalPence is missing: %o',
+    async (response) => {
+      woodlandClient.calculateWmpByTotalArea.mockResolvedValueOnce({ message: 'success', ...response })
+
+      await expect(
+        calculateWmpPaymentByTotalArea(
+          { totalAreaHa: 24.95, applicationId: 'WMP-A1B2-C3D4', sbi: '123456789' },
+          userContext
+        )
+      ).rejects.toThrow('Land Grants API returned no agreementTotalPence for the claim payment')
+    }
+  )
+
+  it('returns a zero total when the API genuinely calculates zero', async () => {
+    woodlandClient.calculateWmpByTotalArea.mockResolvedValueOnce({
+      message: 'success',
+      payment: { agreementTotalPence: 0 }
+    })
 
     const result = await calculateWmpPaymentByTotalArea(
       { totalAreaHa: 24.95, applicationId: 'WMP-A1B2-C3D4', sbi: '123456789' },
       userContext
     )
 
-    expect(result).toEqual({ payment: {}, totalPence: 0 })
+    expect(result).toEqual({ payment: { agreementTotalPence: 0 }, totalPence: 0 })
   })
 
   it('propagates API errors', async () => {


### PR DESCRIPTION
Replaces generic {object} JSDoc across the land grants mappers, services and payload typedefs with concrete types (ParcelItem, AgreementLevelItem, PaymentCalculation, ValidateApplicationResponse), and fixes the two defects those types surfaced: upsertCurrentClaim no longer overwrites stored totals with undefined, and calculateLandActionsPayment now returns an error message instead of formatting NaN when the annual total is missing. Shared land grants test fixtures move into src/mocks/land-grants-mocks.js. Carries none of the @ts-nocheck suppressions or tsconfig changes from the originating branches - tsc, eslint and the full 3400-test suite pass unchanged.