### PR TITLE
TGC-1584: Decouple Parcels API Pact from action fixture shape

### DIFF
--- a/src/contracts/v2/land-grants.client.contract.test.js
+++ b/src/contracts/v2/land-grants.client.contract.test.js
@@ -16,7 +16,7 @@ vi.mock('~/src/server/common/helpers/retry.js', () => ({
   retry: (operation) => operation()
 }))
 
-const { like, eachLike, nullValue, number, string } = MatchersV3
+const { boolean, like, eachLike, nullValue, number, string } = MatchersV3
 const userContext = { defraIdToken: 'defra-id-access-token', sbi: '123456789' }
 const makeLandGrantsHeaders = () => ({
   'Content-Type': 'application/json',
@@ -38,27 +38,31 @@ const HAS_5677 = { parcels: [{ sheetId: 'SD7861', parcelId: '5677' }] }
 const actionWithLimitedAvailability = like({
   code: string('CLIG3'),
   description: string('Manage grassland with very low nutrient inputs'),
-  guidanceUrl: string(
-    'https://www.gov.uk/find-funding-for-land-or-farms/clig3-manage-grassland-with-very-low-nutrient-inputs'
-  ),
   ratePerUnitGbp: number(151),
   availability: { unit: string('ha'), value: number(10.5) }
 })
 const actionWithUnrestrictedAvailability = like({
   code: string('WBD1'),
   description: string('Manage ponds'),
-  guidanceUrl: string('https://www.gov.uk/find-funding-for-land-or-farms/wbd1-manage-ponds'),
   ratePerUnitGbp: number(257),
   availability: { unit: string('count'), value: nullValue() }
 })
+const actionWithConsentInformation = like({
+  sssiConsentRequired: boolean(false),
+  heferRequired: boolean(true)
+})
 
-const parcelsWithActionAvailability = (sizeValue) => ({
+const parcelsWithActionAvailability = (sizeValue, ...additionalActionVariants) => ({
   message: 'success',
   parcels: eachLike({
     parcelId: string('SD6743'),
     sheetId: string('8083'),
     size: { unit: string('ha'), value: number(sizeValue) },
-    actions: arrayContaining(actionWithLimitedAvailability, actionWithUnrestrictedAvailability)
+    actions: arrayContaining(
+      actionWithLimitedAvailability,
+      actionWithUnrestrictedAvailability,
+      ...additionalActionVariants
+    )
   })
 })
 
@@ -68,12 +72,21 @@ const expectActionAvailability = (response) => {
   expect(actions).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        availability: expect.objectContaining({ unit: 'ha', value: expect.any(Number) }),
-        guidanceUrl: expect.any(String)
+        availability: expect.objectContaining({ unit: 'ha', value: expect.any(Number) })
       }),
       expect.objectContaining({
-        availability: { unit: 'count', value: null },
-        guidanceUrl: expect.any(String)
+        availability: { unit: 'count', value: null }
+      })
+    ])
+  )
+}
+
+const expectConsentInformation = (response) => {
+  expect(response.parcels[0].actions).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        sssiConsentRequired: expect.any(Boolean),
+        heferRequired: expect.any(Boolean)
       })
     ])
   )
@@ -446,7 +459,7 @@ describe('parcels', () => {
         path: PARCELS_PATH,
         body: requestBody,
         status: 200,
-        responseBody: parcelsWithActionAvailability(parcelSize),
+        responseBody: parcelsWithActionAvailability(parcelSize, actionWithConsentInformation),
         responseBodyHasMatchers: true
       },
       async (mockserver) => {
@@ -454,11 +467,12 @@ describe('parcels', () => {
 
         expect(response.parcels[0].size.value).toBe(parcelSize)
         expectActionAvailability(response)
+        expectConsentInformation(response)
       }
     )
   })
 
