### PR TITLE
Feature/tgc 1533 user feedback survey

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Repository Guidelines
 
+Before making changes, read `CONTEXT.md`. It is the source of truth for Grants domain terminology and concepts.
+
 ## Project Structure & Module Organization
 
 Application code lives in `src`. Server routes, controllers, helpers, services, and views are under `src/server`; browser JavaScript and Sass are under `src/client`; shared utilities are in `src/shared`; configuration is in `src/config`. Unit tests are colocated as `*.test.js`. Contract assets live in `src/contracts`. Acceptance tests are in `acceptance/test`, with feature files, steps, page objects, and support utilities split by folder. Operational scripts and local tooling are in `scripts/`, `tools/`, `floci/`, and root Docker Compose files.

--- a/acceptance/test/features/application-lifecycle.feature
+++ b/acceptance/test/features/application-lifecycle.feature
@@ -209,6 +209,7 @@ Feature: Application Lifecycle
 
         # review claim
         And should see heading "Example claim start page"
+        And the user should see a phase banner feedback link with journey "claim-inprogress"
         When the user clicks on "Continue"
 
         # claim-declaration
@@ -222,6 +223,8 @@ Feature: Application Lifecycle
         Then the user should be at URL "claim-confirmation"
         And should see heading "Claim submitted"
         And should see claim reference number "-C0001"
+        And the user should see a phase banner feedback link with journey "claim-submitted"
+        And the user should see a confirmation page feedback link with journey "claim-submitted"
 
         # reopen browser and remain on claim confirmation while GAS status is unchanged
         Given the user starts a new browser session

--- a/acceptance/test/steps/then.steps.js
+++ b/acceptance/test/steps/then.steps.js
@@ -230,24 +230,30 @@ Then('(the user )should not see a notification banner', async function () {
   await expect(this.page.locator('div.govuk-notification-banner')).not.toBeVisible()
 })
 
