### PR TITLE
Extend claims acceptance test coverage to check GAS submission

### DIFF
--- a/acceptance/test/features/application-lifecycle.feature
+++ b/acceptance/test/features/application-lifecycle.feature
@@ -134,8 +134,6 @@ Feature: Application Lifecycle
             | SD6351 8781 |
         And continues
 
-        # check-details was moved to after start; no longer visited here
-
         # summary
         Then the user should be at URL "summary"
         When the user continues
@@ -226,6 +224,7 @@ Feature: Application Lifecycle
         When the user clicks on "Confirm and submit"
         And the grants-ui application status for CRN "1100995048" and SBI "115664358" and grant "example-grant-with-auth" should be "CLAIM_SUBMITTED"
         And the claim "-C01" for CRN "1100995048" and SBI "115664358" and grant "example-grant-with-auth" should have status "SUBMITTED"
+        And the claim "-C01" for CRN "1100995048" and SBI "115664358" should be submitted to GAS
 
         # claim-confirmation
         Then the user should be at URL "claim-confirmation"

--- a/acceptance/test/steps/gas.steps.js
+++ b/acceptance/test/steps/gas.steps.js
@@ -12,18 +12,16 @@ const schemas = {
   'example-grant-with-auth': require('../../schemas/example-grant-with-auth-submission.schema.json')
 }
 
-if (process.env.MOCKSERVER_HOST) {
-  Before(async function () {
-    const expectationId = await Gas.setDefaultStatusQuery404Response()
-    expectationIds.push(expectationId)
-  })
+Before(async function () {
+  const expectationId = await Gas.setDefaultStatusQuery404Response()
+  expectationIds.push(expectationId)
+})
 
-  After(async function () {
-    for (const expectationId of expectationIds.all) {
-      await Gas.clearExpectation(expectationId)
-    }
-  })
-}
+After(async function () {
+  for (const expectationId of expectationIds.all) {
+    await Gas.clearExpectation(expectationId)
+  }
+})
 
 Given(
   'the next application submitted to GAS for SBI {string} will return HTTP {int} {string} for {int} requests',
@@ -57,7 +55,7 @@ Then(
     }
 
     const request = await Gas.getApplicationSubmission(referenceNumbers.current)
-    expect(request).not.toBeNull()
+    expect(request).toBeDefined()
     expect(request.body.json.metadata.clientRef).toEqual(referenceNumbers.current.toLowerCase())
     expect(request.body.json.metadata.sbi).toEqual(sbi)
     expect(request.body.json.metadata.crn).toEqual(crn)
@@ -72,10 +70,10 @@ Then('the GAS submission should contain applicant business address', async funct
   }
 
   const request = await Gas.getApplicationSubmission(referenceNumbers.current)
-  expect(request).not.toBeNull()
+  expect(request).toBeDefined()
 
   const actualAddress = request.body.json.answers.applicant?.business?.address
-  expect(actualAddress).not.toBeNull()
+  expect(actualAddress).toBeDefined()
 
   for (const [field, expectedValue] of dataTable.raw()) {
     expect(actualAddress[field]).toEqual(expectedValue)
@@ -93,7 +91,7 @@ Then('the GAS submission should be valid against the {string} schema', async fun
   }
 
   const request = await Gas.getApplicationSubmission(referenceNumbers.current)
-  expect(request).not.toBeNull()
+  expect(request).toBeDefined()
 
   const ajv = new Ajv({ strict: false, formats: { 'date-time': true } })
   const validate = ajv.compile(schema)
@@ -102,6 +100,23 @@ Then('the GAS submission should be valid against the {string} schema', async fun
     throw new Error(`GAS submission answers failed schema validation:\n${JSON.stringify(validate.errors, null, 2)}`)
   }
 })
+
+Then(
+  'the claim {string} for CRN {string} and SBI {string} should be submitted to GAS',
+  async function (claimNumberSuffix, crn, sbi) {
+    if (!referenceNumbers.current) {
+      throw new Error('No reference number stored by earlier step')
+    }
+
+    const request = await Gas.getClaimSubmission(referenceNumbers.current)
+    expect(request).toBeDefined()
+    expect(request.body.json.metadata.clientRef).toEqual(referenceNumbers.current.toLowerCase())
+    expect(request.body.json.metadata.sbi).toEqual(sbi)
+    expect(request.body.json.metadata.crn).toEqual(crn)
+    expect(request.body.json.metadata.configVersion).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(request.body.json.answers.claimNumber).toEqual(`${referenceNumbers.current}${claimNumberSuffix}`)
+  }
+)
 
 Then(
   'the reference number and previous reference number along with SBI {string} and CRN {string} should be submitted to GAS',
@@ -115,7 +130,7 @@ Then(
     }
 
     const request = await Gas.getApplicationSubmission(referenceNumbers.current)
-    expect(request).not.toBeNull()
+    expect(request).toBeDefined()
     expect(request.body.json.metadata.clientRef).toEqual(referenceNumbers.current.toLowerCase())
     expect(request.body.json.metadata.previousClientRef).toEqual(referenceNumbers.previous.toLowerCase())
     expect(request.body.json.metadata.sbi).toEqual(sbi)

--- a/acceptance/test/utils/gas.js
+++ b/acceptance/test/utils/gas.js
@@ -14,6 +14,14 @@ class Gas {
     return requests.find((r) => r.body.json.metadata.clientRef === referenceNumber.toLowerCase())
   }
 
+  async getClaimSubmission(referenceNumber) {
+    const client = mockServerClient(process.env.MOCKSERVER_HOST, process.env.MOCKSERVER_PORT)
+    const requests = await client.retrieveRecordedRequests({
+      path: '/grants/[^/]+/applications/[^/]+/claims'
+    })
+    return requests.find((r) => r.body.json.metadata.clientRef === referenceNumber.toLowerCase())
+  }
+
   async setApplicationSubmissionResponse(sbi, httpStatusCode, errorText, times) {
     const expectationId = `applications-sbi-${sbi}-${httpStatusCode}`
     const client = mockServerClient(process.env.MOCKSERVER_HOST, process.env.MOCKSERVER_PORT)


### PR DESCRIPTION
- Extend claims coverage to check GAS submission
- Remove unnecessary guard for the presence of MockServer left over from time when these tests ran in CDP
- Refactor some inappropriate assertions on the results of `Array.prototype.find` where we could receive `undefined`