-  it('returns HTTP 200 with guidance and availability always included on each action', async () => {
+  it('returns HTTP 200 with numeric and unrestricted availability variants', async () => {
     const parcelSize = 23.3424
     const requestBody = {
       parcelIds: ['SD6743-8083'],
@@ -469,7 +483,8 @@ describe('parcels', () => {
     await pactInteraction(
       {
         given: HAS_8083,
-        receiving: 'a v2 request for a single parcel with actions and size, expecting guidance and availability',
+        receiving:
+          'a v2 request for a single parcel with actions and size, expecting numeric and unrestricted availability',
         path: PARCELS_PATH,
         body: requestBody,
         status: 200,

--- a/src/contracts/v2/land-grants.client.contract.test.js
+++ b/src/contracts/v2/land-grants.client.contract.test.js
@@ -432,38 +432,7 @@ describe('parcels', () => {
   })
 
   it('returns HTTP 200 with consent information for a single parcel', async () => {
-    const parcelWithConsentExample = {
-      parcelId: 'SD6743',
-      sheetId: '8083',
-      size: { value: 23.3424, unit: 'ha' },
-      actions: [
-        {
-          code: 'CMOR1',
-          availability: { value: 10.5, unit: 'ha' },
-          description: 'Assess moorland and produce a written record',
-          ratePerUnitGbp: 10.6,
-          ratePerAgreementPerYearGbp: 272,
-          sssiConsentRequired: false,
-          heferRequired: true
-        },
-        {
-          code: 'UPL1',
-          availability: { value: 20.75, unit: 'ha' },
-          description: 'Moderate livestock grazing on moorland',
-          ratePerUnitGbp: 20,
-          sssiConsentRequired: true,
-          heferRequired: false
-        },
-        {
-          code: 'UPL2',
-          availability: { value: 15.25, unit: 'ha' },
-          description: 'Moderate livestock grazing on moorland',
-          ratePerUnitGbp: 53,
-          sssiConsentRequired: true,
-          heferRequired: false
-        }
-      ]
-    }
+    const parcelSize = 23.3424
     const requestBody = {
       parcelIds: ['SD6743-8083'],
       fields: ['actions', 'size', 'actions.sssiConsentRequired', 'actions.heferRequired'],
@@ -477,43 +446,20 @@ describe('parcels', () => {
         path: PARCELS_PATH,
         body: requestBody,
         status: 200,
-        responseBody: parcelsWithActionAvailability(parcelWithConsentExample.size.value),
+        responseBody: parcelsWithActionAvailability(parcelSize),
         responseBodyHasMatchers: true
       },
       async (mockserver) => {
         const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
 
-        expect(response.parcels[0].size.value).toBe(parcelWithConsentExample.size.value)
+        expect(response.parcels[0].size.value).toBe(parcelSize)
         expectActionAvailability(response)
       }
     )
   })
 
   it('returns HTTP 200 with guidance and availability always included on each action', async () => {
-    const parcelWithMetadataExample = {
-      parcelId: 'SD6743',
-      sheetId: '8083',
-      size: { value: 23.3424, unit: 'ha' },
-      actions: [
-        {
-          code: 'CLIG3',
-          availability: { value: 10.5, unit: 'ha', type: 'total' },
-          description: 'Manage grassland with very low nutrient inputs',
-          ratePerUnitGbp: 10.6,
-          ratePerAgreementPerYearGbp: 272,
-          guidanceUrl: string(
-            'https://www.gov.uk/find-funding-for-land-or-farms/clig3-manage-grassland-with-very-low-nutrient-inputs'
-          )
-        },
-        {
-          code: 'CSAM3',
-          availability: { value: 20.75, unit: 'ha', type: 'partial' },
-          description: 'Herbal leys',
-          ratePerUnitGbp: 224,
-          guidanceUrl: string('https://www.gov.uk/find-funding-for-land-or-farms/csam3-herbal-leys')
-        }
-      ]
-    }
+    const parcelSize = 23.3424
     const requestBody = {
       parcelIds: ['SD6743-8083'],
       fields: ['actions', 'size'],
@@ -527,7 +473,7 @@ describe('parcels', () => {
         path: PARCELS_PATH,
         body: requestBody,
         status: 200,
-        responseBody: parcelsWithActionAvailability(parcelWithMetadataExample.size.value),
+        responseBody: parcelsWithActionAvailability(parcelSize),
         responseBodyHasMatchers: true
       },
       async (mockserver) => {
@@ -542,32 +488,7 @@ describe('parcels', () => {
   })
 
   it('returns HTTP 200 and a list of parcels with actions and size', async () => {
-    const parcelWithActionsAndSizeExample = {
-      parcelId: 'SD6743',
-      sheetId: '8083',
-      size: { value: 23.3424, unit: 'ha' },
-      actions: [
-        {
-          code: 'CMOR1',
-          availability: { value: 10.5, unit: 'ha' },
-          description: 'Assess moorland and produce a written record',
-          ratePerUnitGbp: 10.6,
-          ratePerAgreementPerYearGbp: 272
-        },
-        {
-          code: 'UPL1',
-          availability: { value: 20.75, unit: 'ha' },
-          description: 'Moderate livestock grazing on moorland',
-          ratePerUnitGbp: 20
-        },
-        {
-          code: 'UPL2',
-          availability: { value: 15.25, unit: 'ha' },
-          description: 'Moderate livestock grazing on moorland',
-          ratePerUnitGbp: 53
-        }
-      ]
-    }
+    const parcelSize = 23.3424
     const requestBody = {
       parcelIds: ['SD6743-8083'],
       fields: ['actions', 'size'],
@@ -582,44 +503,19 @@ describe('parcels', () => {
         path: PARCELS_PATH,
         body: requestBody,
         status: 200,
-        responseBody: parcelsWithActionAvailability(parcelWithActionsAndSizeExample.size.value),
+        responseBody: parcelsWithActionAvailability(parcelSize),
         responseBodyHasMatchers: true
       },
       async (mockserver) => {
         const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
-        expect(response.parcels[0].size.value).toBe(parcelWithActionsAndSizeExample.size.value)
+        expect(response.parcels[0].size.value).toBe(parcelSize)
         expectActionAvailability(response)
       }
     )
   })
 
   it('returns HTTP 200 with availability recomputed against a non-empty plannedActions selection', async () => {
-    const parcelWithRecomputedAreaExample = {
-      parcelId: 'SD6743',
-      sheetId: '8083',
-      size: { value: 4.5341, unit: 'ha' },
-      actions: [
-        {
-          code: 'CMOR1',
-          availability: { value: 4.5341, unit: 'ha' },
-          description: 'Assess moorland and produce a written record',
-          ratePerUnitGbp: 10.6,
-          ratePerAgreementPerYearGbp: 272
-        },
-        {
-          code: 'UPL1',
-          availability: { value: 4.5341, unit: 'ha' },
-          description: 'Moderate livestock grazing on moorland',
-          ratePerUnitGbp: 20
-        },
-        {
-          code: 'UPL2',
-          availability: { value: 4.5341, unit: 'ha' },
-          description: 'Moderate livestock grazing on moorland',
-          ratePerUnitGbp: 53
-        }
-      ]
-    }
+    const parcelSize = 4.5341
     const requestBody = {
       parcelIds: ['SD6743-8083'],
       fields: ['actions', 'size'],
@@ -634,12 +530,12 @@ describe('parcels', () => {
         path: PARCELS_PATH,
         body: requestBody,
         status: 200,
-        responseBody: parcelsWithActionAvailability(parcelWithRecomputedAreaExample.size.value),
+        responseBody: parcelsWithActionAvailability(parcelSize),
         responseBodyHasMatchers: true
       },
       async (mockserver) => {
         const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
-        expect(response.parcels[0].size.value).toBe(parcelWithRecomputedAreaExample.size.value)
+        expect(response.parcels[0].size.value).toBe(parcelSize)
         expectActionAvailability(response)
       }
     )

--- a/src/contracts/v2/land-grants.client.contract.test.js
+++ b/src/contracts/v2/land-grants.client.contract.test.js
@@ -16,7 +16,7 @@ vi.mock('~/src/server/common/helpers/retry.js', () => ({
   retry: (operation) => operation()
 }))
 
-const { like, eachLike, string } = MatchersV3
+const { like, eachLike, nullValue, number, string } = MatchersV3
 const userContext = { defraIdToken: 'defra-id-access-token', sbi: '123456789' }
 const makeLandGrantsHeaders = () => ({
   'Content-Type': 'application/json',
@@ -35,9 +35,48 @@ const PARCEL_8083 = { sheetId: 'SD6743', parcelId: '8083' }
 const HAS_8083 = { parcels: [PARCEL_8083] }
 const HAS_NO_PARCELS = { parcels: [] }
 const HAS_5677 = { parcels: [{ sheetId: 'SD7861', parcelId: '5677' }] }
-const UNRESTRICTED_COUNT_ACTION = {
-  code: 'WBD1',
-  availability: { unit: 'count', value: null }
+const actionWithLimitedAvailability = like({
+  code: string('CLIG3'),
+  description: string('Manage grassland with very low nutrient inputs'),
+  guidanceUrl: string(
+    'https://www.gov.uk/find-funding-for-land-or-farms/clig3-manage-grassland-with-very-low-nutrient-inputs'
+  ),
+  ratePerUnitGbp: number(151),
+  availability: { unit: string('ha'), value: number(10.5) }
+})
+const actionWithUnrestrictedAvailability = like({
+  code: string('WBD1'),
+  description: string('Manage ponds'),
+  guidanceUrl: string('https://www.gov.uk/find-funding-for-land-or-farms/wbd1-manage-ponds'),
+  ratePerUnitGbp: number(257),
+  availability: { unit: string('count'), value: nullValue() }
+})
+
+const parcelsWithActionAvailability = (sizeValue) => ({
+  message: 'success',
+  parcels: eachLike({
+    parcelId: string('SD6743'),
+    sheetId: string('8083'),
+    size: { unit: string('ha'), value: number(sizeValue) },
+    actions: arrayContaining(actionWithLimitedAvailability, actionWithUnrestrictedAvailability)
+  })
+})
+
+const expectActionAvailability = (response) => {
+  const actions = response.parcels[0].actions
+
+  expect(actions).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        availability: expect.objectContaining({ unit: 'ha', value: expect.any(Number) }),
+        guidanceUrl: expect.any(String)
+      }),
+      expect.objectContaining({
+        availability: { unit: 'count', value: null },
+        guidanceUrl: expect.any(String)
+      })
+    ])
+  )
 }
 
 function createProvider() {
@@ -55,14 +94,21 @@ function createProvider() {
  * `given` is optional - a malformed request never reaches parcel lookup, so
  * those interactions carry no provider state.
  */
-function pactInteraction({ given, receiving, path: requestPath, body, status, responseBody }, assert) {
+function pactInteraction(
+  { given, receiving, path: requestPath, body, status, responseBody, responseBodyHasMatchers = false },
+  assert
+) {
   const provider = createProvider()
   const withState = given ? provider.given('has parcels', given) : provider
 
   return withState
     .uponReceiving(receiving)
     .withRequest({ method: 'POST', path: requestPath, headers: makeLandGrantsHeaders(), body })
-    .willRespondWith({ status, headers: JSON_HEADERS, body: like(responseBody) })
+    .willRespondWith({
+      status,
+      headers: JSON_HEADERS,
+      body: responseBodyHasMatchers ? responseBody : like(responseBody)
+    })
     .executeTest(assert)
 }
 
@@ -415,8 +461,7 @@ describe('parcels', () => {
           ratePerUnitGbp: 53,
           sssiConsentRequired: true,
           heferRequired: false
-        },
-        UNRESTRICTED_COUNT_ACTION
+        }
       ]
     }
     const requestBody = {
@@ -432,12 +477,14 @@ describe('parcels', () => {
         path: PARCELS_PATH,
         body: requestBody,
         status: 200,
-        responseBody: { message: 'success', parcels: eachLike(parcelWithConsentExample) }
+        responseBody: parcelsWithActionAvailability(parcelWithConsentExample.size.value),
+        responseBodyHasMatchers: true
       },
       async (mockserver) => {
         const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
 
-        expect(response.parcels[0]).toEqual(parcelWithConsentExample)
+        expect(response.parcels[0].size.value).toBe(parcelWithConsentExample.size.value)
+        expectActionAvailability(response)
       }
     )
   })
@@ -464,8 +511,7 @@ describe('parcels', () => {
           description: 'Herbal leys',
           ratePerUnitGbp: 224,
           guidanceUrl: string('https://www.gov.uk/find-funding-for-land-or-farms/csam3-herbal-leys')
-        },
-        UNRESTRICTED_COUNT_ACTION
+        }
       ]
     }
     const requestBody = {
@@ -481,7 +527,8 @@ describe('parcels', () => {
         path: PARCELS_PATH,
         body: requestBody,
         status: 200,
-        responseBody: { message: 'success', parcels: eachLike(parcelWithMetadataExample) }
+        responseBody: parcelsWithActionAvailability(parcelWithMetadataExample.size.value),
+        responseBodyHasMatchers: true
       },
       async (mockserver) => {
         const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
@@ -489,13 +536,7 @@ describe('parcels', () => {
         expect(response.parcels[0].parcelId).toBe('SD6743')
         expect(response.parcels[0].sheetId).toBe('8083')
 
-        expect(response.parcels[0].actions[0].code).toBe('CLIG3')
-        expect(response.parcels[0].actions[0].guidanceUrl).toEqual(expect.any(String))
-        expect(response.parcels[0].actions[0].availability.type).toBe('total')
-
-        expect(response.parcels[0].actions[1].code).toBe('CSAM3')
-        expect(response.parcels[0].actions[1].guidanceUrl).toEqual(expect.any(String))
-        expect(response.parcels[0].actions[1].availability.type).toBe('partial')
+        expectActionAvailability(response)
       }
     )
   })
@@ -524,8 +565,7 @@ describe('parcels', () => {
           availability: { value: 15.25, unit: 'ha' },
           description: 'Moderate livestock grazing on moorland',
           ratePerUnitGbp: 53
-        },
-        UNRESTRICTED_COUNT_ACTION
+        }
       ]
     }
     const requestBody = {
@@ -542,11 +582,13 @@ describe('parcels', () => {
         path: PARCELS_PATH,
         body: requestBody,
         status: 200,
-        responseBody: { message: 'success', parcels: eachLike(parcelWithActionsAndSizeExample) }
+        responseBody: parcelsWithActionAvailability(parcelWithActionsAndSizeExample.size.value),
+        responseBodyHasMatchers: true
       },
       async (mockserver) => {
         const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
-        expect(response.parcels[0]).toEqual(parcelWithActionsAndSizeExample)
+        expect(response.parcels[0].size.value).toBe(parcelWithActionsAndSizeExample.size.value)
+        expectActionAvailability(response)
       }
     )
   })
@@ -575,8 +617,7 @@ describe('parcels', () => {
           availability: { value: 4.5341, unit: 'ha' },
           description: 'Moderate livestock grazing on moorland',
           ratePerUnitGbp: 53
-        },
-        UNRESTRICTED_COUNT_ACTION
+        }
       ]
     }
     const requestBody = {
@@ -593,11 +634,13 @@ describe('parcels', () => {
         path: PARCELS_PATH,
         body: requestBody,
         status: 200,
-        responseBody: { message: 'success', parcels: eachLike(parcelWithRecomputedAreaExample) }
+        responseBody: parcelsWithActionAvailability(parcelWithRecomputedAreaExample.size.value),
+        responseBodyHasMatchers: true
       },
       async (mockserver) => {
         const response = await postToLandGrantsApi(PARCELS_PATH, requestBody, mockserver.url)
-        expect(response.parcels[0]).toEqual(parcelWithRecomputedAreaExample)
+        expect(response.parcels[0].size.value).toBe(parcelWithRecomputedAreaExample.size.value)
+        expectActionAvailability(response)
       }
     )
   })


### PR DESCRIPTION
## Summary

Reworks the Grants UI → Land Grants API Parcels Pact so it reflects realistic action responses rather than a fixed fixture shape.

The previous Pact coupled availability value types and action fields to array indexes. This caused provider verification failures when valid actions, including unrestricted WBD1, appeared in a different order.

## Changes

- Match action arrays using order-independent Pact variants.
- Cover both valid availability forms:
  - numeric `availability.value`;
  - unrestricted `availability.value: null`.
- Remove requirements for optional action fields from generic action variants:
  - `guidanceUrl`;
  - `ratePerAgreementPerYearGbp`;
  - `availability.type`.
- Retain required generic action coverage for code, description, rate per unit, availability unit/value, parcel identifiers, and parcel size.
- Retain consent coverage for the request that explicitly asks for:
  - `actions.sssiConsentRequired`;
  - `actions.heferRequired`.


## Why

The Land Grants API provider fixtures represent real action configurations. They may omit optional fields and may return actions in any valid order.

The Pact should assert only the response fields Grants UI depends on, rather than requiring the API team to add fixture-only fields or arrange actions to match a consumer example.

## Validation

- `npm run format:check`
- `npx vitest run --config vitest.contracts.config.js src/contracts/v2/land-grants.client.contract.test.js`

Result: 23 tests passed.