-Then('(the user )should see a phase banner feedback link', async function () {
-  const link = this.page.locator('.govuk-phase-banner a.govuk-link', { hasText: 'feedback' })
+const expectFeedbackLink = async (page, selector, text, journey) => {
+  const link = page.locator(selector, { hasText: text })
   await expect(link).toBeVisible()
   const href = await link.getAttribute('href')
   const params = new URL(href).searchParams
   expect(params.get('grant')).toBeTruthy()
   expect(params.get('url')).toBeTruthy()
-  expect(params.get('journey')).toEqual('application-inprogress')
+  expect(params.get('journey')).toEqual(journey)
+}
+
+Then('(the user )should see a phase banner feedback link', async function () {
+  await expectFeedbackLink(this.page, '.govuk-phase-banner a.govuk-link', 'feedback', 'application-inprogress')
+})
+
+Then('(the user )should see a phase banner feedback link with journey {string}', async function (journey) {
+  await expectFeedbackLink(this.page, '.govuk-phase-banner a.govuk-link', 'feedback', journey)
 })
 
 Then('(the user )should see a confirmation page feedback link', async function () {
-  const link = this.page.locator('a.govuk-link', { hasText: 'Give feedback on this service' })
-  await expect(link).toBeVisible()
-  const href = await link.getAttribute('href')
-  const params = new URL(href).searchParams
-  expect(params.get('grant')).toBeTruthy()
-  expect(params.get('url')).toBeTruthy()
-  expect(params.get('journey')).toEqual('application-submitted')
+  await expectFeedbackLink(this.page, 'a.govuk-link', 'Give feedback on this service', 'application-submitted')
+})
+
+Then('(the user )should see a confirmation page feedback link with journey {string}', async function (journey) {
+  await expectFeedbackLink(this.page, 'a.govuk-link', 'Give feedback on this service', journey)
 })
 
 Then('(the user )should see SBI {string} as the logged in organisation', async function (expectedSbi) {

--- a/src/server/common/helpers/feedback-survey.js
+++ b/src/server/common/helpers/feedback-survey.js
@@ -15,12 +15,22 @@ export const SURVEY_PARAMS = {
  */
 export const JOURNEY = {
   inProgress: 'application-inprogress',
-  submitted: 'application-submitted'
+  submitted: 'application-submitted',
+  claimInProgress: 'claim-inprogress',
+  claimSubmitted: 'claim-submitted'
 }
 
 /**
- * Path suffixes that represent a submitted application. Everything else within a
- * grant journey is treated as in-progress.
+ * Path suffixes that identify the claim journey. Claims are separate from grant
+ * applications for feedback segmentation, even though they use the same routes
+ * and feedback CTA.
+ */
+export const CLAIM_IN_PROGRESS_PATH_SUFFIXES = ['/claim', '/claim-declaration']
+export const CLAIM_SUBMITTED_PATH_SUFFIXES = ['/claim-confirmation']
+
+/**
+ * Path suffixes that represent a submitted application. Everything else within
+ * a grant application journey is treated as in-progress.
  */
 export const SUBMITTED_PATH_SUFFIXES = ['/confirmation', '/print-submitted-application']
 
@@ -30,6 +40,14 @@ export const SUBMITTED_PATH_SUFFIXES = ['/confirmation', '/print-submitted-appli
  * @returns {string} The journey param value
  */
 export function resolveJourney(path) {
+  if (CLAIM_SUBMITTED_PATH_SUFFIXES.some((suffix) => path?.endsWith(suffix))) {
+    return JOURNEY.claimSubmitted
+  }
+
+  if (CLAIM_IN_PROGRESS_PATH_SUFFIXES.some((suffix) => path?.endsWith(suffix))) {
+    return JOURNEY.claimInProgress
+  }
+
   const isSubmitted = SUBMITTED_PATH_SUFFIXES.some((suffix) => path?.endsWith(suffix))
   return isSubmitted ? JOURNEY.submitted : JOURNEY.inProgress
 }

--- a/src/server/common/helpers/feedback-survey.test.js
+++ b/src/server/common/helpers/feedback-survey.test.js
@@ -17,6 +17,9 @@ describe('#resolveJourney', () => {
   test.each([
     ['/woodland/confirmation', JOURNEY.submitted],
     ['/woodland/print-submitted-application', JOURNEY.submitted],
+    ['/woodland/claim', JOURNEY.claimInProgress],
+    ['/woodland/claim-declaration', JOURNEY.claimInProgress],
+    ['/woodland/claim-confirmation', JOURNEY.claimSubmitted],
     ['/woodland/summary', JOURNEY.inProgress],
     [undefined, JOURNEY.inProgress]
   ])('resolves %s to %s', (path, expected) => {
@@ -58,6 +61,32 @@ describe('#buildFeedbackSurveyUrl', () => {
     const result = buildFeedbackSurveyUrl(mockGrantRequest({ slug: 'woodland', path: '/woodland/confirmation' }))
     const url = new URL(/** @type {string} */ (result))
     expect(url.searchParams.get('journey')).toBe(JOURNEY.submitted)
+  })
+
+  test.each([
+    ['/woodland/claim', JOURNEY.claimInProgress],
+    ['/woodland/claim-confirmation', JOURNEY.claimSubmitted]
+  ])('uses %s for a Woodland Management Plan claim', (path, journey) => {
+    const result = buildFeedbackSurveyUrl(mockSurveyRequest({ slug: 'woodland', path }, 'Woodland Management Plan'))
+    const url = new URL(/** @type {string} */ (result))
+
+    expect(url.searchParams.get('grant')).toBe('Woodland Management Plan')
+    expect(url.searchParams.get('journey')).toBe(journey)
+    expect(url.searchParams.get('url')).toBe(`https://grants.example${path}`)
+  })
+
+  test.each([
+    ['/example-grant-with-auth/claim', JOURNEY.claimInProgress],
+    ['/example-grant-with-auth/claim-confirmation', JOURNEY.claimSubmitted]
+  ])('uses %s for the authenticated example grant claim', (path, journey) => {
+    const result = buildFeedbackSurveyUrl(
+      mockSurveyRequest({ slug: 'example-grant-with-auth', path }, 'Example Grant with Auth')
+    )
+    const url = new URL(/** @type {string} */ (result))
+
+    expect(url.searchParams.get('grant')).toBe('Example Grant with Auth')
+    expect(url.searchParams.get('journey')).toBe(journey)
+    expect(url.searchParams.get('url')).toBe(`https://grants.example${path}`)
   })
 
   test('falls back to the sentence-cased form definition filename when surveyLabel is absent', () => {


### PR DESCRIPTION
## Summary

Adds claim-specific feedback survey context for the Woodland Management Plan and example grant with auth claim journeys.

- Sends `claim-inprogress` on claim start and declaration pages
- Sends `claim-submitted` on the claim confirmation page
- Retains existing application journey values for application pages
- Adds acceptance assertions for phase-banner and claim-confirmation feedback links

## Validation

- `npx vitest run src/server/common/helpers/feedback-survey.test.js src/config/nunjucks/context/context.test.js`
- `npm run lint:types`
- Local acceptance test via `./acceptance/run-local.sh`